### PR TITLE
Fix #1095 - Add SettingsActivity intent in AccountActivity in menu

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
@@ -13,6 +13,7 @@ import android.support.v7.widget.SwitchCompat;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.RelativeLayout;
 
@@ -47,6 +48,7 @@ import org.fossasia.phimpme.base.RecyclerItemClickListner;
 import org.fossasia.phimpme.base.ThemedActivity;
 import org.fossasia.phimpme.data.local.AccountDatabase;
 import org.fossasia.phimpme.data.local.DatabaseHelper;
+import org.fossasia.phimpme.gallery.activities.SettingsActivity;
 import org.fossasia.phimpme.share.flickr.FlickrActivity;
 import org.fossasia.phimpme.share.imgur.ImgurAuthActivity;
 import org.fossasia.phimpme.share.nextcloud.NextCloudAuth;
@@ -181,6 +183,17 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.menu_accounts_activity, menu);
         return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId())
+        {
+            case R.id.action_account_settings:
+                startActivity(new Intent(AccountActivity.this, SettingsActivity.class));
+                return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/app/src/main/res/menu/menu_accounts_activity.xml
+++ b/app/src/main/res/menu/menu_accounts_activity.xml
@@ -3,4 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="org.fossasia.phimpme.accounts.AccountAct">
 
+    <item
+        android:id="@+id/action_account_settings"
+        android:title="@string/settings"
+        app:showAsAction="never"/>
 </menu>


### PR DESCRIPTION
Fix #1095 

Changes: Add Settings to menu of AccountActivity and add intent to launch settings from there

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/22395998/30207348-debd5ba6-94ac-11e7-8b51-73a384f701e9.png)
