### PR TITLE
Removes Original Filter From Media Editor

### DIFF
--- a/app/src/main/res/layout/cropimage.xml
+++ b/app/src/main/res/layout/cropimage.xml
@@ -122,15 +122,6 @@
                             android:text="Negative"
                             android:src="@drawable/negative" />
                         <ImageButton
-                            android:id="@+id/btnOriginal"
-                            android:layout_width="60dp"
-                            android:layout_height="60dp"
-                            android:scaleType="centerCrop"
-                            android:layout_alignParentTop="true"
-                            android:background="@drawable/transparent"
-                            android:src="@drawable/original"
-                            android:text="Original" />
-                        <ImageButton
                             android:id="@+id/btnRotateTopDown"
                             android:layout_width="60dp"
                             android:layout_height="60dp"


### PR DESCRIPTION
In the Media Editor of Gallery, There is no use of having Original Filter in editors as the user, if wanted the same picture- Then user can cancel the edits(By Pressing Cancel Button).
@Abhi2424shek Please Review.


Screenshots for the change: 
![screenshot_2017-03-21-03-21-06-719_vn mbm phimp me](https://cloud.githubusercontent.com/assets/22375731/24123502/c584d504-0de5-11e7-9339-4da25a8bf18a.png)