### PR TITLE
Image doesn't load from all photos mode in SingleMediaActivity

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/leafpic/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/leafpic/activities/LFMainActivity.java
@@ -873,7 +873,7 @@ public class LFMainActivity extends SharedMediaActivity {
         menu.findItem(R.id.excludeAlbumButton).setVisible(editMode && !all_photos);
         menu.findItem(R.id.select_all).setVisible(editMode);
         menu.findItem(R.id.type_sort_action).setVisible(!albumsMode);
-        menu.findItem(R.id.delete_action).setVisible((!albumsMode || editMode));
+        menu.findItem(R.id.delete_action).setVisible((!albumsMode || editMode) && (!all_photos || editMode ));
         menu.findItem(R.id.hideAlbumButton).setVisible(!all_photos);
 
         menu.findItem(R.id.clear_album_preview).setVisible(!albumsMode && getAlbum().hasCustomCover());

--- a/app/src/main/java/org/fossasia/phimpme/leafpic/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/leafpic/activities/SingleMediaActivity.java
@@ -135,6 +135,7 @@ public class SingleMediaActivity extends SharedMediaActivity {
             Album album;
             if ((getIntent().getAction().equals(Intent.ACTION_VIEW) || getIntent().getAction().equals(ACTION_REVIEW)) && getIntent().getData() != null) {
 
+                String path = ContentHelper.getMediaPath(getApplicationContext(), getIntent().getData());
                 File file = null;
                 if (path != null)
                     file = new File(path);


### PR DESCRIPTION
Fix #680 

Changes: 1. Removed the delete button when the user switches to all photos mode and if its not in the edit mode.
2. Now media opens in singleMediaActivity from all photos mode.
