### PR TITLE
Solved redundant image editing page. issue #411

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/gallery/PhimpMeGallery.java
+++ b/app/src/main/java/vn/mbm/phimp/me/gallery/PhimpMeGallery.java
@@ -9,7 +9,7 @@ import vn.mbm.phimp.me.PhimpMe;
 import vn.mbm.phimp.me.R;
 import vn.mbm.phimp.me.Upload;
 import vn.mbm.phimp.me.Utility;
-import vn.mbm.phimp.me.image.CropImage;
+import vn.mbm.phimp.me.gallery3d.media.CropImage;
 import vn.mbm.phimp.me.utils.BasicCallBack;
 import vn.mbm.phimp.me.utils.ImageUtil;
 import vn.mbm.phimp.me.utils.OnSwipeTouchListener;


### PR DESCRIPTION
Fixes issue #411 Removing redundant editing page. 

Changes: Redirected the editing page from image.CromImage.java to gallery.media.CropImage.java. This will bring a uniformity in the app. 

