### PR TITLE
Closes #382 : Image loading stops at bottom

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/newGallery.java
+++ b/app/src/main/java/vn/mbm/phimp/me/newGallery.java
@@ -3485,7 +3485,7 @@ public class newGallery extends Fragment {
 
                   @Override
                   public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
-                      if ((visibleItemCount!=0) && (totalItemCount!=0) ) {
+                      if ((visibleItemCount!=0) && (totalItemCount!=0) && (totalItemCount != localImageCount)) {
                           if ((firstVisibleItem + visibleItemCount == totalItemCount) && (!FLAG_IS_LOADING)) {
                               FLAG_IS_LOADING = true;
                               if (turnsNeeded > 1) {


### PR DESCRIPTION
Fixes issue #382 

Changes:
- Stops image loading calls when the image list is full :)

Screenshots for the change: 
> Not available
