### PR TITLE
changed way of starting photoactivity and editimage activity

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
@@ -54,7 +54,7 @@ import butterknife.ButterKnife;
  * Called from SingleMediaActivity when the user selects the 'edit' option in the toolbar overflow menu.
  */
 public class EditImageActivity extends EditBaseActivity implements View.OnClickListener, View.OnTouchListener {
-    public static final String FILE_PATH = "file_path";
+    public static final String FILE_PATH = "extra_input";
     public static final String EXTRA_OUTPUT = "extra_output";
     public static final String IMAGE_IS_EDIT = "image_is_edit";
 
@@ -138,25 +138,6 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
     public RotateFragment rotateFragment;
     private static String stickerType;
 
-    /**
-     * @param context
-     * @param editImagePath
-     * @param outputPath
-     * @param requestCode
-     */
-    public static void start(Activity context, final String editImagePath, final String outputPath, final int requestCode) {
-        if (TextUtils.isEmpty(editImagePath)) {
-            Toast.makeText(context, R.string.no_choose, Toast.LENGTH_SHORT).show();
-            return;
-        }
-
-        Intent it = new Intent(context, EditImageActivity.class);
-        it.putExtra(EditImageActivity.FILE_PATH, editImagePath);
-        it.putExtra(EditImageActivity.EXTRA_OUTPUT, outputPath);
-        it.putExtra("requestCode",requestCode);
-        context.startActivityForResult(it, requestCode);
-    }
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -169,9 +150,6 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
         ButterKnife.bind(this);
         initView();
         getData();
-        requestCode = getIntent().getIntExtra("requestCode", 1);
-
-//        setInitialFragments();
     }
 
     /**
@@ -195,9 +173,15 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
      * Gets the image to be loaded from the intent and displays this image.
      */
     private void getData() {
-        filePath = getIntent().getStringExtra(FILE_PATH);
-        saveFilePath = getIntent().getStringExtra(EXTRA_OUTPUT);
-        loadImage(filePath);
+        if (null != getIntent() && null != getIntent().getExtras()){
+            Bundle bundle = getIntent().getExtras();
+            filePath = bundle.getString(FILE_PATH);
+            saveFilePath = bundle.getString(EXTRA_OUTPUT);
+            requestCode = bundle.getInt("requestCode", 1);
+            loadImage(filePath);
+            return;
+        }
+        SnackBarHandler.show(parentLayout,R.string.image_invalid);
     }
 
     /**
@@ -417,7 +401,6 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
         setButtonsVisibility();
     }
 
-
     private void onRedoPressed() {
 
         if (mainBitmap != null) {
@@ -472,16 +455,12 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
     }
 
     protected void onSaveTaskDone() {
-        Intent returnIntent = new Intent();
-        returnIntent.putExtra(FILE_PATH, filePath);
-        returnIntent.putExtra(EXTRA_OUTPUT, saveFilePath);
-        returnIntent.putExtra(IMAGE_IS_EDIT, mOpTimes > 0);
-        FileUtil.ablumUpdate(this, saveFilePath);
-        setResult(RESULT_OK, returnIntent);
-
-        if (mOpTimes > 0 || (requestCode == 1 && mOpTimes <= 0))
-            shareImage();
-        else{
+        if (mOpTimes > 0 ){
+            FileUtil.albumUpdate(this, saveFilePath);
+            shareImage(saveFilePath);
+        }else if(mOpTimes <= 0 && requestCode == 1 ){
+            shareImage(filePath);
+        }else {
             AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(mContext);
             alertDialogBuilder.setMessage(R.string.exit_without_edit)
                     .setCancelable(false).setPositiveButton(R.string.confirm, new DialogInterface.OnClickListener() {
@@ -502,10 +481,9 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
     /**
      * Called when the edit_save button is pressed. Used to share the image on social media.
      */
