### PR TITLE
removed the fix date button from details dialog

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/leafpic/activities/SingleMediaActivity.java
+++ b/app/src/main/java/vn/mbm/phimp/me/leafpic/activities/SingleMediaActivity.java
@@ -573,15 +573,6 @@ public class SingleMediaActivity extends SharedMediaActivity {
                         .ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) { }});
-
-                detailsDialog.setButton(DialogInterface.BUTTON_NEUTRAL, getString(R.string.fix_date).toUpperCase(), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        if (!getAlbum().getCurrentMedia().fixDate())
-                            Toast.makeText(SingleMediaActivity.this, R.string.unable_to_fix_date, Toast.LENGTH_SHORT).show();
-                    }
-                });
-
                 detailsDialog.show();
                 break;
 

--- a/app/src/main/java/vn/mbm/phimp/me/leafpic/data/Media.java
+++ b/app/src/main/java/vn/mbm/phimp/me/leafpic/data/Media.java
@@ -225,19 +225,6 @@ public class Media implements Parcelable, Serializable {
         return -1;
     }
 
-    public boolean fixDate(){
-        long newDate = getDateTaken();
-        if (newDate != -1){
-            File f = new File(path);
-            if (f.setLastModified(newDate)) {
-                dateModified = newDate;
-                return true;
-            }
-        }
-        return false;
-    }
-    //</editor-fold>
-
     public File getFile() {
         if (path != null) return new File(path);
         return null;


### PR DESCRIPTION
Fixes issue #523 

Changes: 
Removed the fix date option from dialog as it is not required.

Screenshots for the change: 

![screenshot_2017-06-04-01-19-44-984_vn mbm phimp me](https://cloud.githubusercontent.com/assets/9361754/26756623/82d68256-48c4-11e7-80cc-dfbf6773d92a.png)
