### PR TITLE
Fix crash by removing managed query usage

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/newGallery.java
+++ b/app/src/main/java/vn/mbm/phimp/me/newGallery.java
@@ -3293,10 +3293,9 @@ public class newGallery extends Fragment {
 			final String[] columns = { MediaStore.Images.Thumbnails._ID};
 			final String[] data = { MediaStore.Images.Media.DATA };
 			final String orderBy = MediaStore.Images.Media._ID;
-			Cursor pathcursor = getActivity().managedQuery(
+			Cursor pathcursor = getActivity().getContentResolver().query(
 					MediaStore.Images.Media.EXTERNAL_CONTENT_URI, data,
-					null, null, orderBy);	
-			getActivity().startManagingCursor(pathcursor);
+					null, null, orderBy);
 			if(pathcursor != null){
 				int path_column_index = pathcursor
 						.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
@@ -3317,10 +3316,9 @@ public class newGallery extends Fragment {
 								
 							}
 							else if(c<=20){				
-								Cursor cursor = getActivity().managedQuery(
+								Cursor cursor = getActivity().getContentResolver().query(
 										MediaStore.Images.Media.EXTERNAL_CONTENT_URI, columns,
-										MediaStore.Images.Media.DATA+ " = " + "\""+path+"\"", null, MediaStore.Images.Media._ID);									
-								getActivity().startManagingCursor(cursor);
+										MediaStore.Images.Media.DATA+ " = " + "\""+path+"\"", null, MediaStore.Images.Media._ID);
 								if (cursor != null && cursor.getCount() > 0){
 									cursor.moveToPosition(0);
 									id = cursor.getInt(cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID));	


### PR DESCRIPTION
Closing of managed cursor leads to crash due to requery of the closed
cursor on activity resume. Removal of managed query usage fixes the crash.