### PR TITLE
Added slack id as an environment variable. Closes #95

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,4 @@ after_success:
   - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./upload-apk.sh; fi'
 
 notifications:
-  slack: fossasia:JgzycrBUs0nKnmJhsAxCB4bL
+  slack: $SLACK_ID


### PR DESCRIPTION
Closes #95.
The environment variable has been added to the dashboard.
Now notif won't go to slack from forks.