### PR TITLE
Added real time upload progress for Box uploads

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/utilities/NotificationHandler.java
+++ b/app/src/main/java/org/fossasia/phimpme/utilities/NotificationHandler.java
@@ -29,6 +29,13 @@ public class NotificationHandler {
         mNotifyManager.notify(id, mBuilder.build());
     }
 
+    public static void updateProgress(int uploaded, int total, int percent){
+        mBuilder.setProgress(total, uploaded, false);
+        mBuilder.setContentTitle(ActivitySwitchHelper.getContext().getString(R.string.upload_progress)+" ("+Integer.toString(percent)+"%)");
+        // Issues the notification
+        mNotifyManager.notify(id, mBuilder.build());
+    }
+
     public static void uploadPassed(){
         mBuilder.setContentText(ActivitySwitchHelper.getContext().getString(R.string.upload_done))
                 // Removes the progress bar


### PR DESCRIPTION
Fix #893 

Changes: Added progress listener to the box image uploads.

To test this enter keys in constants and log in with box credentials.
Then upload image on box from share activity.
