### PR TITLE
Upload Image to Pinterest

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/SharingActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/SharingActivity.java
@@ -18,12 +18,14 @@ import android.support.design.widget.Snackbar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.Toolbar;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.android.volley.AuthFailureError;
 import com.android.volley.DefaultRetryPolicy;
@@ -47,6 +49,10 @@ import com.facebook.share.model.SharePhoto;
 import com.facebook.share.model.SharePhotoContent;
 import com.mikepenz.community_material_typeface_library.CommunityMaterial;
 import com.mikepenz.iconics.view.IconicsImageView;
+import com.pinterest.android.pdk.PDKCallback;
+import com.pinterest.android.pdk.PDKClient;
+import com.pinterest.android.pdk.PDKException;
+import com.pinterest.android.pdk.PDKResponse;
 
 import org.fossasia.phimpme.base.ThemedActivity;
 import org.fossasia.phimpme.editor.editimage.view.imagezoom.ImageViewTouch;
@@ -117,7 +123,7 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
     Utils utils = new Utils();
     Bitmap finalBmp;
     Boolean isPostedOnTwitter =false;
-
+    String boardID;
 
 
 
@@ -207,6 +213,7 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
             case R.id.cell_11: //wordpress
                 break;
             case R.id.cell_20: //pinterest
+                openPinterestDialogBox();
                 break;
             case R.id.cell_21: //flickr
                 break;
@@ -264,6 +271,57 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
                     text_caption.setText(caption);
                 }
                 passwordDialog.dismiss();
+            }
+        });
+    }
+
+    private void openPinterestDialogBox() {
+        AlertDialog.Builder captionDialogBuilder = new AlertDialog.Builder(SharingActivity.this, getDialogStyle());
+        final EditText captionEditText = getCaptionDialog(this, captionDialogBuilder);
+
+        captionEditText.setHint(R.string.hint_boardID);
+
+        captionDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
+        captionDialogBuilder.setPositiveButton(getString(R.string.post_action).toUpperCase(), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                //This should br empty it will be overwrite later
+                //to avoid dismiss of the dialog on wrong password
+            }
+        });
+
+        final AlertDialog passwordDialog = captionDialogBuilder.create();
+        passwordDialog.show();
+
+        passwordDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                String captionText = captionEditText.getText().toString();
+                boardID =captionText;
+                shareToPinterest(boardID);
+                passwordDialog.dismiss();
+            }
+        });
+    }
+
+    private void shareToPinterest(final String boardID) {
+        Bitmap image = getBitmapFromPath(saveFilePath);
+        PDKClient
+                .getInstance().createPin(caption, boardID, image, null, new PDKCallback() {
+            @Override
+            public void onSuccess(PDKResponse response) {
+                Log.d(getClass().getName(), response.getData().toString());
+                Snackbar.make(parent, R.string.pinterest_post, Snackbar.LENGTH_LONG).show();
+                //Toast.makeText(SharingActivity.this,message,Toast.LENGTH_SHORT).show();
+
+            }
+
+            @Override
+            public void onFailure(PDKException exception) {
+                Log.e(getClass().getName(), exception.getDetailMessage());
+                Snackbar.make(parent, R.string.Pinterest_fail, Snackbar.LENGTH_LONG).show();
+                //Toast.makeText(SharingActivity.this, boardID + caption, Toast.LENGTH_SHORT).show();
+
             }
         });
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -883,6 +883,10 @@
     <string name="pinterest_app_id">4910600717739247160</string>
     <string name="success">Success</string>
     <string name="fail">Login Fail</string>
+    <string name="Pinterest_fail">BoardID or caption cannot be empty</string>
+    <string name="post_action">POST</string>
+    <string name="hint_boardID">Board ID</string>
+    <string name="pinterest_post">Image posted successfully</string>
 
 
 </resources>

--- a/pdk/src/main/java/com/pinterest/android/pdk/PDKClient.java
+++ b/pdk/src/main/java/com/pinterest/android/pdk/PDKClient.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
+import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Build;
 import android.text.TextUtils;
@@ -350,7 +351,7 @@ public class PDKClient {
         String path =  PINS + pinId;
         getPath(path, getMapWithFields(fields), callback);
     }
-
+/*
     public void createPin(String note, String boardId, String imageUrl, String link, PDKCallback callback) {
         if (Utils.isEmpty(note) || Utils.isEmpty(boardId) || Utils.isEmpty(imageUrl)) {
             if (callback != null) callback.onFailure(new PDKException("Board Id, note, Image cannot be empty"));
@@ -361,6 +362,20 @@ public class PDKClient {
         params.put("note", note);
         if (!Utils.isEmpty(link)) params.put("link", link);
         if (!Utils.isEmpty(link)) params.put("image_url", imageUrl);
+        postPath(PINS, params, callback);
+    }*/
+
+    public void createPin(String note, String boardId, Bitmap image, String link, PDKCallback callback) {
+        if (Utils.isEmpty(note) || Utils.isEmpty(boardId) || image == null) {
+            if (callback != null) callback.onFailure(new PDKException("Board Id, note, Image cannot be empty"));
+            return;
+        }
+
+        HashMap<String, String> params = new HashMap<String, String>();
+        params.put("board", boardId);
+        params.put("note", note);
+        params.put("image_base64", Utils.base64String(image));
+        if (!Utils.isEmpty(link)) params.put("link", link);
         postPath(PINS, params, callback);
     }
 

--- a/pdk/src/main/java/com/pinterest/android/pdk/Utils.java
+++ b/pdk/src/main/java/com/pinterest/android/pdk/Utils.java
@@ -1,11 +1,14 @@
 package com.pinterest.android.pdk;
 
+import android.graphics.Bitmap;
+import android.util.Base64;
 import android.util.Log;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 
 
+import java.io.ByteArrayOutputStream;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
@@ -70,5 +73,12 @@ public class Utils {
             url += paramString;
         }
         return url;
+    }
+
+    public static String base64String(Bitmap bitmap) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, baos);
+        String b64Str = Base64.encodeToString(baos.toByteArray(), Base64.NO_WRAP);
+        return b64Str;
     }
 }


### PR DESCRIPTION
Fix #765 

Changes: Established Image share on Pinterest from SharingActivity.

Steps to reproduce:
->First sign into Pinterest from Accounts Activity. If loggedIn, logout and login again. 
->From sharingActivity add caption.
->Get BoardID: Go to the Pinterest.com-><Your board>->copy the URL of your board and paste it in https://www.nutt.net/how-do-i-get-pinterest-board-id/ . Copy the boardID. 
-> SharingActivity->Pinterest->Paste the BoardID->Post  

