### PR TITLE
Hide toggle button while taking picture and long press to reset color effects

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -119,4 +119,5 @@ dependencies {
     compile "com.android.support:support-v4:$rootProject.supportLibraryVersion"
     compile "com.facebook.stetho:stetho-okhttp3:$rootProject.stethoVersion"
     compile "com.squareup.picasso:picasso:$rootProject.picassoVersion"
+    compile "com.github.amlcurran.showcaseview:library:$rootProject.showcaseVersion"
 }

--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Preview/Preview.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Preview/Preview.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -44,6 +45,9 @@ import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.Toast;
 
+import com.github.amlcurran.showcaseview.ShowcaseView;
+import com.github.amlcurran.showcaseview.targets.ViewTarget;
+
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -68,6 +72,8 @@ import org.fossasia.phimpme.opencamera.Preview.CameraSurface.CameraSurface;
 import org.fossasia.phimpme.opencamera.Preview.CameraSurface.MySurfaceView;
 import org.fossasia.phimpme.opencamera.Preview.CameraSurface.MyTextureView;
 import org.fossasia.phimpme.opencamera.UI.PopupView;
+
+import static android.preference.PreferenceManager.getDefaultSharedPreferences;
 
 /** This class was originally named due to encapsulating the camera preview,
  *  but in practice it's grown to more than this, and includes most of the
@@ -260,6 +266,7 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
 
 	private boolean enable_sound;
     private int colorNum = 0;
+
 
     public Preview(ApplicationInterface applicationInterface, ViewGroup parent) {
 		if( MyDebug.LOG ) {
@@ -1368,24 +1375,50 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
 			if( MyDebug.LOG )
 				Log.d(TAG, "saved color effect: " + value);
 
+			final Activity activity = (Activity)this.getContext();
+
             CameraActivity.toggle.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    final List<String> colorEffect = getSupportedColorEffects();
-                    colorNum++;
-                    if (colorNum == colorEffect.size())
-                        colorNum = 0;
-                    final String color = colorEffect.get(colorNum);
-                    CameraController.SupportedValues supported_values = camera_controller.setColorEffect(color);
-                    if( supported_values != null ) {
-                        color_effects = supported_values.values;
-                        applicationInterface.setColorEffectPref(supported_values.selected_value);
+                    SharedPreferences sharedPreferences = getDefaultSharedPreferences(activity);
+                    Boolean firstClick = sharedPreferences.getBoolean(activity.getString(R.string.first_click),true);
+                    if(firstClick) {
+                        new ShowcaseView.Builder(activity).setTarget(new ViewTarget(R.id.toggle_button, activity))
+                                .setContentTitle(activity.getString(R.string.color_effects))
+                                .setContentText(activity.getString(R.string.toggle_info))
+                                .hideOnTouchOutside()
+                                .build();
                     }
                     else {
-                        applicationInterface.clearColorEffectPref();
+                        final List<String> colorEffect = getSupportedColorEffects();
+                        colorNum++;
+                        if (colorNum == colorEffect.size())
+                            colorNum = 0;
+                        final String color = colorEffect.get(colorNum);
+                        CameraController.SupportedValues supported_values = camera_controller.setColorEffect(color);
+                        if (supported_values != null) {
+                            color_effects = supported_values.values;
+                            applicationInterface.setColorEffectPref(supported_values.selected_value);
+                        } else {
+                            applicationInterface.clearColorEffectPref();
+                        }
                     }
+                    SharedPreferences.Editor editor = sharedPreferences.edit();
+                    editor.putBoolean(activity.getString(R.string.first_click), false);
+                    editor.apply();
                 }
             });
+
+			CameraActivity.toggle.setOnLongClickListener(new View.OnLongClickListener() {
+				@Override
+				public boolean onLongClick(View v) {
+					final List<String> colorEffect = getSupportedColorEffects();
+					colorNum = 0;
+					CameraController.SupportedValues supported_values = camera_controller.setColorEffect(colorEffect.get(0));
+					applicationInterface.setColorEffectPref(supported_values.selected_value);
+					return true;
+				}
+			});
             CameraController.SupportedValues supported_values = camera_controller.setColorEffect(value);
 			if( supported_values != null ) {
 				color_effects = supported_values.values;

--- a/app/src/main/java/org/fossasia/phimpme/opencamera/UI/MainUI.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/UI/MainUI.java
@@ -476,6 +476,7 @@ public class MainUI {
 				View exposureButton = main_activity.findViewById(R.id.exposure);
 				View audioControlButton = main_activity.findViewById(R.id.audio_control);
 				View popupButton = main_activity.findViewById(R.id.popup);
+				View toggleButton = main_activity.findViewById(R.id.toggle_button);
 				if (main_activity.getPreview().getCameraControllerManager().getNumberOfCameras() > 1)
 					switchCameraButton.setVisibility(visibility);
 				if (main_activity.supportsExposureButton() && !main_activity.getPreview().isVideo()) // still allow exposure when recording video
@@ -487,6 +488,7 @@ public class MainUI {
 				}
 				if (!main_activity.getPreview().isVideo() || !main_activity.getPreview().supportsFlash())
 					popupButton.setVisibility(visibility); // still allow popup in order to change flash mode when recording video
+				toggleButton.setVisibility(visibility);
 			}
 		});
 	}

--- a/app/src/main/java/org/fossasia/phimpme/opencamera/UI/PopupView.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/UI/PopupView.java
@@ -613,8 +613,6 @@ public class PopupView extends LinearLayout {
 				List<String> supported_scene_modes = preview.getSupportedSceneModes();
 				addRadioOptionsToPopup(supported_scene_modes, getResources().getString(R.string.scene_mode), PreferenceKeys.getSceneModePreferenceKey(), preview.getCameraController().getDefaultSceneMode(), "TEST_SCENE_MODE", null);
 
-				List<String> supported_color_effects = preview.getSupportedColorEffects();
-				addRadioOptionsToPopup(supported_color_effects, getResources().getString(R.string.color_effect), PreferenceKeys.getColorEffectPreferenceKey(), preview.getCameraController().getDefaultColorEffect(), "TEST_COLOR_EFFECT", null);
 			}
 
 		}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -764,4 +764,7 @@
     <string name="drawable">drawable</string>
     <string name="ic_">ic_</string>
     <string name="_indicator">_indicator</string>
+    <string name="color_effects">Color Effects</string>
+    <string name="toggle_info">Click to switch between colors \n Long press to switch to normal</string>
+    <string name="first_click">first click</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -32,5 +32,6 @@ ext {
     twitterVersion = "3.0.0"
     stethoVersion = "1.5.0"
     picassoVersion = "2.5.2"
+    showcaseVersion = "5.4.3"
 }
 


### PR DESCRIPTION
Fixes issue #598 

Changes: 
1. Now toggle button hides itself while taking picture.
2. Added long click listener to reset color effect.
3. Removed all color effects list from pop up view.
4. Add showcase view to show toggle button functionality.
