### PR TITLE
Added share image to Flickr feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 /app/src/main/jniLibs/
 libopencv_*
 viewflow/
+gradle.properties

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -338,7 +338,22 @@
             android:theme="@style/Theme.AppCompat.NoActionBar"/>
 
         <activity android:name=".nextcloud.NextCloudAuth"/>
+
         <activity android:name=".sharedimgur.ImgurAuthActivity"/>
+
+        <activity
+            android:name=".sharetoflickr.FlickrActivity"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.AppCompat.NoActionBar"
+            android:launchMode="singleTask" >
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="flickrj-android-sample-oauth" />
+            </intent-filter>
+        </activity>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/org/fossasia/phimpme/SharingActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/SharingActivity.java
@@ -73,6 +73,7 @@ import org.fossasia.phimpme.editor.editimage.view.imagezoom.ImageViewTouch;
 import org.fossasia.phimpme.leafpic.activities.LFMainActivity;
 import org.fossasia.phimpme.leafpic.util.AlertDialogsHelper;
 import org.fossasia.phimpme.leafpic.util.ThemeHelper;
+import org.fossasia.phimpme.sharetoflickr.FlickrActivity;
 import org.fossasia.phimpme.sharetwitter.HelperMethods;
 import org.fossasia.phimpme.sharetwitter.LoginActivity;
 import org.fossasia.phimpme.utilities.ActivitySwitchHelper;
@@ -258,6 +259,7 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
                 openPinterestDialogBox();
                 break;
             case R.id.cell_21: //flickr
+                flickrShare();
                 break;
             case R.id.cell_30: //nextcloud
                 shareToNextCloud();
@@ -282,6 +284,23 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
             case R.id.edit_text_caption_container:
                 openCaptionDialogBox();
                 break;
+        }
+    }
+
+    private void flickrShare() {
+        Intent intent = new Intent(getApplicationContext(),
+                FlickrActivity.class);
+        InputStream is = null;
+        File file = new File(saveFilePath);
+        try {
+            is = getContentResolver().openInputStream(Uri.fromFile(file));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        if (is != null) {
+            FlickrActivity.setInputStream(is);
+            FlickrActivity.setFilename(file.getName());
+            startActivity(intent);
         }
     }
 

--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
@@ -42,6 +42,7 @@ import org.fossasia.phimpme.base.ThemedActivity;
 import org.fossasia.phimpme.data.local.AccountDatabase;
 import org.fossasia.phimpme.data.local.DatabaseHelper;
 import org.fossasia.phimpme.nextcloud.NextCloudAuth;
+import org.fossasia.phimpme.sharetoflickr.FlickrActivity;
 import org.fossasia.phimpme.sharedimgur.ImgurAuthActivity;
 import org.fossasia.phimpme.sharedrupal.DrupalLogin;
 import org.fossasia.phimpme.sharewordpress.WordpressLoginActivity;
@@ -201,7 +202,14 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
                     break;
 
                 case 5:
-                    signInPinterest();break;
+                    signInPinterest();
+                    break;
+                case 6:
+                    Intent intent = new Intent(getApplicationContext(),
+                            FlickrActivity.class);
+                    FlickrActivity.setFilename(null);
+                    startActivity(intent);
+                    break;
                 case 7:
                     signInImgur();
                     break;
@@ -274,7 +282,6 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
             ImgurAuthActivity.setBasicCallBack(basicCallBack);
             startActivity(i);
         }
