### PR TITLE
Checking if logged in to Pinterest or not

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountContract.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountContract.java
@@ -15,7 +15,7 @@ import io.realm.RealmQuery;
  */
 
 public class AccountContract {
-    interface View extends MvpView{
+    public interface View extends MvpView{
 
         /**
          * Setting up the recyclerView. The layout manager, decorator etc.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -894,6 +894,8 @@
     <string name="post_action">POST</string>
     <string name="hint_boardID">Board ID</string>
     <string name="pinterest_post">Image posted successfully</string>
+    <string name="pinterest_signIn_fail">Sign in to Pinterest</string>
+    <string name="sign_In">SIGN IN</string>
 
     <string name="placeholder_sentence">This is a placeholder</string>
     <string name="auth_trying_to_login"><![CDATA[Trying to log in &#8230;]]></string>


### PR DESCRIPTION
Fix #815 

Changes: In sharing Activity checks if the user is logged In to the Pinterest or not. If the user is not logged In snack-bar pops to redirect the user to Accounts Activity to log in. 


