### PR TITLE
Activity Stack Maintain from bottom naigation bar

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/base/BaseActivity.java
+++ b/app/src/main/java/vn/mbm/phimp/me/base/BaseActivity.java
@@ -43,14 +43,14 @@ public abstract class BaseActivity extends AppCompatActivity implements BottomNa
     public boolean onNavigationItemSelected(@NonNull final MenuItem item) {
         if (item.getItemId() != getNavigationMenuItemId()) {
             switch (item.getItemId()) {
+                case R.id.navigation_camera:
+                    startActivity(new Intent(this, CameraActivity.class).addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP));
+                    break;
                 case R.id.navigation_home:
                     startActivity(new Intent(this, LFMainActivity.class));
                     break;
-                case R.id.navigation_camera:
-                    startActivity(new Intent(this, CameraActivity.class));
-                    break;
                 case R.id.navigation_accounts:
-                    startActivity(new Intent(this, AccountActivity.class));
+                    startActivity(new Intent(this, AccountActivity.class).addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP));
                     break;
             }
         }


### PR DESCRIPTION
Fixes issue #571 

**Actual Behaviour**
Activities are kept adding in activity stack. Suppose we open home->camera->accounts->camera->home->acccounts. There is a loop between the activities on pressing the back button.

**Changes:**
Clean the stack history. It can be check by performing multiple activities from the bottom navigation bar.
