### PR TITLE
Toolbar update issue on swipe refresh fixed

### DIFF
--- a/app/src/main/java/vn/mbm/phimp/me/leafpic/activities/LFMainActivity.java
+++ b/app/src/main/java/vn/mbm/phimp/me/leafpic/activities/LFMainActivity.java
@@ -1352,6 +1352,8 @@ public class LFMainActivity extends SharedMediaActivity {
             checkNothing();
             swipeRefreshLayout.setRefreshing(false);
             getAlbums().saveBackup(getApplicationContext());
+            invalidateOptionsMenu();
+            finishEditMode();
         }
     }
 
@@ -1377,6 +1379,8 @@ public class LFMainActivity extends SharedMediaActivity {
                 HandlingAlbums.addAlbumToBackup(getApplicationContext(), getAlbum());
             checkNothing();
             swipeRefreshLayout.setRefreshing(false);
+            invalidateOptionsMenu();
+            finishEditMode();
         }
     }
 


### PR DESCRIPTION
Fixes issue #570 Toolbar does not update on swipe refresh

Changes: Added toolbar update function and finish edit mode function on post execution method of swipe refresh.

