### PR TITLE
Changed the colour palette used in the Paint Fragment

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/PaintFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/PaintFragment.java
@@ -1,21 +1,23 @@
 package org.fossasia.phimpme.editor.fragment;
 
+import android.content.DialogInterface;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Matrix;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.Bundle;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.PopupWindow;
 import android.widget.SeekBar;
+import android.widget.TextView;
 
 import org.fossasia.phimpme.R;
 import org.fossasia.phimpme.editor.EditImageActivity;
@@ -24,6 +26,10 @@ import org.fossasia.phimpme.editor.task.StickerTask;
 import org.fossasia.phimpme.editor.ui.ColorPicker;
 import org.fossasia.phimpme.editor.view.CustomPaintView;
 import org.fossasia.phimpme.editor.view.PaintModeView;
+import org.fossasia.phimpme.leafpic.util.ColorPalette;
+
+import uz.shift.colorpicker.LineColorPicker;
+import uz.shift.colorpicker.OnColorChangedListener;
 
 
 public class PaintFragment extends BaseEditFragment implements View.OnClickListener, ColorListAdapter.IColorListAction {
@@ -151,15 +157,42 @@ public class PaintFragment extends BaseEditFragment implements View.OnClickListe
 
     @Override
     public void onMoreSelected(int position) {
-        mColorPicker.show();
-        Button okColor = (Button) mColorPicker.findViewById(R.id.okColorButton);
-        okColor.setOnClickListener(new View.OnClickListener() {
+        selectPaintColor();
+    }
+
+    private void selectPaintColor() {
+        final AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(getActivity());
+        final View dialogLayout = getActivity().getLayoutInflater().inflate(R.layout.color_piker_accent, null);
+        final LineColorPicker colorPicker = (LineColorPicker) dialogLayout.findViewById(R.id.color_picker_accent);
+        final TextView dialogTitle = (TextView) dialogLayout.findViewById(R.id.cp_accent_title);
+        dialogTitle.setText(R.string.paint_color_title);
+        colorPicker.setColors(ColorPalette.getAccentColors(activity.getApplicationContext()));
+        colorPicker.setOnColorChangedListener(new OnColorChangedListener() {
             @Override
-            public void onClick(View v) {
-                setPaintColor(mColorPicker.getColor());
-                mColorPicker.dismiss();
+            public void onColorChanged(int c) {
+                dialogTitle.setBackgroundColor(c);
+
             }
         });
+        dialogBuilder.setView(dialogLayout);
+        dialogBuilder.setNeutralButton(getString(R.string.cancel).toUpperCase(), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.cancel();
+            }
+        });
+        dialogBuilder.setPositiveButton(getString(R.string.ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int which) {
+                setPaintColor(colorPicker.getColor());
+            }
+        });
+        dialogBuilder.setOnDismissListener(new DialogInterface.OnDismissListener() {
+            @Override
+            public void onDismiss(DialogInterface dialog) {
+                dialog.dismiss();
+            }
+        });
+        dialogBuilder.show();
     }
 
     protected void setPaintColor(final int paintColor) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -993,5 +993,6 @@
     <string name="camera_button">Click Amazing Pictures</string>
     <string name="ok_button">GOT IT</string>
     <string name="speech_not_supported">Sorry! Your device doesn\'t support speech input.</string>
+    <string name="paint_color_title">Paint Color</string>
 
 </resources>


### PR DESCRIPTION
Fix #1042 

Changes: Changed the color palette used in the Paint Fragment. The previous color palette for confusing and it was hard for any normal user to choose the desired color. 
It maintains the uniformity of the application.
Steps To Reproduce-> Edit Image Activity->Write->Paint->More