### PR TITLE
Open edit images after saving

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/editor/editimage/EditImageActivity.java
+++ b/app/src/main/java/vn/mbm/phimp/me/editor/editimage/EditImageActivity.java
@@ -5,6 +5,7 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Bitmap;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -19,6 +20,8 @@ import android.view.View.OnClickListener;
 import android.widget.FrameLayout;
 import android.widget.Toast;
 import android.widget.ViewFlipper;
+
+import java.io.File;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -43,6 +46,7 @@ import vn.mbm.phimp.me.editor.editimage.view.StickerView;
 import vn.mbm.phimp.me.editor.editimage.view.TextStickerView;
 import vn.mbm.phimp.me.editor.editimage.view.imagezoom.ImageViewTouch;
 import vn.mbm.phimp.me.editor.editimage.view.imagezoom.ImageViewTouchBase;
+import vn.mbm.phimp.me.leafpic.activities.SingleMediaActivity;
 import vn.mbm.phimp.me.leafpic.util.ThemeHelper;
 
 /**
@@ -121,6 +125,8 @@ public class EditImageActivity extends EditBaseActivity {
     public TuningFragment mTuningFragment;
 
     private SaveImageTask mSaveImageTask;
+    private int requestCode;
+    final String REVIEW_ACTION = "com.android.camera.action.REVIEW";
 
     /**
      * @param context
@@ -137,6 +143,7 @@ public class EditImageActivity extends EditBaseActivity {
         Intent it = new Intent(context, EditImageActivity.class);
         it.putExtra(EditImageActivity.FILE_PATH, editImagePath);
         it.putExtra(EditImageActivity.EXTRA_OUTPUT, outputPath);
+        it.putExtra("requestCode",requestCode);
         context.startActivityForResult(it, requestCode);
     }
 
@@ -148,6 +155,7 @@ public class EditImageActivity extends EditBaseActivity {
         ButterKnife.bind(this);
         initView();
         getData();
+        requestCode = getIntent().getIntExtra("requestCode", 1);
 
     }
 
@@ -469,7 +477,21 @@ public class EditImageActivity extends EditBaseActivity {
 
         FileUtil.ablumUpdate(this, saveFilePath);
         setResult(RESULT_OK, returnIntent);
-        finish();
+        if(requestCode == 1 && mOpTimes<=0) {   //Checks if this Activity was started by PhotoActivity
+            Intent intent = new Intent(REVIEW_ACTION, Uri.fromFile(new File(filePath)));
+            intent.setClass(getApplicationContext(), SingleMediaActivity.class);
+            startActivity(intent);
+            finish();
+        }
+        else if(mOpTimes>0) {
+            Intent intent = new Intent(REVIEW_ACTION, Uri.fromFile(new File(saveFilePath)));
+            intent.setClass(getApplicationContext(), SingleMediaActivity.class);
+            startActivity(intent);
+            finish();
+        }
+        else {
+            finish();
+        }
     }
 
     @Override

--- a/app/src/main/java/vn/mbm/phimp/me/leafpic/data/Album.java
+++ b/app/src/main/java/vn/mbm/phimp/me/leafpic/data/Album.java
@@ -40,6 +40,8 @@ public class Album implements Serializable {
 	private ArrayList<Media> media;
 	private ArrayList<Media> selectedMedias;
 
+    private int selectedCount;
+
 	private Album() {
 		media = new ArrayList<Media>();
 		selectedMedias = new ArrayList<Media>();
@@ -264,7 +266,10 @@ public class Album implements Serializable {
 	}
 
 	public int getSelectedCount() {
-		return selectedMedias.size();
+        if(selectedMedias!=null){
+            selectedCount = selectedMedias.size();
+        }
+		return selectedCount;
 	}
 
 	public boolean areMediaSelected() { return getSelectedCount() != 0;}


### PR DESCRIPTION
Fixes issue #518 Open edited Images after saving

Changes: Added intent to open SingleMediaActivity with new saved images paths. Made changes in Albums.java to avoid null pointer exceptions.

