### PR TITLE
Fix #1146 - App bar not coming on image selection

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -18,6 +18,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
+import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.BottomNavigationView;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.GravityCompat;
@@ -136,11 +137,11 @@ public class LFMainActivity extends SharedMediaActivity {
             Media m = (Media) v.findViewById(R.id.photo_path).getTag();
             //If first long press, turn on selection mode
             if (!all_photos) {
+                appBarOverlay();
                 if (!editMode) {
                     mediaAdapter.notifyItemChanged(getAlbum().toggleSelectPhoto(m));
                     editMode = true;
-                } else
-                    getAlbum().selectAllPhotosUpTo(getAlbum().getIndex(m), mediaAdapter);
+                } else getAlbum().selectAllPhotosUpTo(getAlbum().getIndex(m), mediaAdapter);
 
                 invalidateOptionsMenu();
             } else if (!editMode) {
@@ -162,8 +163,9 @@ public class LFMainActivity extends SharedMediaActivity {
         if (selectedMedias.size() == 0) {
             editMode = false;
             toolbar.setTitle(getString(R.string.all));
-        } else
+        } else {
             toolbar.setTitle(selectedMedias.size() + "/" + size);
+        }
         invalidateOptionsMenu();
         return getImagePosition(m.getPath());
     }
@@ -226,6 +228,7 @@ public class LFMainActivity extends SharedMediaActivity {
                 if (!pickMode) {
                     //if in selection mode, toggle the selected/unselect state of photo
                     if (editMode) {
+                        appBarOverlay();
                         mediaAdapter.notifyItemChanged(getAlbum().toggleSelectPhoto(m));
                         invalidateOptionsMenu();
                     } else {
@@ -240,7 +243,6 @@ public class LFMainActivity extends SharedMediaActivity {
                     finish();
                 }
             } else {
-
                 if (!editMode) {
                     Intent intent = new Intent(REVIEW_ACTION, Uri.fromFile(new File(m.getPath())));
                     intent.putExtra(getString(R.string.all_photo_mode), true);
@@ -248,7 +250,10 @@ public class LFMainActivity extends SharedMediaActivity {
                     intent.putExtra(getString(R.string.allMediaSize), size);
                     intent.setClass(getApplicationContext(), SingleMediaActivity.class);
                     startActivity(intent);
-                } else mediaAdapter.notifyItemChanged(toggleSelectPhoto(m));
+                } else {
+                    mediaAdapter.notifyItemChanged(toggleSelectPhoto(m));
+                }
+
             }
         }
     };
@@ -256,7 +261,6 @@ public class LFMainActivity extends SharedMediaActivity {
     private View.OnLongClickListener albumOnLongCLickListener = new View.OnLongClickListener() {
         @Override
         public boolean onLongClick(View v) {
-
             albumsAdapter.notifyItemChanged(getAlbums().toggleSelectAlbum(((Album) v.findViewById(R.id.album_name).getTag())));
             editMode = true;
             invalidateOptionsMenu();
@@ -279,6 +283,25 @@ public class LFMainActivity extends SharedMediaActivity {
             }
         }
     };
+
+    /**
+     *  Method for clearing the scroll flags.
+     */
+    private void appBarOverlay(){
+        Toolbar toolbar = (Toolbar)findViewById(R.id.toolbar);
+        AppBarLayout.LayoutParams params = (AppBarLayout.LayoutParams) toolbar.getLayoutParams();
+        params.setScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_EXIT_UNTIL_COLLAPSED);  // clear all scroll flags
+    }
+
+    /**
+     * Method for adding the scroll flags.
+     */
+    private void clearOverlay(){
+        Toolbar toolbar = (Toolbar)findViewById(R.id.toolbar);
+        AppBarLayout.LayoutParams params = (AppBarLayout.LayoutParams) toolbar.getLayoutParams();
+        params.setScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
+                | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS);
+    }
 
     public int getImagePosition(String path) {
         int pos = 0;
@@ -469,7 +492,7 @@ public class LFMainActivity extends SharedMediaActivity {
     }
 
     private void initUI() {
-
+        clearOverlay();
         /**** TOOLBAR ****/
         toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
@@ -783,6 +806,10 @@ public class LFMainActivity extends SharedMediaActivity {
 
     private void updateSelectedStuff() {
         if (albumsMode) {
+            if(getAlbums().getSelectedCount()==0)
+                clearOverlay();
+            else
+                appBarOverlay();
             if (editMode)
                 toolbar.setTitle(getAlbums().getSelectedCount() + "/" + getAlbums().dispAlbums.size());
             else {
@@ -795,10 +822,15 @@ public class LFMainActivity extends SharedMediaActivity {
                 });
             }
         } else {
+            if(getAlbum().getSelectedCount()==0)
+                clearOverlay();
+            else
+                appBarOverlay();
             if (editMode)
                 if (!all_photos)
                     toolbar.setTitle(getAlbum().getSelectedCount() + "/" + getAlbum().getMedia().size());
-                else toolbar.setTitle(selectedMedias.size() + "/" + size);
+                else {
+                    toolbar.setTitle(selectedMedias.size() + "/" + size);}
             else {
                 if (!all_photos)
                     toolbar.setTitle(getAlbum().getName());


### PR DESCRIPTION
Fix #1146 - Action bar bug fixed

Changes: Action Bar is now not scrolling up while selecting an album or image(Added two methods appBarOverlay and clearOverlay)

Screenshots for the change: 
![giphy](https://user-images.githubusercontent.com/21143936/30509068-74c0c4cc-9ac4-11e7-8fb1-cd580c419376.gif)