### PR TITLE
Hidden set as album preview option if no image selected

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/leafpic/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/leafpic/activities/LFMainActivity.java
@@ -885,7 +885,7 @@ public class LFMainActivity extends SharedMediaActivity {
         if (getAlbums().getSelectedCount() == 1)
             menu.findItem(R.id.set_pin_album).setTitle(getAlbums().getSelectedAlbum(0).isPinned() ? getString(R.string.un_pin) : getString(R.string.pin));
         menu.findItem(R.id.set_pin_album).setVisible(albumsMode && getAlbums().getSelectedCount() == 1);
-        menu.findItem(R.id.setAsAlbumPreview).setVisible(!albumsMode && !all_photos);
+        menu.findItem(R.id.setAsAlbumPreview).setVisible(!albumsMode && !all_photos && getAlbum().getSelectedCount()==1);
         menu.findItem(R.id.affixPhoto).setVisible(!albumsMode && (getAlbum().getSelectedCount() > 1) || selectedMedias.size() > 1);
         return super.onPrepareOptionsMenu(menu);
     }


### PR DESCRIPTION
Fix #914 

Changes: Added condition to hide option if the selected photos count not equals to one.
