### PR TITLE
Update Phimpme.java

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/PhimpMe.java
+++ b/app/src/main/java/vn/mbm/phimp/me/PhimpMe.java
@@ -821,7 +821,8 @@ public class PhimpMe extends AppCompatActivity implements BottomNavigationView.O
                 getSupportFragmentManager().beginTransaction()
                         .replace(R.id.fragment_container, frag)
                         .commit();
-                currentScreen = HomeScreenState.GALLERY;
+                currentScreen = HomeScreenState.GALLERY;                
+                keycode = 0;
             } else {
                 AlertDialog.Builder alertbox = new AlertDialog.Builder(ctx);
                 alertbox.setMessage(getString(R.string.exit_message));


### PR DESCRIPTION
Setting keycode to zero after getting view of home screen (Gallery) on pressing back button so that it shouldn't close the app after getting back to home screen at pressing back once on any other option. It should only return to home screen.

Fixes issue #86 

Changes: Fixed error that if you press back button on any option it goes to home screen and closes app promptly now it just goes to home screen. 

Screenshots for the change: 
