### PR TITLE
Fix #1087 - Update toolbar information when image is moved

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -581,6 +581,7 @@ public class SingleMediaActivity extends SharedMediaActivity {
                     @Override
                     public void folderSelected(String path) {
                         getAlbum().moveCurrentMedia(getApplicationContext(), path);
+                        getSupportActionBar().setTitle((getAlbum().getCurrentMediaIndex() + 1) + " " + getString(R.string.of) + " " + getAlbum().getMedia().size());
 
                         if (getAlbum().getMedia().size() == 0) {
                             if (customUri) finish();


### PR DESCRIPTION
Fix #1087 

Changes: Add this line after :  getAlbum().moveCurrentMedia(getApplicationContext(), path);
 getSupportActionBar().setTitle((getAlbum().getCurrentMediaIndex() + 1) + " " + getString(R.string.of) + " " + getAlbum().getMedia().size());

The toolbar info now updates when the image is moved
