### PR TITLE
Added dark theme colors for cells in sharing activity

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/SharingActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/SharingActivity.java
@@ -138,10 +138,15 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
     private Realm realm = Realm.getDefaultInstance();
     private String caption;
     private boolean atleastOneShare = false;
+    private int[] cellcolors_LightTheme = {R.color.facebook_color, R.color.twitter_color,
+            R.color.instagram_color,R.color.wordpress_color,
+            R.color.pinterest_color, R.color.flickr_color,
+            R.color.nextcloud_color, R.color.imgur_color,
+            R.color.other_share_color};
     private PhimpmeProgressBarHandler phimpmeProgressBarHandler;
+    private int[] cellcolors_DarkTheme = {R.color.facebook_color_darktheme, R.color.twitter_color_darktheme, R.color.instagram_color_darktheme,
+            R.color.wordpress_color_darktheme, R.color.pinterest_color_darktheme, R.color.flickr_color_darktheme, R.color.nextcloud_color_darktheme, R.color.imgur_color_darktheme, R.color.other_share_color_darktheme};
 
-    private int[] cellcolors = {R.color.facebook_color, R.color.twitter_color, R.color.instagram_color,
-            R.color.wordpress_color, R.color.pinterest_color, R.color.flickr_color, R.color.nextcloud_color, R.color.imgur_color, R.color.other_share_color};
     private int[] icons_drawables = {R.drawable.ic_facebook_black, R.drawable.ic_twitter_black,
             R.drawable.ic_instagram_black, R.drawable.ic_wordpress_black, R.drawable.ic_pinterest_black,
             R.drawable.ic_flickr_black, R.drawable.ic_nextcloud, R.drawable.ic_imgur,R.drawable.ic_share_minimal};
@@ -207,8 +212,13 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
             cells.get(i).setOnClickListener(this);
             icons.get(i).setImageResource(icons_drawables[i]);
             titles.get(i).setText(titles_text[i]);
-            icons.get(i).setColorFilter(getResources().getColor(cellcolors[i]));
-            titles.get(i).setTextColor(getResources().getColor(cellcolors[i]));
+            if(themeHelper.getBaseTheme() == ThemeHelper.LIGHT_THEME) {
+                icons.get(i).setColorFilter(getResources().getColor(cellcolors_LightTheme[i]));
+                titles.get(i).setTextColor(getResources().getColor(cellcolors_LightTheme[i]));
+            }else {
+                icons.get(i).setColorFilter(getResources().getColor(cellcolors_DarkTheme[i]));
+                titles.get(i).setTextColor(getResources().getColor(cellcolors_DarkTheme[i]));
+            }
         }
         toolbar.setNavigationOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -384,9 +384,20 @@
     <color name="wordpress_color">#21759B</color>
     <color name="pinterest_color">#C92228</color>
     <color name="flickr_color">#FC329B</color>
+    <color name="nextcloud_color">#0F89CD</color>
     <color name="imgur_color">#000000</color>
     <color name="other_share_color">@color/md_indigo_900</color>
-    <color name="nextcloud_color">#0F89CD</color>
+
+    <color name="facebook_color_darktheme">#778bca</color>
+    <color name="twitter_color_darktheme">#7ad4ff</color>
+    <color name="instagram_color_darktheme">#ff56a5</color>
+    <color name="wordpress_color_darktheme">#53a7cd</color>
+    <color name="pinterest_color_darktheme">#ff5e64</color>
+    <color name="flickr_color_darktheme">#ff5ac3</color>
+    <color name="nextcloud_color_darktheme">#2da7eb</color>
+    <color name="imgur_color_darktheme">#fcfcfcfc</color>
+    <color name="other_share_color_darktheme">@color/md_indigo_400</color>
+
     <color name="card_background">#e1e0e0</color>
     <!-- Drupal Login-->
     <color name="button_background">#d67601</color>

--- a/pdk/build.gradle
+++ b/pdk/build.gradle
@@ -21,5 +21,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:21.0.3'
-    compile 'com.mcxiaoke.volley:library:1.0.+'
+    compile 'com.mcxiaoke.volley:library:1.0.19'
 }


### PR DESCRIPTION
Fix #797 
Changes: Added color resources of all accounts for dark theme
Screenshots for the change: 
![screenshot_20170716-192330](https://user-images.githubusercontent.com/15368561/28248203-132eabac-6a5e-11e7-8872-724d698c2bb3.png)

