### PR TITLE
Added app shortcuts to directly open camera, gallery or accounts from launcher

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -178,6 +178,8 @@
             <intent-filter>
                 <action android:name="vn.mbm.phimp.me.leafpic.OPEN_ALBUM" />
             </intent-filter>
+            <meta-data android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
         <activity
             android:name=".leafpic.activities.LFMainActivity"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -787,6 +787,13 @@
     <string name="account_logged_twitter">Twitter account logged in successfully.</string>
     <string name="twitter_uploading">Image uploading on Twitter</string>
 
+    <!--App shortcuts-->
+    <string name="camera_short">Camera</string>
+    <string name="camera_long">Opens Phimpme Camera</string>
+    <string name="home_short">Gallery</string>
+    <string name="home_long">Opens Phimpme Gallery</string>
+    <string name="account_short">Accounts</string>
+    <string name="account_long">Opens Phimpme Account</string>
 
     <!--All photos-->
     <string name="all_photos">All_photos</string>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,45 @@
+<shortcuts xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="camera"
+        android:enabled="true"
+        android:icon="@drawable/ic_camera_alt_black_24dp"
+        android:shortcutShortLabel="@string/camera_short"
+        android:shortcutLongLabel="@string/camera_long"
+        android:shortcutDisabledMessage="@string/camera_short"
+        tools:targetApi="n_mr1">
+        <intent
+            android:action="android.media.action.IMAGE_CAPTURE_SECURE"
+            android:targetPackage="org.fossasia.phimpme"
+            android:targetClass="org.fossasia.phimpme.opencamera.Camera.CameraActivity" />
+        <categories android:name="android.intent.category.DEFAULT" />
+    </shortcut>
+    <shortcut
+        android:shortcutId="gallery"
+        android:enabled="true"
+        android:icon="@drawable/ic_home"
+        android:shortcutShortLabel="@string/home_short"
+        android:shortcutLongLabel="@string/home_long"
+        android:shortcutDisabledMessage="@string/home_short"
+        tools:targetApi="n_mr1">
+        <intent
+            android:action="android.intent.action.albumsAct"
+            android:targetPackage="org.fossasia.phimpme"
+            android:targetClass="org.fossasia.phimpme.leafpic.activities.LFMainActivity" />
+        <categories android:name="android.intent.category.DEFAULT" />
+    </shortcut>
+    <shortcut
+        android:shortcutId="accounts"
+        android:enabled="true"
+        android:icon="@drawable/ic_account_box_black_24dp"
+        android:shortcutShortLabel="@string/account_short"
+        android:shortcutLongLabel="@string/account_long"
+        android:shortcutDisabledMessage="@string/account_short"
+        tools:targetApi="n_mr1">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.fossasia.phimpme"
+            android:targetClass="org.fossasia.phimpme.accounts.AccountActivity" />
+        <categories android:name="android.intent.category.DEFAULT" />
+    </shortcut>
+</shortcuts>


### PR DESCRIPTION
Fix #1037 

Changes: Added static shortcuts to open gallery, camera or accounts on long clicking the app icon

Note - Works for Android versions greater than 7.0 (Nougat)

![photo6107040648910710740](https://user-images.githubusercontent.com/20367966/29471398-8156ada4-846d-11e7-8e81-866a04a1c64b.jpg)

