### PR TITLE
changed progress dialog to progress bar when applying edits

### DIFF
--- a/app/src/androidTest/java/org/fossasia/phimpme/leafpic/activities/HomeScreenTest.java
+++ b/app/src/androidTest/java/org/fossasia/phimpme/leafpic/activities/HomeScreenTest.java
@@ -34,9 +34,8 @@ import static org.hamcrest.Matchers.allOf;
 @RunWith(AndroidJUnit4.class)
 public class HomeScreenTest {
 
-
     @Rule
-    public ActivityTestRule<SplashScreen> mActivityTestRule = new ActivityTestRule<>(SplashScreen.class);
+    public ActivityTestRule<LFMainActivity> mActivityTestRule = new ActivityTestRule<>(LFMainActivity.class);
 
     @UiThreadTest
     @Before

--- a/app/src/androidTest/java/org/fossasia/phimpme/leafpic/activities/SettingsActivityTest.java
+++ b/app/src/androidTest/java/org/fossasia/phimpme/leafpic/activities/SettingsActivityTest.java
@@ -1,16 +1,22 @@
 package org.fossasia.phimpme.leafpic.activities;
 
 
+import android.app.Activity;
+import android.app.KeyguardManager;
+import android.support.test.annotation.UiThreadTest;
 import android.support.test.espresso.ViewInteraction;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.suitebuilder.annotation.LargeTest;
+import android.view.WindowManager;
 
 import org.fossasia.phimpme.R;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static android.content.Context.KEYGUARD_SERVICE;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.scrollTo;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
@@ -23,6 +29,31 @@ public class SettingsActivityTest {
 
     @Rule
     public ActivityTestRule<SettingsActivity> mActivityTestRule = new ActivityTestRule<>(SettingsActivity.class);
+
+    @UiThreadTest
+    @Before
+    public void setUp() throws Exception {
+        final Activity activity = mActivityTestRule.getActivity();
+        try {
+            mActivityTestRule.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    KeyguardManager mKG = (KeyguardManager) activity.getSystemService(KEYGUARD_SERVICE);
+                    KeyguardManager.KeyguardLock mLock = mKG.newKeyguardLock(KEYGUARD_SERVICE);
+                    mLock.disableKeyguard();
+
+                    //turn the screen on
+                    activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
+                            | WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD
+                            | WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+                            | WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+                            | WindowManager.LayoutParams.FLAG_ALLOW_LOCK_WHILE_SCREEN_ON);
+                }
+            });
+        } catch (Throwable throwable) {
+            throwable.printStackTrace();
+        }
+    }
 
     @Test
     public void settingsActivityTest() {

--- a/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
@@ -1,12 +1,12 @@
 package org.fossasia.phimpme.editor;
 
-import android.app.Activity;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.graphics.Bitmap;
 import android.graphics.Color;
+import android.graphics.PorterDuff;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -16,9 +16,10 @@ import android.util.DisplayMetrics;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.ImageButton;
-import android.widget.Toast;
+import android.widget.ProgressBar;
 
 import org.fossasia.phimpme.R;
+import org.fossasia.phimpme.leafpic.util.ColorPalette;
 import org.fossasia.phimpme.share.SharingActivity;
 import org.fossasia.phimpme.editor.fragment.AddTextFragment;
 import org.fossasia.phimpme.editor.fragment.CropFragment;
@@ -109,6 +110,9 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
     ImageButton undo;
     @Nullable @BindView(R.id.edit_redo)
     ImageButton redo;
+    @Nullable @BindView(R.id.progress_bar_edit)
+    ProgressBar progressBar;
+
 
     @Nullable @BindView(R.id.sticker_panel)
     public StickerView mStickerView;// Texture layers View
@@ -195,6 +199,8 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
         imageHeight = metrics.heightPixels / 2;
 
         bitmapsForUndo = new ArrayList<>();
+        progressBar.getIndeterminateDrawable()
+                .setColorFilter(ColorPalette.getLighterColor(getPrimaryColor()), PorterDuff.Mode.SRC_ATOP);
 
         cancel.setOnClickListener(this);
         save.setOnClickListener(this);
@@ -444,6 +450,14 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
 
     public void resetOpTimes() {
         isBeenSaved = true;
+    }
+
+    public void showProgressBar(){
+        progressBar.setVisibility(View.VISIBLE);
+    }
+
+    public void hideProgressBar(){
+        progressBar.setVisibility(View.GONE);
     }
 
     /**

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/SliderFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/SliderFragment.java
@@ -212,7 +212,7 @@ public class SliderFragment extends BaseEditFragment implements View.OnClickList
         @Override
         protected void onPostExecute(Bitmap result) {
             super.onPostExecute(result);
-            if (dialog!=null)dialog.dismiss();
+            activity.hideProgressBar();
             if (result == null)
                 return;
             filterBit = result;
@@ -222,9 +222,7 @@ public class SliderFragment extends BaseEditFragment implements View.OnClickList
         @Override
         protected void onPreExecute() {
             super.onPreExecute();
-            dialog = EditImageActivity.getLoadingDialog(getActivity(),
-                    R.string.applying, false);
-            dialog.show();
+            activity.showProgressBar();
         }
 
     }

--- a/app/src/main/jni/enhance.cpp
+++ b/app/src/main/jni/enhance.cpp
@@ -76,7 +76,7 @@ extern "C" {
         double r_val = 0.299, g_val = 0.587, b_val = 0.114;
         double r,g,b;
         for (y = 0; y < src.rows; y++) {
-            for (x = 0; x < src.cols/3; x++) {
+            for (x = 0; x < src.cols; x++) {
                 r = src.at<Vec3b>(y, x)[2]/255.0;
                 g = src.at<Vec3b>(y, x)[1]/255.0;
                 b = src.at<Vec3b>(y, x)[0]/255.0;

--- a/app/src/main/res/layout/activity_image_edit.xml
+++ b/app/src/main/res/layout/activity_image_edit.xml
@@ -162,4 +162,12 @@
             android:visibility="gone" />
     </FrameLayout>
 
+    <ProgressBar
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:id="@+id/progress_bar_edit"
+        android:visibility="gone"
+        />
+
 </RelativeLayout>


### PR DESCRIPTION
Fix #972 

Changes: 
Progress dialog was large and the message was also not visible as it appears only for a fraction of second. 
It looks better after replacing it with a progressbar.

Also fixed an error while adjusting saturation