### PR TITLE
Fixed Facebook Upload Image

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -307,7 +307,7 @@
         </provider>
         <provider
             android:name="com.facebook.FacebookContentProvider"
-            android:authorities="com.facebook.app.FacebookContentProvider111535049486318"
+            android:authorities="com.facebook.app.FacebookContentProvider125766838062659"
             android:exported="true" />
 
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -307,7 +307,7 @@
         </provider>
         <provider
             android:name="com.facebook.FacebookContentProvider"
-            android:authorities="com.facebook.app.FacebookContentProvider1920575401558694"
+            android:authorities="com.facebook.app.FacebookContentProvider111535049486318"
             android:exported="true" />
 
         <activity
@@ -323,11 +323,6 @@
         <meta-data
             android:name="com.facebook.sdk.ApplicationId"
             android:value="@string/facebook_app_id" />
-
-        <provider
-            android:name="com.facebook.FacebookContentProvider"
-            android:authorities="com.facebook.app.FacebookContentProvider1920575401558694"
-            android:exported="true" />
 
         <activity
             android:name=".accounts.AccountActivity"

--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
@@ -462,8 +462,10 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
      */
     public void signInFacebook() {
 
+        List<String> permissionNeeds = Arrays.asList("publish_actions");
         loginManager = LoginManager.getInstance();
-        loginManager.logInWithReadPermissions(this, Arrays.asList("email", "public_profile"));
+        loginManager.logInWithPublishPermissions(this, permissionNeeds);
+        //loginManager.logInWithReadPermissions(this, Arrays.asList("email", "public_profile"));
         loginManager.registerCallback(callbackManager,
                 new FacebookCallback<LoginResult>() {
                     @Override

--- a/app/src/main/java/org/fossasia/phimpme/share/SharingActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/share/SharingActivity.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.PorterDuff;
@@ -55,6 +56,7 @@ import com.facebook.messenger.ShareToMessengerParams;
 import com.facebook.share.ShareApi;
 import com.facebook.share.model.SharePhoto;
 import com.facebook.share.model.SharePhotoContent;
+import com.facebook.share.widget.ShareDialog;
 import com.google.android.gms.plus.PlusShare;
 import com.mikepenz.community_material_typeface_library.CommunityMaterial;
 import com.mikepenz.iconics.view.IconicsImageView;
@@ -123,12 +125,14 @@ import static org.fossasia.phimpme.data.local.AccountDatabase.AccountName.OTHERS
 import static org.fossasia.phimpme.data.local.AccountDatabase.AccountName.TWITTER;
 import static org.fossasia.phimpme.utilities.Constants.BOX_CLIENT_ID;
 import static org.fossasia.phimpme.utilities.Constants.BOX_CLIENT_SECRET;
+import static org.fossasia.phimpme.utilities.Constants.PACKAGE_FACEBOOK;
 import static org.fossasia.phimpme.utilities.Utils.checkNetwork;
 import static org.fossasia.phimpme.utilities.Utils.copyToClipBoard;
 import static org.fossasia.phimpme.utilities.Utils.getBitmapFromPath;
 import static org.fossasia.phimpme.utilities.Utils.getImageUri;
 import static org.fossasia.phimpme.utilities.Utils.getMimeType;
 import static org.fossasia.phimpme.utilities.Utils.getStringImage;
+import static org.fossasia.phimpme.utilities.Utils.isAppInstalled;
 import static org.fossasia.phimpme.utilities.Utils.promptSpeechInput;
 import static org.fossasia.phimpme.utilities.Utils.shareMsgOnIntent;
 
@@ -202,6 +206,7 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
 
     public boolean uploadFailedBox = false;
     public String uploadName;
+    ShareDialog shareDialog;
 
     public static String getClientAuth() {
         return Constants.IMGUR_HEADER_CLIENt + " " + Constants.MY_IMGUR_CLIENT_ID;
@@ -227,6 +232,7 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
         setStatusBarColor();
         checkNetwork(this, parent);
         configureBoxClient();
+        shareDialog = new ShareDialog(this);
     }
 
     private void configureBoxClient() {
@@ -725,7 +731,8 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
     }
 
     private void shareToFacebook() {
-        if (Utils.checkAlreadyExist(FACEBOOK)) {
+        PackageManager packageManager = (ActivitySwitchHelper.context).getPackageManager();
+        if (isAppInstalled(PACKAGE_FACEBOOK, packageManager)) {
             Bitmap image = getBitmapFromPath(saveFilePath);
             SharePhoto photo = new SharePhoto.Builder()
                     .setBitmap(image)
@@ -736,12 +743,11 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
                     .addPhoto(photo)
                     .build();
 
-            ShareApi.share(content, null);
-            SnackBarHandler.show(parent, R.string.facebook_image_posted);
-        } else {
-            SnackBarHandler.show(parent, R.string.facebook_signIn_fail);
-        }
+            shareDialog.show(content);
+        } else
+            SnackBarHandler.show(parent, R.string.install_facebook);
     }
+
 
     private void shareToOthers() {
         Uri uri = Uri.fromFile(new File(saveFilePath));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="action_popup">Popup settings</string>
     <string name="intro_text">Touch to focus, and press the blue camera button to take photos. For more help, click Online help from Settings. Open Camera is completely free. If you like this app, please consider buying my donate app :) (see link in Settings, or Online help).\n\nPrivacy Policy: Location permission is required for geotagging, but this is disabled by default. If enabled, your location is encoded in the saved files (and it is only used for this purpose).</string>
     <string name="intro_ok">OK (This message won\'t show again)</string>
-    <string name="facebook_app_id">111535049486318</string>
+    <string name="facebook_app_id">125766838062659</string>
     <string name="answer_yes">Yes</string>
     <string name="answer_no">No</string>
 
@@ -1004,5 +1004,6 @@
     <string name="upload_history">Upload History</string>
     <string name="toggle_button">Toggle Button</string>
     <string name="empty_upload_msg">You haven\'t shared anything.</string>
+    <string name="install_facebook">Facebook not installed</string>
 
 </resources>


### PR DESCRIPTION
Fix #1007 
Changes: Fixed image upload on Facebook due to an inactive account. 
Currently, Image upload is possible only for Developers. Once Facebook Reviews the app, public users can upload the image on Facebook. 