### PR TITLE
Closes issue #353 No size info of image when exif data unavailable 

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/gallery/PhimpMeGallery.java
+++ b/app/src/main/java/vn/mbm/phimp/me/gallery/PhimpMeGallery.java
@@ -17,9 +17,11 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.database.Cursor;
+import android.graphics.BitmapFactory;
 import android.media.ExifInterface;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.ParcelFileDescriptor;
 import android.provider.MediaStore;
 import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.FloatingActionButton;
@@ -353,10 +355,27 @@ public class PhimpMeGallery extends AppCompatActivity implements View.OnClickLis
             ExifInterface exif_data = new ExifInterface(file.getAbsolutePath());
             Date lastModDate = new Date(file.lastModified());
             long length = file.length()/1024;
+            String img_width = exif_data.getAttribute(ExifInterface.TAG_IMAGE_WIDTH);
+            String img_height = exif_data.getAttribute(ExifInterface.TAG_IMAGE_LENGTH);
+            if(img_width.isEmpty() || img_height.isEmpty() || img_width.equals("0") || img_height.equals("0") ) {
+                try {
+                    BitmapFactory.Options options = new BitmapFactory.Options();
+                    options.inJustDecodeBounds = true;
+                    ParcelFileDescriptor fd = getContentResolver().openFileDescriptor(Uri.fromFile(file), "r");
+                    if (fd != null) {
+                        BitmapFactory.decodeFileDescriptor(fd.getFileDescriptor(), null, options);
+                        img_width = options.outWidth + "";
+                        img_height = options.outHeight + "";
+                        fd.close();
+                        options = null;
+                    }
+                } catch (Exception e) {
+                }
+            }
             ((TextView)pwindo.getContentView().findViewById(R.id.path)).setText(file.getAbsolutePath());
             ((TextView)pwindo.getContentView().findViewById(R.id.time)).setText(lastModDate.toString());
-            ((TextView)pwindo.getContentView().findViewById(R.id.image_width)).setText(exif_data.getAttribute(ExifInterface.TAG_IMAGE_WIDTH));
-            ((TextView)pwindo.getContentView().findViewById(R.id.height)).setText(exif_data.getAttribute(ExifInterface.TAG_IMAGE_LENGTH));
+            ((TextView)pwindo.getContentView().findViewById(R.id.image_width)).setText(img_width);
+            ((TextView)pwindo.getContentView().findViewById(R.id.height)).setText(img_height);
             ((TextView)pwindo.getContentView().findViewById(R.id.size)).setText(Long.toString(length)+ "KB");
 
         } catch (IOException e) {

--- a/app/src/main/java/vn/mbm/phimp/me/gallery/PhimpMeGallery.java
+++ b/app/src/main/java/vn/mbm/phimp/me/gallery/PhimpMeGallery.java
@@ -357,7 +357,7 @@ public class PhimpMeGallery extends AppCompatActivity implements View.OnClickLis
             long length = file.length()/1024;
             String img_width = exif_data.getAttribute(ExifInterface.TAG_IMAGE_WIDTH);
             String img_height = exif_data.getAttribute(ExifInterface.TAG_IMAGE_LENGTH);
-            if(img_width.isEmpty() || img_height.isEmpty() || img_width.equals("0") || img_height.equals("0") ) {
+            if("0".equals(img_width) || "0".equals(img_height)) {
                 try {
                     BitmapFactory.Options options = new BitmapFactory.Options();
                     options.inJustDecodeBounds = true;


### PR DESCRIPTION
Fixes issue #353 
Changes: 
image size is assigned by using its data when exifdata is not available