### PR TITLE
Fixed media count issue

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/leafpic/data/providers/MediaStoreProvider.java
+++ b/app/src/main/java/vn/mbm/phimp/me/leafpic/data/providers/MediaStoreProvider.java
@@ -126,8 +126,7 @@ public class  MediaStoreProvider {
 
 	private static int getAlbumCount(Context context, long id) {
 		int c = 0;
-		String selection = "( "+MediaStore.Files.FileColumns.MEDIA_TYPE + "=? or "
-										   + MediaStore.Files.FileColumns.MEDIA_TYPE + "=? ) and " + MediaStore.Files.FileColumns.PARENT + "=?";
+		String selection = "( " + MediaStore.Files.FileColumns.MEDIA_TYPE + "=? ) and " + MediaStore.Files.FileColumns.PARENT + "=?";
 
 		String[] selectionArgs = new String[] {
 						String.valueOf(MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE),


### PR DESCRIPTION
Fixes issue #537 Media count in album is always zero

Changes: Now the count is displayed according to no. of media in the album