-    private void shareImage(){
+    private void shareImage(String filePath){
         Intent shareIntent = new Intent(EditImageActivity.this, SharingActivity.class);
-        shareIntent.putExtra(EXTRA_OUTPUT, saveFilePath);
-        setResult(RESULT_OK, shareIntent);
+        shareIntent.putExtra(EXTRA_OUTPUT, filePath);
         startActivity(shareIntent);
         finish();
     }
@@ -527,11 +505,6 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
     public void setStickerType(String stickerType) {
         EditImageActivity.stickerType = stickerType;
     }
-
-    public String getStickerType(){
-        return stickerType;
-    }
-
 
     @Override
     public boolean onTouch(View v, MotionEvent event) {

--- a/app/src/main/java/org/fossasia/phimpme/editor/utils/FileUtil.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/utils/FileUtil.java
@@ -35,7 +35,7 @@ public class FileUtil {
      * @param context
      * @param dstPath
      */
-    public static void ablumUpdate(final Context context, final String dstPath) {
+    public static void albumUpdate(final Context context, final String dstPath) {
         if (TextUtils.isEmpty(dstPath) || context == null)
             return;
 

--- a/app/src/main/java/org/fossasia/phimpme/leafpic/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/leafpic/activities/SingleMediaActivity.java
@@ -492,7 +492,11 @@ public class SingleMediaActivity extends SharedMediaActivity {
                     uri = Uri.fromFile(new File(getAlbum().getCurrentMedia().getPath()));
                 else
                     uri = Uri.fromFile(new File(LFMainActivity.listAll.get(current_image_pos).getPath()));
-                EditImageActivity.start(this,uri.getPath(),outputFile.getAbsolutePath(),ACTION_REQUEST_EDITIMAGE);
+                Intent editIntent = new Intent(SingleMediaActivity.this, EditImageActivity.class);
+                editIntent.putExtra("extra_input",uri.getPath());
+                editIntent.putExtra("extra_output",outputFile.getAbsolutePath());
+                editIntent.putExtra("requestCode",ACTION_REQUEST_EDITIMAGE);
+                startActivity(editIntent);
                 break;
 
             case R.id.action_use_as:

--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/CameraActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/CameraActivity.java
@@ -391,7 +391,9 @@ public class CameraActivity extends ThemedActivity implements AudioListener.Audi
 						clicks_count++; // Count till max defined image is captured and saved
 						if (!("preference_photo_mode_expo_bracketing").equals(mode) && Integer.parseInt(burst_mode) == 1) {
 							clicks_count = 0;
-							PhotoActivity.start(CameraActivity.this, filepath, 10);
+							Intent intent = new Intent(CameraActivity.this, PhotoActivity.class);
+							intent.putExtra("filepath",filepath);
+							startActivity(intent);
 						} else if (("preference_photo_mode_expo_bracketing").equals(mode) && clicks_count >= bundle.getInt("max_expo_bracketing_n_images")) { // Start Activity once when the third image is saved
 							clicks_count = 0; //Turn image count to zero in case user wants to click another set of photos.
 							Intent intent = new Intent(REVIEW_ACTION, Uri.fromFile(new File(filepath)));

--- a/app/src/main/res/layout/activity_photo.xml
+++ b/app/src/main/res/layout/activity_photo.xml
@@ -3,6 +3,7 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:background="@color/white"
+    android:id="@+id/parentLayout"
     android:orientation="vertical">
 
     <include

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -980,4 +980,5 @@
     <string name="logged_in_flickr">Tumblr account logged in successfully.</string>
     <string name="uploading">Image uploading in progress.</string>
     <string name="auth_failed">Authorization failed</string>
+    <string name="image_invalid">Invalid Image</string>
 </resources>


### PR DESCRIPTION
Fix #876 
Changes:
- removed unnecessary static start methods
- changed startactivityforresult to startactivity(result is not used anywhere)
- fixed empty white images being created when a new photo is captured and shared without editing.
