### PR TITLE
Fix #1155 - Fix Navigation Icon

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -814,7 +814,7 @@ public class LFMainActivity extends SharedMediaActivity {
         }
 
         if (editMode) {
-            toolbar.setNavigationIcon(getToolbarIcon(GoogleMaterial.Icon.gmd_check));
+            toolbar.setNavigationIcon(getToolbarIcon(GoogleMaterial.Icon.gmd_clear));
             toolbar.setNavigationOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {


### PR DESCRIPTION
Fix #1155 Navigation Icon now on selecting album/image(s) is a X(clear).

Changes: Changed check to clear

Screenshots for the change: 
![tempo](https://user-images.githubusercontent.com/21143936/30511942-39e5fc4a-9b01-11e7-94ad-193190b4e065.jpeg)