-
     }
 
     private void signInPinterest() {

--- a/app/src/main/java/org/fossasia/phimpme/sharetoflickr/FlickrActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/sharetoflickr/FlickrActivity.java
@@ -1,0 +1,183 @@
+package org.fossasia.phimpme.sharetoflickr;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.SharedPreferences.Editor;
+import android.content.pm.ActivityInfo;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Handler;
+import android.widget.Toast;
+
+import org.fossasia.phimpme.base.ThemedActivity;
+import org.fossasia.phimpme.sharetoflickr.tasks.GetOAuthTokenTask;
+import org.fossasia.phimpme.sharetoflickr.tasks.OAuthTask;
+import org.fossasia.phimpme.sharetoflickr.tasks.UploadPhotoTask;
+import com.googlecode.flickrjandroid.oauth.OAuth;
+import com.googlecode.flickrjandroid.oauth.OAuthToken;
+import com.googlecode.flickrjandroid.people.User;
+
+import java.io.InputStream;
+
+public class FlickrActivity extends ThemedActivity {
+	public static final String CALLBACK_SCHEME = "flickrj-android-sample-oauth";
+	public static final String PREFS_NAME = "flickrj-android-sample-pref";
+	public static final String KEY_OAUTH_TOKEN = "flickrj-android-oauthToken";
+	public static final String KEY_TOKEN_SECRET = "flickrj-android-tokenSecret";
+	public static final String KEY_USER_NAME = "flickrj-android-userName";
+	public static final String KEY_USER_ID = "flickrj-android-userId";
+	private static InputStream photoStream;
+	static String filename = null;
+	Handler h = new Handler();
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+
+		new Thread() {
+			public void run() {
+				h.post(init);
+			};
+		}.start();
+	}
+
+	Runnable init = new Runnable() {
+
+		@Override
+		public void run() {
+			OAuth oauth = getOAuthToken();
+			if (oauth == null || oauth.getUser() == null) {
+				OAuthTask task = new OAuthTask(getContext());
+				task.execute();
+			} else {
+				if (filename != null)
+					load(oauth);
+			}
+		}
+	};
+
+	private void load(OAuth oauth) {
+		if (oauth != null) {
+
+			UploadPhotoTask taskUpload = new UploadPhotoTask(this,filename);
+			taskUpload.setOnUploadDone(new UploadPhotoTask.onUploadDone() {
+				@Override
+				public void onComplete() {
+					finish();
+				}
+			});
+			taskUpload.execute(oauth);
+		}
+	}
+
+	@Override
+	protected void onNewIntent(Intent intent) {
+		// this is very important, otherwise you would get a null Scheme in the
+		// onResume later on.
+		setIntent(intent);
+	}
+
+	@Override
+	public void onResume() {
+		super.onResume();
+		Intent intent = getIntent();
+		String scheme = intent.getScheme();
+		OAuth savedToken = getOAuthToken();
+
+		if (CALLBACK_SCHEME.equals(scheme)
+				&& (savedToken == null || savedToken.getUser() == null)) {
+			Uri uri = intent.getData();
+			String query = uri.getQuery();
+			String[] data = query.split("&");
+			if (data != null && data.length == 2) {
+				String oauthToken = data[0].substring(data[0].indexOf("=") + 1);
+				String oauthVerifier = data[1].substring(data[1].indexOf("=") + 1);
+				OAuth oauth = getOAuthToken();
+				if (oauth != null && oauth.getToken() != null
+						&& oauth.getToken().getOauthTokenSecret() != null) {
+					GetOAuthTokenTask task = new GetOAuthTokenTask(this);
+					task.execute(oauthToken, oauth.getToken()
+							.getOauthTokenSecret(), oauthVerifier);
+				}
+			}
+		}
+	}
+
+	public void onOAuthDone(OAuth result) {
+		if (result == null) {
+			Toast.makeText(this, "Authorization failed",
+					Toast.LENGTH_LONG).show();
+		} else {
+			User user = result.getUser();
+			OAuthToken token = result.getToken();
+			if (user == null || user.getId() == null || token == null
+					|| token.getOauthToken() == null
+					|| token.getOauthTokenSecret() == null) {
+				Toast.makeText(this, "Authorization failed",
+						Toast.LENGTH_LONG).show();
+				return;
+			}
+			String message = "Login Success";
+			Toast.makeText(this, message, Toast.LENGTH_LONG).show();
+			saveOAuthToken(user.getUsername(), user.getId(),
+					token.getOauthToken(), token.getOauthTokenSecret());
+			load(result);
+		}
+	}
+
+	public OAuth getOAuthToken() {
+		// Restore preferences
+		SharedPreferences settings = getSharedPreferences(PREFS_NAME,
+				Context.MODE_PRIVATE);
+		String oauthTokenString = settings.getString(KEY_OAUTH_TOKEN, null);
+		String tokenSecret = settings.getString(KEY_TOKEN_SECRET, null);
+		if (oauthTokenString == null && tokenSecret == null) {
+			return null;
+		}
+		OAuth oauth = new OAuth();
+		String userName = settings.getString(KEY_USER_NAME, null);
+		String userId = settings.getString(KEY_USER_ID, null);
+		if (userId != null) {
+			User user = new User();
+			user.setUsername(userName);
+			user.setId(userId);
+			oauth.setUser(user);
+		}
+		OAuthToken oauthToken = new OAuthToken();
+		oauth.setToken(oauthToken);
+		oauthToken.setOauthToken(oauthTokenString);
+		oauthToken.setOauthTokenSecret(tokenSecret);
+		return oauth;
+	}
+
+	public void saveOAuthToken(String userName, String userId, String token, String tokenSecret) {
+
+		SharedPreferences sp = getSharedPreferences(PREFS_NAME,
+				Context.MODE_PRIVATE);
+		Editor editor = sp.edit();
+		editor.putString(KEY_OAUTH_TOKEN, token);
+		editor.putString(KEY_TOKEN_SECRET, tokenSecret);
+		editor.putString(KEY_USER_NAME, userName);
+		editor.putString(KEY_USER_ID, userId);
+		editor.apply();
+	}
+
+	public static void setInputStream(InputStream inputStream){
+		photoStream = inputStream;
+	}
+
+	public static InputStream getInputStream(){
+		return photoStream;
+	}
+
+	public static void setFilename(String file){
+		filename = file;
+	}
+
+	private Context getContext() {
+		return this;
+
+	}
+}

