### PR TITLE
Minimized the build warnings to zero

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
@@ -409,7 +409,7 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
     }
 
     private void signInPinterest() {
-        List scopes = new ArrayList<String>();
+        ArrayList<String> scopes = new ArrayList<String>();
         scopes.add(PDKClient.PDKCLIENT_PERMISSION_READ_PUBLIC);
         scopes.add(PDKClient.PDKCLIENT_PERMISSION_WRITE_PUBLIC);
         scopes.add(PDKClient.PDKCLIENT_PERMISSION_READ_RELATIONSHIPS);

--- a/app/src/main/java/org/fossasia/phimpme/gallery/data/HandlingAlbums.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/data/HandlingAlbums.java
@@ -97,6 +97,7 @@ public class HandlingAlbums {
     }
   }
 
+  @SuppressWarnings("unchecked")
   public static void addAlbumToBackup(final Context context, final Album album) {
     new Thread(new Runnable() {
       public void run() {
@@ -134,7 +135,7 @@ public class HandlingAlbums {
     }).start();
   }
 
-
+  @SuppressWarnings("unchecked")
   public void restoreBackup(Context context) {
     FileInputStream inStream;
     try {


### PR DESCRIPTION
Fix #1153 
Changes: 
Earlier 2 types of warnings were issued:
1) Unchecked Cast: This was caused because a variable ("o") of the type **Object** was cast into an ArrayList<String> and Android Studio isn't sure whether the casting is safe or not and so it'll always give a warning .So the only way was to suppress warnings by using **SuppressWarning** annotation at the 2 places from where the error was popping up.

2) In the second type the issue was that the code wasn't using **Generics** . So **List** type variable  had to be written as List (String) otherwise if a List object of type other than String would be added , it would give a compile time error.

Screenshots for the change: 
![warnings](https://user-images.githubusercontent.com/20684618/30523075-40a3b688-9bf8-11e7-8d90-7e2c6170cf97.png)
