### PR TITLE
Added Crashyltics for crash reporting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'io.fabric'
 apply plugin: 'jacoco-android'
 apply plugin: 'realm-android'
 
@@ -101,6 +102,7 @@ repositories {
         url 'https://github.com/uPhyca/stetho-realm/raw/master/maven-repo'
     }
     maven { url "https://jitpack.io" }
+    maven { url 'https://maven.fabric.io/public' }
 }
 
 
@@ -160,6 +162,9 @@ dependencies {
 
     compile project(':pdk')
 //    compile 'com.android.volley:volley:1.0.0'
+    compile('com.crashlytics.sdk.android:crashlytics:2.6.8@aar') {
+        transitive = true;
+    }
 }
 apply plugin: 'com.google.gms.google-services'
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -361,6 +361,9 @@
             android:name=".share.shareowncloud.OwnCloudActivity"
             android:label="@string/title_activity_own_cloud"
             android:theme="@style/AppTheme.NoActionBar"></activity>
+        <meta-data
+            android:name="io.fabric.ApiKey"
+            android:value="78c6ec5c18fcd10ffbfd28ae038f3311f2763889" />
     </application>
 
 </manifest>

--- a/app/src/main/java/org/fossasia/phimpme/MyApplication.java
+++ b/app/src/main/java/org/fossasia/phimpme/MyApplication.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.support.multidex.MultiDex;
 import android.util.Log;
 
+import com.crashlytics.android.Crashlytics;
 import com.facebook.stetho.Stetho;
 import com.twitter.sdk.android.core.DefaultLogger;
 import com.twitter.sdk.android.core.Twitter;
@@ -12,6 +13,7 @@ import com.twitter.sdk.android.core.TwitterAuthConfig;
 import com.twitter.sdk.android.core.TwitterConfig;
 import com.uphyca.stetho_realm.RealmInspectorModulesProvider;
 
+import io.fabric.sdk.android.Fabric;
 import org.fossasia.phimpme.leafpic.data.Album;
 import org.fossasia.phimpme.leafpic.data.HandlingAlbums;
 
@@ -56,6 +58,7 @@ public class MyApplication extends Application {
                 .build();
         Realm.setDefaultConfiguration(realmConfiguration);
         super.onCreate();
+        Fabric.with(this, new Crashlytics());
 
         /**
          * Stetho initialization

--- a/build.gradle
+++ b/build.gradle
@@ -6,12 +6,17 @@ buildscript {
     repositories {
         jcenter()
         maven { url 'https://jitpack.io' }
+        maven { url 'https://maven.fabric.io/public' }
+
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.google.gms:google-services:3.0.0'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
         classpath "io.realm:realm-gradle-plugin:$realm_version"
+        classpath 'io.fabric.tools:gradle:1.+'
+
+
     }
 }
 


### PR DESCRIPTION
Fix #829 

Changes:

Added crashlytics instead of firebase because Firebase also promotes to use crashlytics.
Also added all other 4 members in fabric portal.


