### PR TITLE
added text color and colorfilter on images in SharingActivity

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/share/ShareAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/share/ShareAdapter.java
@@ -1,5 +1,6 @@
 package org.fossasia.phimpme.share;
 
+import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -9,6 +10,7 @@ import android.widget.TextView;
 
 import org.fossasia.phimpme.R;
 import org.fossasia.phimpme.data.local.AccountDatabase;
+import org.fossasia.phimpme.leafpic.util.ThemeHelper;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -22,6 +24,7 @@ import static org.fossasia.phimpme.utilities.ActivitySwitchHelper.getContext;
 
 public class ShareAdapter extends RecyclerView.Adapter<ShareAdapter.ViewHolder> {
 
+    ThemeHelper themeHelper = new ThemeHelper(getContext());
     @Override
     public ShareAdapter.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(parent.getContext())
@@ -42,6 +45,25 @@ public class ShareAdapter extends RecyclerView.Adapter<ShareAdapter.ViewHolder> 
                 , getContext().getPackageName());
 
         holder.accountImage.setImageResource(id);
+
+        id = getContext().getResources().getIdentifier((name.toLowerCase()) + "_color"
+                , context.getString(R.string.color)
+                , getContext().getPackageName());
+
+        if (themeHelper.getBaseTheme() == ThemeHelper.LIGHT_THEME){
+
+            holder.accountName.setTextColor(ContextCompat.getColor(getContext(), id));
+            holder.accountImage.setColorFilter(ContextCompat.getColor(getContext(), id));
+
+        } else {
+
+            id = getContext().getResources().getIdentifier((name.toLowerCase()) + "_color_darktheme"
+                    , context.getString(R.string.color)
+                    , getContext().getPackageName());
+
+            holder.accountName.setTextColor(ContextCompat.getColor(getContext(), id));
+            holder.accountImage.setColorFilter(ContextCompat.getColor(getContext(), id));
+        }
     }
 
     @Override

--- a/app/src/main/res/layout/share_item_view.xml
+++ b/app/src/main/res/layout/share_item_view.xml
@@ -4,11 +4,11 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:gravity="center"
-              android:paddingLeft="20dp"
+              android:orientation="horizontal"
               android:paddingBottom="@dimen/share_item_padding"
-              android:paddingTop="@dimen/share_item_padding"
+              android:paddingLeft="20dp"
               android:paddingRight="@dimen/share_item_padding"
-              android:orientation="horizontal">
+              android:paddingTop="@dimen/share_item_padding">
 
     <ImageView
         android:id="@+id/account_image"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -380,26 +380,35 @@
     <color name="share_done_button_color">#01B683</color>
     <color name="facebook_color">#3b5998</color>
     <color name="twitter_color">#48A2E5</color>
-    <color name="instagram_color">#D42473</color>
-    <color name="wordpress_color">#21759B</color>
+    <color name="drupal_color">#21759B</color>
+    <color name="nextcloud_color">#0F89CD</color>
+    <color name="wordpress_color">#278BB8</color>
     <color name="pinterest_color">#C92228</color>
     <color name="flickr_color">#FC329B</color>
-    <color name="nextcloud_color">#0F89CD</color>
     <color name="imgur_color">#000000</color>
+    <color name="dropbox_color">#007ee5</color>
+    <color name="owncloud_color">#1D2D44</color>s
     <color name="googleplus_color">#d34836</color>
+    <color name="box_color">#d34836</color>
+    <color name="tumblr_color">#32506d</color>
+    <color name="instagram_color">#125688</color>
     <color name="others_color">@color/md_indigo_900</color>
 
     <color name="facebook_color_darktheme">#778bca</color>
     <color name="twitter_color_darktheme">#7ad4ff</color>
-    <color name="instagram_color_darktheme">#ff56a5</color>
+    <color name="drupal_color_darktheme">#7ad4ff</color>
+    <color name="nextcloud_color_darktheme">#2da7eb</color>
     <color name="wordpress_color_darktheme">#53a7cd</color>
     <color name="pinterest_color_darktheme">#ff5e64</color>
     <color name="flickr_color_darktheme">#ff5ac3</color>
-    <color name="nextcloud_color_darktheme">#2da7eb</color>
     <color name="imgur_color_darktheme">#fcfcfcfc</color>
-    <color name="other_share_color_darktheme">@color/md_indigo_400</color>
-    <color name="dropbox_color">#48A2E5</color>
     <color name="dropbox_color_darktheme">#778bca</color>
+    <color name="owncloud_color_darktheme">#a1b8d9</color>
+    <color name="googleplus_color_darktheme">#45556c</color>
+    <color name="box_color_darktheme">#da8587</color>
+    <color name="tumblr_color_darktheme">#698dc1</color>
+    <color name="instagram_color_darktheme">#ff56a5</color>
+    <color name="other_share_color_darktheme">@color/md_indigo_400</color>
 
     <color name="card_background">#e1e0e0</color>
     <!-- Drupal Login-->
@@ -411,6 +420,4 @@
 
     <!--Wordpress Login-->
     <color name="wordpress_color_login">#48A2E5</color>
-    <color name="owncloud_color">#1D2D44</color>
-    <color name="owncloud_color_darktheme">#45556c</color>
 </resources>


### PR DESCRIPTION
Fix #873 

Changes: Generated the color resources in the loop for light as well as dark theme and applied on the text and icons in the `ShareAdapter`

Screenshots for the change: 
<img width="295" alt="screen shot 2017-07-26 at 2 09 47 pm" src="https://user-images.githubusercontent.com/6936968/28612206-1fdb29b0-720c-11e7-9296-baef81ddfbfb.png">
