### PR TITLE
Fixed #427 removed white screen after splash

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/SplashScreen.java
+++ b/app/src/main/java/vn/mbm/phimp/me/SplashScreen.java
@@ -1,15 +1,14 @@
 package vn.mbm.phimp.me;
 
-import vn.mbm.phimp.me.R;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.MotionEvent;
 
 public class SplashScreen extends Activity {
-	
-	protected int _splashTime = 2000; 
-	
+
+	protected int _splashTime = 2000;
+
 	private Thread splashTread;
 
 
@@ -59,5 +58,5 @@ public class SplashScreen extends Activity {
 	    }
 	    return true;
 	}
-	
+
 }

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -11,6 +11,7 @@
         <item name="windowBackgroundTheme">@color/white</item>
         <item name="IconsColor">@color/icongrey</item>
         <item name="textThemes">@color/icongrey</item>
+        <item name="android:windowDisablePreview">true</item>
         <item name="themeCardColor" >@color/white</item>
         <item name="BottomNavigationIconsColor" >@drawable/bottom_nav_icon_color_light</item>
         <item name="android:windowBackground">@color/colorWindowBackground</item>
@@ -24,6 +25,7 @@
         <item name="colorPrimaryTheme">@color/primary_material_dark_2</item>
         <item name="IconsColor">@color/white</item>
         <item name="textThemes">@color/white70</item>
+        <item name="android:windowDisablePreview">true</item>
         <item name="windowBackgroundTheme">@color/ColorWindowBackgroundInverse</item>
         <item name="colorPrimaryDarkTheme">@color/colorPrimaryDarkInverse</item>
         <item name="colorAccentTheme">@color/blue_dark</item>


### PR DESCRIPTION
Fixes issue #427 Annoying white screen after splash 
Changes:
The white screen is due to windows preview.
Disabled the window preview.
