### PR TITLE
Turns Travis CI green. Closes #121

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ licenses:
 before_script:
   - echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a
   - emulator -avd test -no-audio -no-window &
-  - android-wait-for-emulator
+  - sleep 300
   - adb shell input keyevent 82 &
 
 script:


### PR DESCRIPTION
The espresso tests were failing. This would resolve the issues and Travis would be up again.

Closes issue #121

Changes: wait for emulator option waits for the emulator but doesnot define a definite time, so I replaced it with  to sleep for a definite time.

**Since this was a high priority issue, I thought I would take it up**
Please review.