### PR TITLE
Fixed Facebook share image when native app is not installed.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -280,11 +280,6 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths"/>
         </provider>
-        <provider
-            android:name="com.facebook.FacebookContentProvider"
-            android:authorities="com.facebook.app.FacebookContentProvider1920575401558694"
-            android:exported="true"/>
-
         <activity
             android:name=".SharingActivity"
             android:screenOrientation="portrait"
@@ -297,12 +292,10 @@
         <meta-data
             android:name="com.facebook.sdk.ApplicationId"
             android:value="@string/facebook_app_id"/>
-         
-
 
         <provider
             android:name="com.facebook.FacebookContentProvider"
-            android:authorities="com.facebook.app.FacebookContentProvider1920575401558694"
+            android:authorities="com.facebook.app.FacebookContentProvider111535049486318"
             android:exported="true"/>
 
         <activity

--- a/app/src/main/java/org/fossasia/phimpme/SharingActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/SharingActivity.java
@@ -329,12 +329,12 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
             Snackbar.make(parent,R.string.instagram_not_installed,Snackbar.LENGTH_LONG).show();
     }
 
-    /*@Override
+    @Override
     protected void onActivityResult(int requestCode, int responseCode, Intent data) {
         super.onActivityResult(requestCode, responseCode, data);
         callbackManager.onActivityResult(requestCode, responseCode, data);
         atleastOneShare = true;
-    }*/
+    }
 
     private void goToHome() {
         Intent home = new Intent(SharingActivity.this, LFMainActivity.class);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="action_popup">Popup settings</string>
     <string name="intro_text">Touch to focus, and press the blue camera button to take photos. For more help, click Online help from Settings. Open Camera is completely free. If you like this app, please consider buying my donate app :) (see link in Settings, or Online help).\n\nPrivacy Policy: Location permission is required for geotagging, but this is disabled by default. If enabled, your location is encoded in the saved files (and it is only used for this purpose).</string>
     <string name="intro_ok">OK (This message won\'t show again)</string>
-    <string name="facebook_app_id">428086644239211</string>
+    <string name="facebook_app_id">111535049486318</string>
     <string name="answer_yes">Yes</string>
     <string name="answer_no">No</string>
 


### PR DESCRIPTION
Fix #747 

Changes: Fixed Facebook share image when the native app is not installed.
 
