### PR TITLE
fixes issue #321 App crashes if user edit image in upload section

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/gallery3d/media/CropImage.java
+++ b/app/src/main/java/vn/mbm/phimp/me/gallery3d/media/CropImage.java
@@ -564,7 +564,6 @@ public class CropImage extends MonitoredActivity {
                             doRotate90(mImageView);
                             mImageView.mHighlightViews.clear();
                             if (mBitmap != null && !mBitmap.isRecycled()) {
-                                mBitmap.recycle();
                                 mBitmap = null;
                             }
                             mBitmap = modifiedBitmap;
@@ -1004,6 +1003,7 @@ public class CropImage extends MonitoredActivity {
         mx.setRotate(90);
         //modifiedBitmap.recycle();
         modifiedBitmap = Bitmap.createBitmap(bm,0,0,bm.getWidth(),bm.getHeight(),mx,true);
+        flippedImaged=modifiedBitmap;
         image.setImageBitmap(modifiedBitmap);
     }
     public static Bitmap doHorizontalFlip(Bitmap sampleBitmap) {


### PR DESCRIPTION
Fixes issue #321 

Changes: error was due to recycled bitmap so I removed bitmap.recycle() after image is rotated and also updated bitmap which is send to imagefilter class.

Screenshots for the change: 
