### PR TITLE
Fix #1121 - Toolbar does not overlap with main content.

### DIFF
--- a/app/src/main/res/layout/activity_leafpic.xml
+++ b/app/src/main/res/layout/activity_leafpic.xml
@@ -22,6 +22,7 @@
                />
         </android.support.design.widget.AppBarLayout>
         <LinearLayout
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">


### PR DESCRIPTION
Fix #1121 

Changes: Add layout_behaviour to the main content.

Screenshots for the change: 
![21744031_1804024702959669_2713146130966773760_n](https://user-images.githubusercontent.com/22395998/30417853-bf20e0dc-994e-11e7-86c7-9b7be9c43859.gif)