--- a/app/src/main/java/org/fossasia/phimpme/sharetoflickr/FlickrHelper.java
+++ b/app/src/main/java/org/fossasia/phimpme/sharetoflickr/FlickrHelper.java
@@ -1,0 +1,67 @@
+package org.fossasia.phimpme.sharetoflickr;
+
+import com.googlecode.flickrjandroid.Flickr;
+import com.googlecode.flickrjandroid.REST;
+import com.googlecode.flickrjandroid.RequestContext;
+import com.googlecode.flickrjandroid.interestingness.InterestingnessInterface;
+import com.googlecode.flickrjandroid.oauth.OAuth;
+import com.googlecode.flickrjandroid.oauth.OAuthToken;
+import com.googlecode.flickrjandroid.photos.PhotosInterface;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+public final class FlickrHelper {
+
+	private static FlickrHelper instance = null;
+	private static final String API_KEY = "YOUR_API_TOKEN_HERE";
+	private static final String API_SEC = "YOUR_SECRET_TOKEN_HERE";
+
+	private FlickrHelper() {
+
+	}
+
+	public static FlickrHelper getInstance() {
+		if (instance == null) {
+			instance = new FlickrHelper();
+		}
+
+		return instance;
+	}
+
+	public Flickr getFlickr() {
+		try {
+			Flickr f = new Flickr(API_KEY, API_SEC, new REST());
+			return f;
+		} catch (ParserConfigurationException e) {
+			return null;
+		}
+	}
+
+	public Flickr getFlickrAuthed(String token, String secret) {
+		Flickr f = getFlickr();
+		RequestContext requestContext = RequestContext.getRequestContext();
+		OAuth auth = new OAuth();
+		auth.setToken(new OAuthToken(token, secret));
+		requestContext.setOAuth(auth);
+		return f;
+	}
+
+	public InterestingnessInterface getInterestingInterface() {
+		Flickr f = getFlickr();
+		if (f != null) {
+			return f.getInterestingnessInterface();
+		} else {
+			return null;
+		}
+	}
+
+	public PhotosInterface getPhotosInterface() {
+		Flickr f = getFlickr();
+		if (f != null) {
+			return f.getPhotosInterface();
+		} else {
+			return null;
+		}
+	}
+
+}

