### PR TITLE
Removed ShowcaseView from the gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,7 +103,6 @@ dependencies {
     compile "com.twitter.sdk.android:twitter:$rootProject.twitterVersion"
     compile "com.android.support:support-v4:$rootProject.supportLibraryVersion"
     compile "com.facebook.stetho:stetho-okhttp3:$rootProject.stethoVersion"
-    compile "com.github.amlcurran.showcaseview:library:$rootProject.showcaseVersion"
     compile "com.github.nextcloud:android-library:$rootProject.nextCloudVersion"
     compile files('libs/twitter4j-core-3.0.5.jar')
     compile files('libs/twitter4j-media-support-3.0.5.jar')

--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Preview/Preview.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Preview/Preview.java
@@ -45,8 +45,6 @@ import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.Toast;
 
-import com.github.amlcurran.showcaseview.ShowcaseView;
-import com.github.amlcurran.showcaseview.targets.ViewTarget;
 
 import org.fossasia.phimpme.R;
 import org.fossasia.phimpme.opencamera.Camera.CameraActivity;


### PR DESCRIPTION
Fix #1074 

Changes: Since we are using MaterialShowCaseView there is no need for ShowcaseView in the Gradle.
