### PR TITLE
Color Filter on icons in upload fragment

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/Upload.java
+++ b/app/src/main/java/vn/mbm/phimp/me/Upload.java
@@ -259,6 +259,7 @@ public class Upload extends android.support.v4.app.Fragment {
         removableList = new ArrayList<>();
         // Initiate clear panel buttons
         selectAllBtn = (ImageView) view.findViewById(R.id.btnSelectAll);
+        selectAllBtn.setColorFilter(color);
         selectAllBtn.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -281,6 +282,7 @@ public class Upload extends android.support.v4.app.Fragment {
         });
 
         clearSelectionBtn = (ImageView) view.findViewById(R.id.btnDeselectAll);
+        clearSelectionBtn.setColorFilter(color);
         clearSelectionBtn.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -292,6 +294,7 @@ public class Upload extends android.support.v4.app.Fragment {
         });
 
         removeSelectedBtn = (ImageView) view.findViewById(R.id.btnClearSelected);
+        removeSelectedBtn.setColorFilter(color);
         removeSelectedBtn.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {


### PR DESCRIPTION
Changes: All icons used in app are of grey color. When we long press on upload grid 3 icons appear for deselecting, remove etc. They are of black color. I applied the same color filter to those icons.

Screenshots for the change: 
<table>
<th>PREVIOUS</th><th>NOW</th>
<tr>
<td><img src="https://cloud.githubusercontent.com/assets/14369357/24084100/eede741e-0d09-11e7-8379-83b10ee7006c.png" width="320px">
</td>
<td><img src="https://cloud.githubusercontent.com/assets/14369357/24084098/deb3dc28-0d09-11e7-9a6e-b8b6f4e36d03.png" width="320px">
</td>
</tr>
</table>