--- a/app/src/main/java/org/fossasia/phimpme/sharetoflickr/tasks/GetOAuthTokenTask.java
+++ b/app/src/main/java/org/fossasia/phimpme/sharetoflickr/tasks/GetOAuthTokenTask.java
@@ -1,0 +1,45 @@
+package org.fossasia.phimpme.sharetoflickr.tasks;
+
+import android.os.AsyncTask;
+import org.fossasia.phimpme.sharetoflickr.FlickrHelper;
+import org.fossasia.phimpme.sharetoflickr.FlickrActivity;
+import com.googlecode.flickrjandroid.Flickr;
+import com.googlecode.flickrjandroid.oauth.OAuth;
+import com.googlecode.flickrjandroid.oauth.OAuthInterface;
+
+public class GetOAuthTokenTask extends AsyncTask<String, Integer, OAuth> {
+
+	private FlickrActivity activity;
+
+	public GetOAuthTokenTask(FlickrActivity context) {
+		this.activity = context;
+	}
+
+	@Override
+	protected OAuth doInBackground(String... params) {
+		String oauthToken = params[0];
+		String oauthTokenSecret = params[1];
+		String verifier = params[2];
+
+		Flickr f = FlickrHelper.getInstance().getFlickr();
+		OAuthInterface oauthApi = null;
+		if (f != null) {
+			oauthApi = f.getOAuthInterface();
+			try {
+				return oauthApi.getAccessToken(oauthToken, oauthTokenSecret,
+						verifier);
+			} catch (Exception e) {
+				return null;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	protected void onPostExecute(OAuth result) {
+		if (activity != null) {
+			activity.onOAuthDone(result);
+		}
+	}
+
+}

--- a/app/src/main/java/org/fossasia/phimpme/sharetoflickr/tasks/OAuthTask.java
+++ b/app/src/main/java/org/fossasia/phimpme/sharetoflickr/tasks/OAuthTask.java
@@ -1,0 +1,83 @@
+package org.fossasia.phimpme.sharetoflickr.tasks;
+
+import android.app.ProgressDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnCancelListener;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.widget.Toast;
+
+import org.fossasia.phimpme.sharetoflickr.FlickrHelper;
+import org.fossasia.phimpme.sharetoflickr.FlickrActivity;
+import com.googlecode.flickrjandroid.Flickr;
+import com.googlecode.flickrjandroid.auth.Permission;
+import com.googlecode.flickrjandroid.oauth.OAuthToken;
+
+import java.net.URL;
+
+public class OAuthTask extends AsyncTask<Void, Integer, String> {
+
+	private static final Uri OAUTH_CALLBACK_URI = Uri
+			.parse(FlickrActivity.CALLBACK_SCHEME + "://oauth"); //$NON-NLS-1$
+
+	private Context mContext;
+
+	private ProgressDialog mProgressDialog;
+
+	public OAuthTask(Context context) {
+		super();
+		this.mContext = context;
+	}
+
+	@Override
+	protected void onPreExecute() {
+		super.onPreExecute();
+		mProgressDialog = ProgressDialog.show(mContext,
+				"", "Generating the authorization request..."); //$NON-NLS-1$ //$NON-NLS-2$
+		mProgressDialog.setCanceledOnTouchOutside(true);
+		mProgressDialog.setCancelable(true);
+		mProgressDialog.setOnCancelListener(new OnCancelListener() {
+			@Override
+			public void onCancel(DialogInterface dlg) {
+				OAuthTask.this.cancel(true);
+			}
+		});
+	}
+
+	@Override
+	protected String doInBackground(Void... params) {
+		try {
+			Flickr f = FlickrHelper.getInstance().getFlickr();
+			OAuthToken oauthToken = f.getOAuthInterface().getRequestToken(
+					OAUTH_CALLBACK_URI.toString());
+			saveTokenSecrent(oauthToken.getOauthTokenSecret());
+			URL oauthUrl = f.getOAuthInterface().buildAuthenticationUrl(
+					Permission.WRITE, oauthToken);
+			return oauthUrl.toString();
+		} catch (Exception e) {
+			//			logger.error("Error to oauth", e); //$NON-NLS-1$
+			return "error:" + e.getMessage(); //$NON-NLS-1$
+		}
+	}
+
+	private void saveTokenSecrent(String tokenSecret) {
+		FlickrActivity act = (FlickrActivity) mContext;
+		act.saveOAuthToken(null, null, null, tokenSecret);
+	}
+
+	@Override
+	protected void onPostExecute(String result) {
+		if (mProgressDialog != null) {
+			mProgressDialog.dismiss();
+		}
+		if (result != null && !result.startsWith("error")) {
+			mContext.startActivity(new Intent(Intent.ACTION_VIEW, Uri
+					.parse(result)));
+		} else {
+			Toast.makeText(mContext, result, Toast.LENGTH_LONG).show();
+		}
+	}
+
+}

--- a/app/src/main/java/org/fossasia/phimpme/sharetoflickr/tasks/UploadPhotoTask.java
+++ b/app/src/main/java/org/fossasia/phimpme/sharetoflickr/tasks/UploadPhotoTask.java
@@ -1,0 +1,91 @@
+package org.fossasia.phimpme.sharetoflickr.tasks;
+
+import android.app.ProgressDialog;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnCancelListener;
+import android.os.AsyncTask;
+import android.util.Log;
+import android.widget.Toast;
+import org.fossasia.phimpme.sharetoflickr.FlickrHelper;
+import org.fossasia.phimpme.sharetoflickr.FlickrActivity;
+import com.googlecode.flickrjandroid.Flickr;
+import com.googlecode.flickrjandroid.oauth.OAuth;
+import com.googlecode.flickrjandroid.oauth.OAuthToken;
+import com.googlecode.flickrjandroid.uploader.UploadMetaData;
+
+public class UploadPhotoTask extends AsyncTask<OAuth, Void, String> {
+
+	private final FlickrActivity flickrjAndroidSampleActivity;
+	private String filename;
+	private onUploadDone monUploadDone;
+	private ProgressDialog mProgressDialog;
+
+	public UploadPhotoTask(FlickrActivity flickrjAndroidSampleActivity,
+			String filename) {
+		this.flickrjAndroidSampleActivity = flickrjAndroidSampleActivity;
+		this.filename = filename;
+	}
+
+
+	@Override
+	protected void onPreExecute() {
+		super.onPreExecute();
+		mProgressDialog = ProgressDialog.show(flickrjAndroidSampleActivity,
+				"", "Uploading...");
+		mProgressDialog.setCanceledOnTouchOutside(true);
+		mProgressDialog.setCancelable(true);
+		mProgressDialog.setOnCancelListener(new OnCancelListener() {
+			@Override
+			public void onCancel(DialogInterface dlg) {
+				UploadPhotoTask.this.cancel(true);
+			}
+		});
+	}
+
+	@Override
+	protected String doInBackground(OAuth... params) {
+		OAuth oauth = params[0];
+		OAuthToken token = oauth.getToken();
+
+		try {
+			Flickr f = FlickrHelper.getInstance().getFlickrAuthed(
+					token.getOauthToken(), token.getOauthTokenSecret());
+
+			UploadMetaData uploadMetaData = new UploadMetaData();
+			uploadMetaData.setTitle(filename);
+			return f.getUploader().upload("hello",
+					FlickrActivity.getInputStream(), uploadMetaData);
+		} catch (Exception e) {
+			Log.e("boom!!", "" + e.toString());
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	@Override
+	protected void onPostExecute(String response) {
+		if (mProgressDialog != null) {
+			mProgressDialog.dismiss();
+		}
+
+		if (response != null) {
+			Log.e("Flickr response", "" + response);
+		} else {
+			Log.e("Flickr response", "Error");
+		}
+		if (monUploadDone != null) {
+			monUploadDone.onComplete();
+		}
+		Toast.makeText(flickrjAndroidSampleActivity.getApplicationContext(),
+				response, Toast.LENGTH_SHORT).show();
+	}
+
+	public void setOnUploadDone(onUploadDone monUploadDone) {
+		this.monUploadDone = monUploadDone;
+	}
+
+	public interface onUploadDone {
+		void onComplete();
+	}
+
+}


### PR DESCRIPTION
Fix #809 

Changes: Added functions and tasks for authenticating and sharing image to flickr.

Testing:
First add the API token and Secret token in FlickrHelper class. then build the application.
Add account by clicking Flickr item in account activity.
Then click Flickr in sharing activity.