### PR TITLE
Fix #1109 - add Fossasia contributors link

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/AboutActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/AboutActivity.java
@@ -116,7 +116,13 @@ public class AboutActivity extends ThemedActivity {
 
     private void setUpActions(){
 
-
+        //Fossasia contributors
+        findViewById(R.id.about_fossasia).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                cts.launchUrl("https://github.com/fossasia/phimpme-android/graphs/contributors");
+            }
+        });
         //GitHub
         findViewById(R.id.ll_about_support_github).setOnClickListener(new View.OnClickListener() {
             @Override


### PR DESCRIPTION
Fix #1109 

Changes: Fossasia contributors link is now working

Screenshots for the change: 
![screenshot_20170912-190114](https://user-images.githubusercontent.com/20878145/30328432-f52c99f4-97ec-11e7-9485-fd4c29aaf59c.png)
![screenshot_20170912-190132](https://user-images.githubusercontent.com/20878145/30328452-01568db6-97ed-11e7-9f22-d578982ab7b9.png)
