### PR TITLE
fixes issue #404 App Crash in camera page

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/Camera2.java
+++ b/app/src/main/java/vn/mbm/phimp/me/Camera2.java
@@ -796,9 +796,6 @@ public class Camera2 extends android.support.v4.app.Fragment {
 			_intent.putExtra("scale", true);
 			_intent.putExtra("activityName", "Camera2");
 
-			//resetting capture progress flag
-			FLAG_CAPTURE_IN_PROGRESS = false;
-
 			startActivityForResult(_intent, 1);
 			//progress.dismiss();
 

--- a/app/src/main/java/vn/mbm/phimp/me/gallery3d/media/CropImage.java
+++ b/app/src/main/java/vn/mbm/phimp/me/gallery3d/media/CropImage.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
 
+import vn.mbm.phimp.me.Camera2;
 import vn.mbm.phimp.me.ImagesFilter;
 import vn.mbm.phimp.me.PhimpMe;
 import vn.mbm.phimp.me.R;
@@ -267,6 +268,10 @@ public class CropImage extends MonitoredActivity {
     @Override
     public void onCreate(Bundle icicle) {
         super.onCreate(icicle);
+
+        //reset capture progress flag in camera
+        Camera2.FLAG_CAPTURE_IN_PROGRESS = false;
+
         //set dark theme
         if (Utility.getTheme(getApplicationContext()) == ThemeDark) {
             setTheme(R.style.AppTheme_Dark);


### PR DESCRIPTION
Fixes issue #404 App Crash in camera page

Changes: 
After multiple tries, finally found the reason. 
The Capture progress flag is getting reset before the next activity opens. There is a time gap between those steps. So if the capture button is pressed in that moment, the app is getting crashed.
So I moved the reset statement of progress flag to next opening activity and that worked fine.