### PR TITLE
Hide copy and move item if no item is selected

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/leafpic/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/leafpic/activities/LFMainActivity.java
@@ -117,6 +117,7 @@ public class LFMainActivity extends SharedMediaActivity {
     public int pos;
     private ArrayList<Media> media;
     private ArrayList<Media> selectedMedias = new ArrayList<>();
+    public boolean visible;
 
     /*
     editMode-  When true, user can select items by clicking on them one by one
@@ -870,9 +871,11 @@ public class LFMainActivity extends SharedMediaActivity {
 
         togglePrimaryToolbarOptions(menu);
         updateSelectedStuff();
-
-        menu.findItem(R.id.action_copy).setVisible(!all_photos);
-        menu.findItem(R.id.action_move).setVisible(!all_photos);
+        visible = getAlbum().getSelectedCount()>0;
+        menu.findItem(R.id.action_copy).setVisible(visible);
+        menu.findItem(R.id.action_move).setVisible(visible || editMode);
+        //menu.findItem(R.id.action_copy).setVisible(!all_photos);
+        //menu.findItem(R.id.action_move).setVisible(!all_photos);
         menu.findItem(R.id.excludeAlbumButton).setVisible(editMode && !all_photos);
         menu.findItem(R.id.select_all).setVisible(editMode);
         menu.findItem(R.id.delete_action).setVisible((!albumsMode || editMode) && (!all_photos || editMode ));


### PR DESCRIPTION
Fix #714 

Changes:

- Copy feature is enabled only when a photo is selected. 

- Copy feature disabled from the album view. 

- Move feature is enabled only when an album or a photo is selected


