### PR TITLE
Google plus & Instagram handled correctly in sharing activity

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
@@ -41,11 +41,6 @@ import com.pinterest.android.pdk.PDKResponse;
 import com.tumblr.loglr.Interfaces.ExceptionHandler;
 import com.tumblr.loglr.Interfaces.LoginListener;
 import com.tumblr.loglr.Loglr;
-import com.twitter.sdk.android.core.Callback;
-import com.twitter.sdk.android.core.Result;
-import com.twitter.sdk.android.core.TwitterCore;
-import com.twitter.sdk.android.core.TwitterException;
-import com.twitter.sdk.android.core.TwitterSession;
 import com.twitter.sdk.android.core.identity.TwitterAuthClient;
 
 import org.fossasia.phimpme.R;
@@ -60,7 +55,6 @@ import org.fossasia.phimpme.share.imgur.ImgurAuthActivity;
 import org.fossasia.phimpme.share.nextcloud.NextCloudAuth;
 import org.fossasia.phimpme.share.owncloud.OwnCloudActivity;
 import org.fossasia.phimpme.share.tumblr.TumblrClient;
-import org.fossasia.phimpme.share.flickr.FlickrHelper;
 import org.fossasia.phimpme.share.twitter.LoginActivity;
 import org.fossasia.phimpme.share.wordpress.WordpressLoginActivity;
 import org.fossasia.phimpme.utilities.ActivitySwitchHelper;
@@ -159,7 +153,7 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
         pdkClient.onConnect(this);
         setDebugMode(true);
         setupDropBox();
-        googleApiClient();
+      //  googleApiClient();
         configureBoxClient();
     }
 
@@ -168,7 +162,7 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
         AndroidAuthSession session = new AndroidAuthSession(appKeys);
         mDBApi = new DropboxAPI<AndroidAuthSession>(session);
     }
-    private void googleApiClient(){
+/*    private void googleApiClient(){
         // Configure sign-in to request the user's ID, email address, and basic
         // profile. ID and basic profile are included in DEFAULT_SIGN_IN.
         GoogleSignInOptions gso = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
@@ -177,10 +171,10 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
         // Build a GoogleApiClient with access to the Google Sign-In API and the
         // options specified by gso.
         mGoogleApiClient = new GoogleApiClient.Builder(this)
-                .enableAutoManage(this /* FragmentActivity */, AccountActivity.this /* OnConnectionFailedListener */)
+                .enableAutoManage(this, AccountActivity.this)
                 .addApi(Auth.GOOGLE_SIGN_IN_API, gso)
                 .build();
-    }
+    }*/
     private void configureBoxClient() {
         BoxConfig.CLIENT_ID = BOX_CLIENT_ID;
         BoxConfig.CLIENT_SECRET = BOX_CLIENT_SECRET;
@@ -282,10 +276,6 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
                 case OWNCLOUD:
                     Intent ownCloudShare = new Intent(getContext(), OwnCloudActivity.class);
                     startActivityForResult(ownCloudShare, OWNCLOUD_REQUEST_CODE);
-                    break;
-
-                case GOOGLEPLUS:
-                    signInGooglePlus();
                     break;
 
                 case BOX:
@@ -449,7 +439,7 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
                 @Override
                 public void onFailure(PDKException exception) {
                     Log.e(getClass().getName(), exception.getDetailMessage());
-                    SnackBarHandler.show(parentLayout,R.string.fail);
+                    SnackBarHandler.show(parentLayout,R.string.pinterest_signIn_fail);
                 }
             });
             SnackBarHandler.show(parentLayout,"logged IN");
@@ -605,23 +595,12 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
             try {
                 // Required to complete auth, sets the access token on the session
                 mDBApi.getSession().finishAuthentication();
-
                 String accessToken = mDBApi.getSession().getOAuth2AccessToken();
-
                 realm.beginTransaction();
-
-                // Creating Realm object for AccountDatabase Class
-                account = realm.createObject(AccountDatabase.class,
-                        DROPBOX.toString());
-
-                // Writing values in Realm database
-
+                account = realm.createObject(AccountDatabase.class, DROPBOX.toString());
                 account.setUsername(DROPBOX.toString());
                 account.setToken(String.valueOf(accessToken));
-
-                // Finally committing the whole data
                 realm.commitTransaction();
-
             } catch (IllegalStateException e) {
                 Log.i("DbAuthLog", "Error authenticating", e);
             }
@@ -637,56 +616,36 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
         pdkClient.onOauthResponse(requestCode, resultCode,
                 data);
 
