### PR TITLE
Fix: Toolbar count changes on deleting a picture from albums mode

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -442,6 +442,7 @@ public class SingleMediaActivity extends SharedMediaActivity {
                 }
             }
             adapter.notifyDataSetChanged();
+            getSupportActionBar().setTitle((getAlbum().getCurrentMediaIndex() + 1) + " " + getString(R.string.of) + " " + getAlbum().getMedia().size());
         } else {
             deleteMedia(LFMainActivity.listAll.get(current_image_pos).getPath());
             LFMainActivity.listAll.remove(current_image_pos);


### PR DESCRIPTION
Fix #1061 

Changes: Now the toolbar image count changes on deleting a photo from the Albums mode
