### PR TITLE
 Fixes issue #375 state of checkbox is changing automatically

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/Settings.java
+++ b/app/src/main/java/vn/mbm/phimp/me/Settings.java
@@ -444,7 +444,7 @@ public class Settings extends Fragment
 //		lLocalGallery.setOrientation(LinearLayout.HORIZONTAL);
 
 		CheckBox chkLocalGallery = (CheckBox)getView().findViewById(R.id.checkbox_gallery);
-		chkLocalGallery.setChecked(PhimpMe.FEEDS_LOCAL_GALLERY);
+		chkLocalGallery.setChecked(PhimpMe.check_download_local_gallery);
 		chkLocalGallery.setOnCheckedChangeListener(new OnCheckedChangeListener()
 		{
 			@Override


### PR DESCRIPTION
Fixes issue #375 

Changes: on clicking save button after taking pic, phimpme activity start again and hence FEEDS_LOCAL_GALLERY variable(which is controling the state of checkbox) get reset. So I replace it by another variable which is changing only in settings activity.

Screenshots for the change: 
