### PR TITLE
Filter by images fix

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/leafpic/data/Album.java
+++ b/app/src/main/java/vn/mbm/phimp/me/leafpic/data/Album.java
@@ -128,7 +128,7 @@ public class Album implements Serializable {
 				break;
 			case IMAGES:
 				for (Media media1 : media)
-					if (media1.isImage()) mediaArrayList.add(media1);
+					if (media1.isImage() && !media1.isGif()) mediaArrayList.add(media1);
 				break;
 
 		}


### PR DESCRIPTION
Fixes issue #548 Filter by images option fixed

Changes: Now GIF's doesn't show along with images.
