### PR TITLE
fixes issue #368 : camera switch button not working properl

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/Camera2.java
+++ b/app/src/main/java/vn/mbm/phimp/me/Camera2.java
@@ -93,7 +93,9 @@ public class Camera2 extends android.support.v4.app.Fragment {
 	double lat;
 	double lon;
 	int statusScreen = 0;
+	int uiOptions;
 	View view;
+	View decorView;
 
 	// Directions for Camera Button Orientations
 	private final int NE = 45;
@@ -125,8 +127,8 @@ public class Camera2 extends android.support.v4.app.Fragment {
 	@Override
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 
-		View decorView = getActivity().getWindow().getDecorView();
-		int uiOptions = View.SYSTEM_UI_FLAG_FULLSCREEN;
+		decorView = getActivity().getWindow().getDecorView();
+		uiOptions = View.SYSTEM_UI_FLAG_FULLSCREEN;
 		decorView.setSystemUiVisibility(uiOptions);
 
 		view=  inflater.inflate(R.layout.camera, container, false);
@@ -322,7 +324,7 @@ public class Camera2 extends android.support.v4.app.Fragment {
 			lon = -1;
 		}
 		try{
-			mCamera = Camera.open();}catch(Exception e){
+			mCamera = Camera.open(PhimpMe.camera_use);}catch(Exception e){
 		}
 		//mCamera.setDisplayOrientation(90);
 		setCameraDisplayOrientation(getActivity(), 0, mCamera);
@@ -691,6 +693,7 @@ public class Camera2 extends android.support.v4.app.Fragment {
 		//PhimpMe.hideTabs();
 		//PhimpMe.hideAd();
 		mOrientation.enable();
+		decorView.setSystemUiVisibility(uiOptions);
 		try{
 			mCamera = Camera.open(PhimpMe.camera_use);
 		}catch(Exception e){}


### PR DESCRIPTION
Fixes issue #368 

Changes: When we replaced camera fragment by other fragment and then replacing that fragment by camera fragment, camera fragment start from initial i.e from Oncreateview and at oncreateview we are initializing camera by default . So I changed that so that camera will be updated accordingly. Similiar for status bar. When we click discard button onresume method of camera fragment get called so I added code there to hide status bar.

Screenshots for the change: 
