### PR TITLE
Toolbar option to switch to all photos

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/leafpic/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/leafpic/activities/LFMainActivity.java
@@ -5,6 +5,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
+import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
@@ -53,6 +54,7 @@ import org.fossasia.phimpme.leafpic.data.HandlingAlbums;
 import org.fossasia.phimpme.leafpic.data.Media;
 import org.fossasia.phimpme.leafpic.data.base.FilterMode;
 import org.fossasia.phimpme.leafpic.data.base.SortingOrder;
+import org.fossasia.phimpme.leafpic.data.providers.StorageProvider;
 import org.fossasia.phimpme.leafpic.util.Affix;
 import org.fossasia.phimpme.leafpic.util.AlertDialogsHelper;
 import org.fossasia.phimpme.leafpic.util.ContentHelper;
@@ -63,6 +65,7 @@ import org.fossasia.phimpme.leafpic.util.StringUtils;
 import org.fossasia.phimpme.leafpic.views.GridSpacingItemDecoration;
 import org.fossasia.phimpme.utilities.ActivitySwitchHelper;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Locale;
 
@@ -95,6 +98,13 @@ public class LFMainActivity extends SharedMediaActivity {
     private SelectAlbumBottomSheet bottomSheetDialogFragment;
     private SwipeRefreshLayout swipeRefreshLayout;
     private boolean hidden = false, pickMode = false, editMode = false, albumsMode = true, firstLaunch = true;
+
+    //To handle all photos/Album conditions
+    public boolean all_photos = false;
+    final String REVIEW_ACTION = "com.android.camera.action.REVIEW";
+    public static ArrayList<Media> listAll;
+    public int size;
+    public int pos;
     /*
     editMode-  When true, user can select items by clicking on them one by one
      */
@@ -109,17 +119,19 @@ public class LFMainActivity extends SharedMediaActivity {
         public boolean onLongClick(View v) {
             Media m = (Media) v.findViewById(R.id.photo_path).getTag();
             //If first long press, turn on selection mode
-            if (!editMode) {
-                mediaAdapter.notifyItemChanged(getAlbum().toggleSelectPhoto(m));
-                editMode = true;
-            } else
-                getAlbum().selectAllPhotosUpTo(getAlbum().getIndex(m), mediaAdapter);
+            if (!all_photos) {
+                if (!editMode) {
+                    mediaAdapter.notifyItemChanged(getAlbum().toggleSelectPhoto(m));
+                    editMode = true;
+                } else
+                    getAlbum().selectAllPhotosUpTo(getAlbum().getIndex(m), mediaAdapter);
 
-            invalidateOptionsMenu();
+                invalidateOptionsMenu();
+            } else
+                Toast.makeText(LFMainActivity.this, getString(R.string.albums_mode), Toast.LENGTH_SHORT).show();
             return true;
         }
     };
-
 
     /**
      * Handles short clicks on photos.
@@ -131,22 +143,34 @@ public class LFMainActivity extends SharedMediaActivity {
         @Override
         public void onClick(View v) {
             Media m = (Media) v.findViewById(R.id.photo_path).getTag();
-            if (!pickMode) {
-                //if in selection mode, toggle the selected/unselect state of photo
-                if (editMode) {
-                    mediaAdapter.notifyItemChanged(getAlbum().toggleSelectPhoto(m));
-                    invalidateOptionsMenu();
+            if (all_photos) {
+                size = listAll.size();
+                pos = getImagePosition(m.getPath());
+            }
+            if (!all_photos) {
+                if (!pickMode) {
+                    //if in selection mode, toggle the selected/unselect state of photo
+                    if (editMode) {
+                        mediaAdapter.notifyItemChanged(getAlbum().toggleSelectPhoto(m));
+                        invalidateOptionsMenu();
+                    } else {
+                        getAlbum().setCurrentPhotoIndex(m);
+                        Intent intent = new Intent(LFMainActivity.this, SingleMediaActivity.class);
+                        intent.setAction(SingleMediaActivity.ACTION_OPEN_ALBUM);
+                        startActivity(intent);
+                    }
                 } else {
-                    getAlbum().setCurrentPhotoIndex(m);
-                    Intent intent = new Intent(LFMainActivity.this, SingleMediaActivity.class);
-                    intent.setAction(SingleMediaActivity.ACTION_OPEN_ALBUM);
-                    startActivity(intent);
+                    setResult(RESULT_OK, new Intent().setData(m.getUri()));
+                    finish();
                 }
             } else {
-                setResult(RESULT_OK, new Intent().setData(m.getUri()));
-                finish();
+                Intent intent = new Intent(REVIEW_ACTION, Uri.fromFile(new File(m.getPath())));
+                intent.putExtra(getString(R.string.all_photo_mode), true);
+                intent.putExtra(getString(R.string.position), pos);
+                intent.putExtra(getString(R.string.allMediaSize), size);
+                intent.setClass(getApplicationContext(), SingleMediaActivity.class);
+                startActivity(intent);
             }
-
         }
     };
 
@@ -177,6 +201,17 @@ public class LFMainActivity extends SharedMediaActivity {
         }
     };
 
+    public int getImagePosition(String path) {
+        int pos = 0;
+        for (int i = 0; i < listAll.size(); i++) {
+            if (listAll.get(i).getPath().equals(path)) {
+                pos = i;
+                break;
+            }
+        }
+        return pos;
+    }
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -187,6 +222,7 @@ public class LFMainActivity extends SharedMediaActivity {
         editMode = false;
         securityObj = new SecurityHelper(LFMainActivity.this);
         pickMode = getIntent().getExtras().getBoolean(SplashScreen.PICK_MODE);
+        listAll = StorageProvider.getAllShownImages(LFMainActivity.this);
 
         initUI();
         displayData(getIntent().getExtras());
@@ -228,7 +264,24 @@ public class LFMainActivity extends SharedMediaActivity {
         invalidateOptionsMenu();
     }
 
+    private void displayAllMedia(boolean reload) {
+        toolbar.setTitle(getString(R.string.all_media));
+        toolbar.setNavigationIcon(getToolbarIcon(GoogleMaterial.Icon.gmd_arrow_back));
+        mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
+        mediaAdapter.swapDataSet(listAll);
+        if (reload) new PrepareAllPhotos().execute();
+        toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                displayAlbums();
+            }
+        });
+        albumsMode = editMode = false;
+        invalidateOptionsMenu();
+    }
+
     private void displayAlbums() {
+        all_photos = false;
         displayAlbums(true);
     }
 
@@ -342,8 +395,12 @@ public class LFMainActivity extends SharedMediaActivity {
                     getAlbums().clearSelectedAlbums();
                     new PrepareAlbumTask().execute();
                 } else {
-                    getAlbum().clearSelectedPhotos();
-                    new PreparePhotosTask().execute();
+                    if (!all_photos) {
+                        getAlbum().clearSelectedPhotos();
+                        new PreparePhotosTask().execute();
+                    } else {
+                        new PrepareAllPhotos().execute();
+                    }
                 }
             }
         });
@@ -586,7 +643,9 @@ public class LFMainActivity extends SharedMediaActivity {
             if (editMode)
                 toolbar.setTitle(getAlbum().getSelectedCount() + "/" + getAlbum().getMedia().size());
             else {
-                toolbar.setTitle(getAlbum().getName());
+                if (!all_photos)
+                    toolbar.setTitle(getAlbum().getName());
+                else toolbar.setTitle(getString(R.string.all_media));
                 toolbar.setNavigationIcon(getToolbarIcon(GoogleMaterial.Icon.gmd_arrow_back));
                 toolbar.setNavigationOnClickListener(new View.OnClickListener() {
                     @Override
@@ -635,6 +694,9 @@ public class LFMainActivity extends SharedMediaActivity {
         getMenuInflater().inflate(R.menu.menu_albums, menu);
 
         if (albumsMode) {
+            Drawable shareIcon = getResources().getDrawable(R.drawable.ic_photo_24dp, getTheme());
+            shareIcon.setColorFilter(Color.WHITE, PorterDuff.Mode.SRC_ATOP);
+            menu.findItem(R.id.all_photos).setIcon(shareIcon);
             menu.findItem(R.id.select_all).setTitle(
                     getString(getAlbums().getSelectedCount() == albumsAdapter.getItemCount()
                             ? R.string.clear_selected
@@ -698,10 +760,12 @@ public class LFMainActivity extends SharedMediaActivity {
             editMode = getAlbums().getSelectedCount() != 0;
             menu.setGroupVisible(R.id.album_options_menu, editMode);
             menu.setGroupVisible(R.id.photos_option_men, false);
+            menu.findItem(R.id.all_photos).setVisible(true);
         } else {
             editMode = getAlbum().areMediaSelected();
             menu.setGroupVisible(R.id.photos_option_men, editMode);
             menu.setGroupVisible(R.id.album_options_menu, !editMode);
+            menu.findItem(R.id.all_photos).setVisible(false);
         }
 
         togglePrimaryToolbarOptions(menu);
@@ -737,6 +801,15 @@ public class LFMainActivity extends SharedMediaActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
 
         switch (item.getItemId()) {
+
+            case R.id.all_photos:
+                if (!all_photos) {
+                    all_photos = true;
+                    displayAllMedia(true);
+                } else {
+                    displayAlbums();
+                }
+                return true;
 
             case R.id.select_all:
                 if (albumsMode) {
@@ -1431,6 +1504,34 @@ public class LFMainActivity extends SharedMediaActivity {
             swipeRefreshLayout.setRefreshing(false);
             invalidateOptionsMenu();
             finishEditMode();
+        }
+    }
+
+    private class PrepareAllPhotos extends AsyncTask<Void, Void, Void> {
+
+        @Override
+        protected void onPreExecute() {
+            swipeRefreshLayout.setRefreshing(true);
+            toggleRecyclersVisibility(false);
+            super.onPreExecute();
+        }
+
+        @Override
+        protected Void doInBackground(Void... arg0) {
+            getAlbum().updatePhotos(getApplicationContext());
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(Void result) {
+            mediaAdapter.swapDataSet(StorageProvider.getAllShownImages(LFMainActivity.this));
+            if (!hidden)
+                HandlingAlbums.addAlbumToBackup(getApplicationContext(), getAlbum());
+            checkNothing();
+            swipeRefreshLayout.setRefreshing(false);
+            invalidateOptionsMenu();
+            finishEditMode();
+            toolbar.setTitle(getString(R.string.all_media));
         }
     }
 

--- a/app/src/main/java/org/fossasia/phimpme/leafpic/data/providers/StorageProvider.java
+++ b/app/src/main/java/org/fossasia/phimpme/leafpic/data/providers/StorageProvider.java
@@ -1,6 +1,10 @@
 package org.fossasia.phimpme.leafpic.data.providers;
 
+import android.app.Activity;
 import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.MediaStore;
 
 import org.fossasia.phimpme.leafpic.data.Album;
 import org.fossasia.phimpme.leafpic.data.CustomAlbumsHelper;
@@ -110,6 +114,32 @@ public class StorageProvider {
         File[] images = new File(path).listFiles(new ImageFileFilter(includeVideo));
         for (File image : images)
             list.add(new Media(image));
+        return list;
+    }
+
+    public static ArrayList<Media> getAllShownImages(Activity activity) {
+        Uri uri;
+        Cursor cursor;
+        int column_index;
+        ArrayList<String> listOfAllImages = new ArrayList<String>();
+        ArrayList<Media> list = new ArrayList<Media>();
+        String absolutePathOfImage;
+        uri = android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+
+        String[] projection = {MediaStore.MediaColumns.DATA};
+
+        cursor = activity.getContentResolver().query(uri, projection, null,
+                null, null);
+
+        // column_index = cursor.getColumnIndexOrThrow(MediaColumns.DATA);
+        column_index = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATA);
+        while (cursor.moveToNext()) {
+            absolutePathOfImage = cursor.getString(column_index);
+            listOfAllImages.add(absolutePathOfImage);
+        }
+        for (String path : listOfAllImages) {
+            list.add(new Media(new File(path)));
+        }
         return list;
     }
 

--- a/app/src/main/res/drawable/ic_photo_24dp.xml
+++ b/app/src/main/res/drawable/ic_photo_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
+</vector>

--- a/app/src/main/res/menu/menu_albums.xml
+++ b/app/src/main/res/menu/menu_albums.xml
@@ -3,6 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="org.fossasia.phimpme.leafpic.activities.LFMainActivity">
 
+    <item
+        android:id="@+id/all_photos"
+        android:title="@string/all_photos"
+        app:showAsAction="always" />
+
     <group android:id="@+id/general_action">
 
         <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -761,4 +761,13 @@
     <string name="drawable">drawable</string>
     <string name="ic_">ic_</string>
     <string name="_indicator">_indicator</string>
+
+    <!--All photos-->
+    <string name="all_photos">All_photos</string>
+    <string name="all_photo_mode">photo mode</string>
+    <string name="position">position</string>
+    <string name="allMediaSize">size</string>
+    <string name="all_media">All</string>
+    <string name="albums_mode">Switch to albums mode</string>
+
 </resources>


### PR DESCRIPTION
Fixes issue #435 Toolbar option to switch to all photos.

Changes: 

1. Added all photos option.
2. Added click listeners for all photos to display it in singleMediaActivity.
3. Updated viewPager adapter with all media list.

