### PR TITLE
Fix: App crash on opening photos from the all photos list

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -252,10 +252,11 @@ public class SingleMediaActivity extends SharedMediaActivity {
             mViewPager.setOnPageChangeListener(new PagerRecyclerView.OnPageChangeListener() {
                 @Override
                 public void onPageChanged(int oldPosition, int position) {
+                    current_image_pos = position;
                     getAlbum().setCurrentPhotoIndex(position);
                     toolbar.setTitle((position + 1) + " " + getString(R.string.of) + " " + size_all);
                     invalidateOptionsMenu();
-                    pathForDescription = getAlbum().getMedia().get(position).getPath();
+                    pathForDescription = LFMainActivity.listAll.get(position).getPath();
                 }
             });
             mViewPager.scrollToPosition(all_photo_pos);


### PR DESCRIPTION
Fix #1063 

Changes: Fixed the app crash on opening photos from the all photos list. Getting the image description from the getAlbums function was causing a null pointer exception.

