### PR TITLE
Fix #1165 - Display snackbar when media is moved and copied.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -21,6 +21,7 @@ import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.BottomNavigationView;
+import android.support.design.widget.CoordinatorLayout;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
@@ -122,6 +123,8 @@ public class LFMainActivity extends SharedMediaActivity {
     private ArrayList<Media> media;
     private ArrayList<Media> selectedMedias = new ArrayList<>();
     public boolean visible;
+
+    CoordinatorLayout coordinatorLayoutMainContent;
 
     // To handle back pressed
     boolean doubleBackToExitPressedOnce = false;
@@ -325,7 +328,7 @@ public class LFMainActivity extends SharedMediaActivity {
         super.onCreate(savedInstanceState);
         Log.e("TAG", "lfmain");
 
-
+        coordinatorLayoutMainContent = (CoordinatorLayout) findViewById(R.id.cl_main_content);
         BottomNavigationView navigationView = (BottomNavigationView)findViewById(R.id.bottombar);
 
         SP = PreferenceUtil.getInstance(getApplicationContext());
@@ -1562,7 +1565,8 @@ public class LFMainActivity extends SharedMediaActivity {
                     @Override
                     public void folderSelected(String path) {
                         swipeRefreshLayout.setRefreshing(true);
-                        if (getAlbum().moveSelectedMedia(getApplicationContext(), path) > 0) {
+                        int numberOfImagesMoved;
+                        if ((numberOfImagesMoved = getAlbum().moveSelectedMedia(getApplicationContext(), path)) > 0) {
                             if (getAlbum().getMedia().size() == 0) {
                                 getAlbums().removeCurrentAlbum();
                                 albumsAdapter.notifyDataSetChanged();
@@ -1571,6 +1575,10 @@ public class LFMainActivity extends SharedMediaActivity {
                             mediaAdapter.swapDataSet(getAlbum().getMedia());
                             finishEditMode();
                             invalidateOptionsMenu();
+                            if(numberOfImagesMoved > 1)
+                                SnackBarHandler.show(coordinatorLayoutMainContent, getString(R.string.photos_moved_successfully));
+                            else
+                                SnackBarHandler.show(coordinatorLayoutMainContent, getString(R.string.photo_moved_successfully));
                         } else requestSdCardPermissions();
 
                         swipeRefreshLayout.setRefreshing(false);
@@ -1591,6 +1599,8 @@ public class LFMainActivity extends SharedMediaActivity {
                         bottomSheetDialogFragment.dismiss();
                         if (!success)
                             requestSdCardPermissions();
+                        else
+                            SnackBarHandler.show(coordinatorLayoutMainContent, getString(R.string.copied_successfully));
                     }
                 });
                 bottomSheetDialogFragment.show(getSupportFragmentManager(), bottomSheetDialogFragment.getTag());

--- a/app/src/main/res/layout/activity_leafpic.xml
+++ b/app/src/main/res/layout/activity_leafpic.xml
@@ -6,35 +6,37 @@
     android:layout_height="match_parent"
     tools:openDrawer="start">
 
-    <android.support.design.widget.CoordinatorLayout
+    <RelativeLayout
         android:id="@+id/Relative_Album_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
         android:theme="@style/Theme.AppCompat.NoActionBar">
         <!---->
         <android.support.design.widget.AppBarLayout
+            android:id="@+id/appbar_toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
+
             <include
                 android:id="@+id/toolbar"
-                layout="@layout/toolbar"
-               />
+                layout="@layout/toolbar" />
         </android.support.design.widget.AppBarLayout>
+
         <LinearLayout
-            app:layout_behavior="@string/appbar_scrolling_view_behavior"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:layout_above="@+id/bottombar"
+            android:layout_below="@id/appbar_toolbar"
+            android:orientation="vertical"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
             <android.support.v4.widget.SwipeRefreshLayout
                 android:id="@+id/swipeRefreshLayout"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:paddingBottom="@dimen/height_bottombar" >
+                android:layout_height="match_parent">
 
-                <RelativeLayout
-                    android:id="@+id/rl_main_content"
+                <android.support.design.widget.CoordinatorLayout
+                    android:id="@+id/cl_main_content"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent">
 
@@ -53,8 +55,7 @@
                         android:id="@+id/grid_photos"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
-                        android:layout_gravity="center_horizontal"
-                        />
+                        android:layout_gravity="center_horizontal" />
 
                     <TextView
                         android:id="@+id/nothing_to_show"
@@ -68,17 +69,18 @@
                         android:textSize="18sp"
                         android:visibility="invisible"
                         tools:targetApi="lollipop" />
-                </RelativeLayout>
+                </android.support.design.widget.CoordinatorLayout>
             </android.support.v4.widget.SwipeRefreshLayout>
 
         </LinearLayout>
 
         <include
+            android:id="@+id/bottombar"
             layout="@layout/element_bottom_navigation"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="bottom" />
-    </android.support.design.widget.CoordinatorLayout>
+            android:layout_alignParentBottom="true" />
+    </RelativeLayout>
 
     <include
         android:id="@+id/drawer_items"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1007,5 +1007,8 @@
     <string name="install_facebook">Facebook not installed</string>
     <string name="restart_app">Please restart the app for better results!</string>
     <string name="press_back_again_to_exit">Press back again to exit</string>
+    <string name="photos_moved_successfully">Photos moved successfully</string>
+    <string name="photo_moved_successfully">Photo moved successfully</string>
+    <string name="copied_successfully">Copied successfully</string>
 
 </resources>


### PR DESCRIPTION
Fix #1165 

Changes: Change to CoordinatorLayout in activity_leafpic.xml so that Snackbar is displayed properly

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/22395998/30735018-2211efa4-9f9b-11e7-890a-ca089998bf3b.png)
