### PR TITLE
fix: Margins of the GridView

### DIFF
--- a/app/src/main/res/layout/newgallery.xml
+++ b/app/src/main/res/layout/newgallery.xml
@@ -62,8 +62,9 @@
 			android:numColumns="3"
 			android:verticalSpacing="5dp"
 			android:horizontalSpacing="5dp"
-			android:layout_marginTop="5dp"
-			android:layout_marginBottom="?attr/actionBarSize"
+			android:layout_marginTop="3dp"
+			android:layout_marginLeft="3dp"
+			android:layout_marginRight="3dp"
 			android:gravity="center" />
 
 	</LinearLayout>


### PR DESCRIPTION
Adjusted the margins of the Home View [ #55 ] The new build in development had an additional margin which lifts the Gallery up. In this fix, I've corrected it!

Changes: 
- Margins were misaligned in the Home View gallery. They were set to 3dp!
