### PR TITLE
fix: Implements Travis to run Espresso UI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,14 @@ licenses:
     - 'android-sdk-license-.+'
     - 'google-gdk-license-.+'
 
-script: 
+before_script:
+  - echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a
+  - emulator -avd test -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
+
+script:
+ - ./gradlew connectedAndroidTest
  - ./gradlew build
 
 after_success:

--- a/app/src/androidTest/java/vn/mbm/phimp/me/CameraActivityTest.java
+++ b/app/src/androidTest/java/vn/mbm/phimp/me/CameraActivityTest.java
@@ -15,7 +15,6 @@ import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withParent;
 import static org.hamcrest.Matchers.allOf;
 
 @LargeTest
@@ -30,12 +29,6 @@ public class CameraActivityTest {
         ViewInteraction bottomNavigationItemView = onView(
                 allOf(withId(R.id.tab_camera), isDisplayed()));
         bottomNavigationItemView.perform(click());
-
-        ViewInteraction appCompatImageButton = onView(
-                allOf(withId(R.id.switch_camera),
-                        withParent(withId(R.id.lnCam)),
-                        isDisplayed()));
-        appCompatImageButton.check(matches(isDisplayed()));
 
         ViewInteraction appCompatImageButton2 = onView(
                 allOf(withId(R.id.takephoto), isDisplayed()));

--- a/app/src/androidTest/java/vn/mbm/phimp/me/UploadActivityTest.java
+++ b/app/src/androidTest/java/vn/mbm/phimp/me/UploadActivityTest.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.TimeUnit;
 
 import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.pressBack;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -79,38 +80,38 @@ public class UploadActivityTest {
                                 allOf(withId(R.id.relativeLayout2),
                                         childAtPosition(
                                                 withId(R.id.tabUpload),
-                                                3)),
+                                                2)),
                                 0),
                         isDisplayed()));
         textView2.check(matches(withText("Photos")));
 
-        ViewInteraction appCompatImageButton = onView(
+        ViewInteraction appCompatImageView = onView(
                 allOf(withId(R.id.btnUploadAccountAdd),
                         withParent(allOf(withId(R.id.relativeLayout1),
                                 withParent(withId(R.id.tabUpload)))),
                         isDisplayed()));
-        appCompatImageButton.check(matches(isDisplayed()));
+        appCompatImageView.check(matches(isDisplayed()));
 
-        ViewInteraction appCompatButton = onView(
-                allOf(withId(R.id.btnUploadPhoto), withText("Upload"),
+        ViewInteraction appCompatImageView2 = onView(
+                allOf(withId(R.id.btnUploadPhoto),
                         withParent(allOf(withId(R.id.relativeLayout2),
                                 withParent(withId(R.id.tabUpload)))),
                         isDisplayed()));
-        appCompatButton.check(matches(isDisplayed()));
+        appCompatImageView2.check(matches(isDisplayed()));
 
-        ViewInteraction appCompatImageButton2 = onView(
+        ViewInteraction appCompatImageView3 = onView(
                 allOf(withId(R.id.upload_sendDirectly),
                         withParent(allOf(withId(R.id.relativeLayout2),
                                 withParent(withId(R.id.tabUpload)))),
                         isDisplayed()));
-        appCompatImageButton2.check(matches(isDisplayed()));
+        appCompatImageView3.check(matches(isDisplayed()));
 
-        ViewInteraction appCompatImageButton3 = onView(
+        ViewInteraction appCompatImageView4 = onView(
                 allOf(withId(R.id.btnUploadPhotoAdd),
                         withParent(allOf(withId(R.id.relativeLayout2),
                                 withParent(withId(R.id.tabUpload)))),
                         isDisplayed()));
-        appCompatImageButton3.check(matches(isDisplayed()));
+        appCompatImageView4.check(matches(isDisplayed()));
 
         Espresso.unregisterIdlingResources(idlingResource);
 
@@ -135,4 +136,3 @@ public class UploadActivityTest {
         };
     }
 }
-

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,8 @@
         >
         <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
 
-        <uses-library android:name="com.google.android.maps" />  
+        <uses-library android:name="com.google.android.maps"
+            android:required="false"/>
         		 <service android:name=".CollectUserData" />
        	 	<!-- Start of Crittercism Support Forum Manifest Code -->
 				<activity android:name="com.crittercism.NewFeedbackSpringboardActivity" android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen"></activity>


### PR DESCRIPTION
Fixes issue #77  : Implementation of UI tests with espresso

Changes: Implement Travis to run UI tests. Changed the UploadActivityTest a bit as it got changed in the recent PR. Removed the switchCamera button test as  it depends upon the no. of cameras in the device.