-        if ((requestCode == OWNCLOUD_REQUEST_CODE && resultCode == RESULT_OK)
-                || (requestCode == NEXTCLOUD_REQUEST_CODE && resultCode == RESULT_OK)){
-            // Begin realm transaction
+        if ((requestCode == OWNCLOUD_REQUEST_CODE && resultCode == RESULT_OK) || (requestCode == NEXTCLOUD_REQUEST_CODE && resultCode == RESULT_OK)) {
             realm.beginTransaction();
-
-            if (requestCode == NEXTCLOUD_REQUEST_CODE){
-                account = realm.createObject(AccountDatabase.class,
-                        NEXTCLOUD.toString());
+            if (requestCode == NEXTCLOUD_REQUEST_CODE) {
+                account = realm.createObject(AccountDatabase.class, NEXTCLOUD.toString());
             } else {
-                account = realm.createObject(AccountDatabase.class,
-                        OWNCLOUD.toString());
+                account = realm.createObject(AccountDatabase.class, OWNCLOUD.toString());
             }
-
-            // Writing values in Realm database
             account.setServerUrl(data.getStringExtra(getString(R.string.server_url)));
             account.setUsername(data.getStringExtra(getString(R.string.auth_username)));
             account.setPassword(data.getStringExtra(getString(R.string.auth_password)));
-
-            // Finally committing the whole data
             realm.commitTransaction();
         }
-        // Result returned from launching the Intent from GoogleSignInApi.getSignInIntent(...);
-        if (requestCode == RC_SIGN_IN) {
+     /*   if (requestCode == RC_SIGN_IN) {
             GoogleSignInResult result = Auth.GoogleSignInApi.getSignInResultFromIntent(data);
             handleSignInResult(result);
-        }
+        }*/
     }
 
-    private void handleSignInResult(GoogleSignInResult result) {
+    /*private void handleSignInResult(GoogleSignInResult result) {
         if (result.isSuccess()) {
-            // Signed in successfully, show authenticated UI.
             GoogleSignInAccount acct = result.getSignInAccount();//acct.getDisplayName()
             SnackBarHandler.show(parentLayout,R.string.success);
-            // Begin realm transaction
             realm.beginTransaction();
-
-            // Creating Realm object for AccountDatabase Class
-            account = realm.createObject(AccountDatabase.class,
-                    GOOGLEPLUS.name());
-
-            account.setUsername(acct.getDisplayName());
-
-            // Finally committing the whole data
+            account = realm.createObject(AccountDatabase.class, GOOGLEPLUS.name());account.setUsername(acct.getDisplayName());
+            account.setUserId(acct.getId());
             realm.commitTransaction();
         } else {
-            // Signed out, show unauthenticated UI.
-            SnackBarHandler.show(parentLayout,R.string.fail);
-            //updateUI(false);
+            SnackBarHandler.show(parentLayout,R.string.google_auth_fail);
         }
-    }
+    }*/
 
     @Override
     public void onConnectionFailed(@NonNull ConnectionResult connectionResult) {

--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountAdapter.java
@@ -18,6 +18,7 @@ import butterknife.ButterKnife;
 import io.realm.Realm;
 import io.realm.RealmQuery;
 
+import static org.fossasia.phimpme.data.local.AccountDatabase.HIDEINACCOUNTS;
 import static org.fossasia.phimpme.utilities.ActivitySwitchHelper.context;
 import static org.fossasia.phimpme.utilities.ActivitySwitchHelper.getContext;
 
@@ -92,10 +93,10 @@ public class AccountAdapter extends RecyclerView.Adapter<AccountAdapter.ViewHold
     @Override
     public int getItemCount() {
         /**
-         * We are using the enum from the AccountDatabase model class, (-2) from the lengtg because
-         * Other and Instagram option is only required in the Sharing activity.
+         * We are using the enum from the AccountDatabase model class, (-HIDEINACCOUNTS) from the length because
+         * whatsapp, Instagram , googleplus and others option is only required in the Sharing activity.
          */
-        return AccountDatabase.AccountName.values().length-2;
+        return AccountDatabase.AccountName.values().length - HIDEINACCOUNTS;
     }
 
     public void setResults(RealmQuery<AccountDatabase> results) {

--- a/app/src/main/java/org/fossasia/phimpme/data/local/AccountDatabase.java
+++ b/app/src/main/java/org/fossasia/phimpme/data/local/AccountDatabase.java
@@ -12,10 +12,14 @@ import io.realm.annotations.PrimaryKey;
 
 public class AccountDatabase extends RealmObject{
 
+    /*Add hidden account option in last and increase the count option in hideInAccount variable*/
+
+
     public enum AccountName {
         FACEBOOK, TWITTER, DRUPAL, NEXTCLOUD, WORDPRESS, PINTEREST, FLICKR, IMGUR, DROPBOX, OWNCLOUD
-        , GOOGLEPLUS, BOX, TUMBLR, INSTAGRAM,WHATSAPP, OTHERS
+        , BOX, TUMBLR, INSTAGRAM, WHATSAPP, GOOGLEPLUS,  OTHERS
     }
+    public static int HIDEINACCOUNTS = 4;
 
     @PrimaryKey
     String name;

--- a/app/src/main/java/org/fossasia/phimpme/share/SharingActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/share/SharingActivity.java
@@ -358,9 +358,6 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
                 shareToNextCloudAndOwnCloud(getString(R.string.owncloud));
                 break;
 
-            case GOOGLEPLUS:
-                shareToGoogle();
-                break;
 
             case BOX:
                 shareToBox();
@@ -402,7 +399,7 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
 
     private void shareToGoogle() {
         Uri uri = getImageUri(context);
-        PlusShare.Builder share = new PlusShare.Builder(this);
+        PlusShare.Builder share = new PlusShare.Builder(SharingActivity.this);
         share.setText(caption);
         share.addStream(uri);
         share.setType(getResources().getString(R.string.image_type));

--- a/app/src/main/java/org/fossasia/phimpme/utilities/Constants.java
+++ b/app/src/main/java/org/fossasia/phimpme/utilities/Constants.java
@@ -37,9 +37,10 @@ public class Constants {
     public final static String PACKAGE_WHATSAPP = "com.whatsapp";
     public final static String PACKAGE_GOOGLEPLUS = "com.google.android.apps.plus";
     public final static String PACKAGE_HIKE = "com.bsb.hike";
-    public final static String PACKAGE_MESSENGER = "org.telegram.messenger";
+    public final static String PACKAGE_MESSENGER = "com.facebook.orca";
     public final static String PACKAGE_TWITTER = "com.twitter.android";
     public final static String PACKAGE_PLAYSTORE = "com.android.vending";
+    public final static String PACKAGE_TELEGRAM = "org.telegram.messenger";
 
 
 }

--- a/app/src/main/java/org/fossasia/phimpme/utilities/Utils.java
+++ b/app/src/main/java/org/fossasia/phimpme/utilities/Utils.java
@@ -21,6 +21,7 @@ import io.realm.RealmQuery;
 import io.realm.RealmResults;
 
 import static android.content.Context.CLIPBOARD_SERVICE;
+import static org.fossasia.phimpme.utilities.Constants.PACKAGE_GOOGLEPLUS;
 import static org.fossasia.phimpme.utilities.Constants.PACKAGE_INSTAGRAM;
 import static org.fossasia.phimpme.utilities.Constants.PACKAGE_WHATSAPP;
 
@@ -118,6 +119,10 @@ public class Utils {
 
         if (isAppInstalled(PACKAGE_WHATSAPP,packageManager))
             list.add(AccountDatabase.AccountName.WHATSAPP);
+
+        if (isAppInstalled(PACKAGE_GOOGLEPLUS,packageManager))
+            list.add(AccountDatabase.AccountName.GOOGLEPLUS);
+
 
         list.addAll(getLoggedInAccountsList());
         if (!list.contains(AccountDatabase.AccountName.IMGUR))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -902,12 +902,11 @@
     <string name="pinterest_app_id">4910600717739247160</string>
     <string name="pinterest_app_secret">6a3eba976f2d4ce13c1d4f0852ff17b242768b124905cc83c36faa99da3a1ad1</string>
     <string name="success">Success</string>
-    <string name="fail">Login Fail</string>
     <string name="Pinterest_fail">BoardID or caption cannot be empty</string>
     <string name="post_action">POST</string>
     <string name="hint_boardID">Board ID</string>
     <string name="pinterest_post">Image posted successfully</string>
-    <string name="pinterest_signIn_fail">Sign in to Pinterest</string>
+    <string name="pinterest_signIn_fail">Failed to sign in Pinterest</string>
     <string name="sign_In">SIGN IN</string>
     <string name="pinterest_board_message">Get your Pinterest Board ID from the LINK</string>
     <string name="Pinterest_link">&lt;a href=https://www.nutt.net/how-do-i-get-pinterest-board-id/> Get Board ID from the LINK</string>
@@ -941,12 +940,14 @@
     <string name="uploaded_box">Uploaded to Box</string>
     <string name="title_activity_own_cloud">OwnCloudActivity</string>
 
-    <string name="image_type">image/jpeg</string>
+    <string name="image_type">image/*</string>
 
     <!--Google+-->
     <string name="success_google">Image uploaded successfully on Google+</string>
     <string name="error_google">An error occurred while uploading</string>
     <string name="googlePlus">Google+</string>
+    <string name="google_auth_fail">Authentication fail</string>
+
 
     <!--Box-->
     <string name="upload_failed">Upload failed</string>


### PR DESCRIPTION
Fix #894 

Changes:

- [x] Removed google plus authentication.
- [x] Added a New variable in account database to handle hidden number.
- [x] Check if google plus is installed then it will visible in a share account.

Because we cannot google plus api. The only way to use google plus domain API and it is paid.
