### PR TITLE
fix: [ #180 ] No photos label will appear again!

### DIFF
--- a/app/src/androidTest/java/vn/mbm/phimp/me/UploadActivityTest.java
+++ b/app/src/androidTest/java/vn/mbm/phimp/me/UploadActivityTest.java
@@ -112,6 +112,17 @@ public class UploadActivityTest {
                         isDisplayed()));
         btnUploadAddView.check(matches(isDisplayed()));
 
+        ViewInteraction uploadBtnPanel = onView(
+                allOf(withId(R.id.uploadButtonPanel),
+                        withParent(withId(R.id.relativeLayout2)),
+                        isDisplayed()));
+        uploadBtnPanel.check(matches(isDisplayed()));
+
+        ViewInteraction noPhotosLabel = onView(
+                allOf(withId(R.id.nophotos),
+                        isDisplayed()));
+        noPhotosLabel.check(matches(isDisplayed()));
+
         Espresso.unregisterIdlingResources(idlingResource);
 
     }

--- a/app/src/main/java/vn/mbm/phimp/me/Upload.java
+++ b/app/src/main/java/vn/mbm/phimp/me/Upload.java
@@ -301,6 +301,9 @@ public class Upload extends android.support.v4.app.Fragment {
                     ((ImageAdapter) listPhotoUpload.getAdapter()).notifyDataSetChanged();
                     panelLable.setText(getResources().getString(R.string.upload));
                     toggleButtonPanel(false);
+                    if (uploadGridList.isEmpty()) {
+                        noPhotos.setVisibility(View.VISIBLE);
+                    }
                 }
             }
         });


### PR DESCRIPTION
Fixes issue #180 _No Picture Selected :(_ label invisible after removing all the images

Changes: 
- Made _No Picture Selected :(_ label visible when the list is emptied
- Wrote Espresso tests to validate

Screenshots for the change: 
![device-2017-03-19-1](https://cloud.githubusercontent.com/assets/14261304/24080410/990b3a12-0cc4-11e7-8921-514ddde0a3cd.png)
