### PR TITLE
Fix #1099 - Open keyboard when password is prompted 

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
@@ -16,6 +16,7 @@ import android.support.v7.widget.CardView;
 import android.support.v7.widget.SwitchCompat;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.RadioButton;
@@ -346,6 +347,8 @@ public class SettingsActivity extends ThemedActivity {
         });
 
         final AlertDialog passwordDialog = passwordDialogBuilder.create();
+        passwordDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+
         passwordDialog.show();
 
         passwordDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
Fix #1099 

Changes: The keyboard is automatically opened when password is prompted for entering Security section.

Screenshots for the change: 
![21621994_1801108489917957_898263239_n](https://user-images.githubusercontent.com/22395998/30261041-51ab4cb2-96e8-11e7-8e50-587776bc3b8d.gif)

