### PR TITLE
Fix #1156 - Clicking navigation icon after album selection, now doesn't change toolbar title.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -173,7 +173,8 @@ public class LFMainActivity extends SharedMediaActivity {
             m.setSelected(false);
         if (selectedMedias != null)
             selectedMedias.clear();
-        toolbar.setTitle(getString(R.string.all));
+        if(localFolder) toolbar.setTitle(getString(R.string.local_folder));
+        else toolbar.setTitle(getString(R.string.hidden_folder));
     }
 
 


### PR DESCRIPTION
Fix #1156 Toolbar title is now as expected on clicking navigation icon.

Changes
Earlier On Clicking navigation icon after selecting album(s), toolbar title changes to All. Now it is working as expected.

Screenshots for the change: 
![giphy](https://user-images.githubusercontent.com/21143936/30512184-ac38caca-9b06-11e7-9048-c0270a4a2ecf.gif)

