### PR TITLE
fix: Account manager SignIn Switch color according to the theme

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
@@ -7,11 +7,11 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.SwitchCompat;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.Menu;
 import android.view.View;
-import android.widget.Switch;
 import android.widget.Toast;
 
 import com.dropbox.client2.DropboxAPI;
@@ -95,7 +95,7 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        accountAdapter = new AccountAdapter();
+        accountAdapter = new AccountAdapter(getAccentColor(), getPrimaryColor());
         accountPresenter = new AccountPresenter(realm);
         phimpmeProgressBarHandler = new PhimpmeProgressBarHandler(this);
         accountPresenter.attachView(this);
@@ -165,7 +165,7 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
 
     @Override
     public void onItemClick(final View childView, final int position) {
-        final Switch signInSignOut = (Switch) childView.findViewById(R.id.sign_in_sign_out_switch);
+        final SwitchCompat signInSignOut = (SwitchCompat) childView.findViewById(R.id.sign_in_sign_out_switch);
 
        /* boolean isSignedIn = realmResult.equalTo("name"
                 , accountsList[position]).isValid();
@@ -266,11 +266,8 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
                             account.setUsername(bundle.getString(getString(R.string.auth_username)));
                             account.setToken(bundle.getString(getString(R.string.auth_token)));
                             realm.commitTransaction();
-
                         }
-
                     }
-
                 }
             };
             Intent i = new Intent(AccountActivity.this, ImgurAuthActivity.class);

--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountAdapter.java
@@ -1,15 +1,16 @@
 package org.fossasia.phimpme.accounts;
 
 import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.SwitchCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
-import android.widget.Switch;
 import android.widget.TextView;
 
 import org.fossasia.phimpme.R;
 import org.fossasia.phimpme.data.local.AccountDatabase;
+import org.fossasia.phimpme.leafpic.util.ThemeHelper;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -27,6 +28,15 @@ import static org.fossasia.phimpme.utilities.ActivitySwitchHelper.getContext;
 public class AccountAdapter extends RecyclerView.Adapter<AccountAdapter.ViewHolder> {
     private Realm realm = Realm.getDefaultInstance();
     private RealmQuery<AccountDatabase> realmResult = realm.where(AccountDatabase.class);
+    public int switchAccentColor;
+    public int switchBackgroundColor;
+    private ThemeHelper themeHelper;
+
+    public AccountAdapter(int switchColor, int switchBackgroundColor) {
+        this.switchAccentColor = switchColor;
+        this.switchBackgroundColor = switchBackgroundColor;
+        themeHelper = new ThemeHelper(getContext());
+    }
 
     @Override
     public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
@@ -40,11 +50,13 @@ public class AccountAdapter extends RecyclerView.Adapter<AccountAdapter.ViewHold
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
         realmResult = realm.where(AccountDatabase.class);
+        themeHelper.updateSwitchColor(holder.signInSignOutSwitch, switchBackgroundColor);
         if (realmResult.equalTo("name", accountName[position]).count() > 0){
             holder.accountName.setText(realmResult
                     .equalTo("name", accountName[position]).findAll()
                     .first().getUsername());
             holder.signInSignOutSwitch.setChecked(true);
+            themeHelper.updateSwitchColor(holder.signInSignOutSwitch, switchAccentColor);
         } else {
             holder.accountName.setText(accountName[position]);
         }
@@ -78,7 +90,7 @@ public class AccountAdapter extends RecyclerView.Adapter<AccountAdapter.ViewHold
         TextView accountName;
 
         @BindView(R.id.sign_in_sign_out_switch)
-        Switch signInSignOutSwitch;
+        SwitchCompat signInSignOutSwitch;
 
         public ViewHolder(View itemView) {
             super(itemView);

--- a/app/src/main/res/layout/accounts_item_view.xml
+++ b/app/src/main/res/layout/accounts_item_view.xml
@@ -59,7 +59,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_close_black_24dp" />
 
-    <Switch
+    <android.support.v7.widget.SwitchCompat
         android:id="@+id/sign_in_sign_out_switch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
Fix #826

Changes: Using `ThemeHelper` fixed the color of SignIn Switch 

Screenshots for the change: 
<img width="675" alt="screen shot 2017-07-18 at 2 37 13 pm" src="https://user-images.githubusercontent.com/6936968/28311931-e6da5b1a-6bce-11e7-8af9-3fae4d8ee287.png">

