### PR TITLE
closes issue #297 Cropped image quality is very low

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/image/CropImage.java
+++ b/app/src/main/java/vn/mbm/phimp/me/image/CropImage.java
@@ -181,10 +181,7 @@ public class CropImage extends MonitoredActivity {
                 Log.d("mSaveUri", mSaveUri.toString());
                 Log.d("p[0]", p[0]);
 
-                /*BitmapFactory.Options options = new BitmapFactory.Options();
-                options.inSampleSize = 4;*/
                 mBitmap = BitmapFactory.decodeFile(p[0]);
-                //mBitmap = Bitmap.createScaledBitmap(mBitmap, mBitmap.getWidth() * 4, mBitmap.getHeight() * 4, false);
 
                 modifiedBitmap = flippedImaged = mBitmapSave = mBitmap;
 

--- a/app/src/main/java/vn/mbm/phimp/me/image/CropImage.java
+++ b/app/src/main/java/vn/mbm/phimp/me/image/CropImage.java
@@ -184,13 +184,13 @@ public class CropImage extends MonitoredActivity {
 
                 BitmapFactory.Options options = new BitmapFactory.Options();
                 options.inSampleSize = 4;
-                mBitmap = BitmapFactory.decodeFile(p[0], options);
+                /*mBitmap = BitmapFactory.decodeFile(p[0], options);
                 if (mBitmap.getWidth() % 2 != 0 || mBitmap.getHeight() % 2 != 0) {
                     //bitmap width , height must even
-                    Log.i("CropImage", "mBitmap width or height not even");
+                    Log.i("CropImage", "mBitmap width or height not even");*/
                     mBitmap = Bitmap.createScaledBitmap(mBitmap, mBitmap.getWidth() * 4, mBitmap.getHeight() * 4, false);
 
-                }
+                //}
                 modifiedBitmap = flippedImaged = mBitmap;
 
                 Log.i("CropImage", "mBitmap Width :" + mBitmap.getWidth() + " mBitmap Height : " + mBitmap.getHeight());

--- a/app/src/main/java/vn/mbm/phimp/me/image/CropImage.java
+++ b/app/src/main/java/vn/mbm/phimp/me/image/CropImage.java
@@ -193,14 +193,14 @@ public class CropImage extends MonitoredActivity
 				Log.d("p[0]",p[0]);	
 				
 				BitmapFactory.Options options = new BitmapFactory.Options();
-		        options.inSampleSize = 4;		    	
+		        options.inSampleSize = 4;
 		        mBitmap = BitmapFactory.decodeFile( p[0], options );
-		        if(mBitmap.getWidth() %2 != 0||mBitmap.getHeight() %2 != 0){
+		        /*if(mBitmap.getWidth() %2 != 0||mBitmap.getHeight() %2 != 0){
 		        	//bitmap width , height must even
-		        	Log.i("CropImage","mBitmap width or height not even");			        	
-		        	mBitmap=Bitmap.createScaledBitmap(mBitmap, mBitmap.getWidth()*4, mBitmap.getHeight()*4, false);
+		        	Log.i("CropImage","mBitmap width or height not even");*/
+		       	mBitmap=Bitmap.createScaledBitmap(mBitmap, mBitmap.getWidth()*4, mBitmap.getHeight()*4, false);
 	        				        	
-		        }
+		        //}
 				modifiedBitmap= flippedImaged = mBitmap;
 				
 				Log.i("CropImage", "mBitmap Width :"+mBitmap.getWidth()+" mBitmap Height : "+mBitmap.getHeight());

--- a/app/src/main/java/vn/mbm/phimp/me/image/CropImage.java
+++ b/app/src/main/java/vn/mbm/phimp/me/image/CropImage.java
@@ -182,15 +182,11 @@ public class CropImage extends MonitoredActivity {
                 Log.d("mSaveUri", mSaveUri.toString());
                 Log.d("p[0]", p[0]);
 
-                BitmapFactory.Options options = new BitmapFactory.Options();
-                options.inSampleSize = 4;
-                /*mBitmap = BitmapFactory.decodeFile(p[0], options);
-                if (mBitmap.getWidth() % 2 != 0 || mBitmap.getHeight() % 2 != 0) {
-                    //bitmap width , height must even
-                    Log.i("CropImage", "mBitmap width or height not even");*/
-                    mBitmap = Bitmap.createScaledBitmap(mBitmap, mBitmap.getWidth() * 4, mBitmap.getHeight() * 4, false);
+                /*BitmapFactory.Options options = new BitmapFactory.Options();
+                options.inSampleSize = 4;*/
+                mBitmap = BitmapFactory.decodeFile(p[0]);
+                //mBitmap = Bitmap.createScaledBitmap(mBitmap, mBitmap.getWidth() * 4, mBitmap.getHeight() * 4, false);
 
-                //}
                 modifiedBitmap = flippedImaged = mBitmap;
 
                 Log.i("CropImage", "mBitmap Width :" + mBitmap.getWidth() + " mBitmap Height : " + mBitmap.getHeight());


### PR DESCRIPTION
Fixes issue #297 
Changes: 
At line 196 of cropimage class. There the image is getting downsampled by 4.
A scaledbitmap is being created only with those images whose dimensions after downsampling are not even. But this should be performed even if the dimensions are even. I changed that.
