### PR TITLE
Fix #1169 - Tapping on tile now auto collapse the navigation shade

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/MyTileService.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/MyTileService.java
@@ -46,6 +46,7 @@ public class MyTileService extends TileService {
         Intent intent = new Intent(this, CameraActivity.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.setAction(TILE_ID);
-        startActivity(intent);
+        /* This collapse the navigation drawer/shade, so that user is focused on the functionality */
+        startActivityAndCollapse(intent);
     }
 }

--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/MyTileServiceFrontCamera.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/MyTileServiceFrontCamera.java
@@ -46,6 +46,7 @@ public class MyTileServiceFrontCamera extends TileService {
         Intent intent = new Intent(this, CameraActivity.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.setAction(TILE_ID);
-        startActivity(intent);
+        /* This collapse the navigation drawer/shade, so that user is focused on the functionality */
+        startActivityAndCollapse(intent);
     }
 }

--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/MyTileServiceVideo.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/MyTileServiceVideo.java
@@ -46,6 +46,7 @@ public class MyTileServiceVideo extends TileService {
         Intent intent = new Intent(this, CameraActivity.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.setAction(TILE_ID);
-        startActivity(intent);
+        /* This collapse the navigation drawer/shade, so that user is focused on the functionality */
+        startActivityAndCollapse(intent);
     }
 }


### PR DESCRIPTION
Fix #1169 Navigation Shade, now auto close on tapping on quick setting tile(Camera/Selfie/Video).

Changes: Before navigation shade was not collapsing on by its own, now it is

Screenshots for the change: 
![giphy](https://user-images.githubusercontent.com/21143936/30546063-2be8a314-9ca9-11e7-882a-f535f0c6c59a.gif)
Same is with the selfie and video tile. 
