### PR TITLE
Fix #1190 - Prompting dialog for sharing image

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
@@ -497,9 +497,9 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
     protected void onSaveTaskDone() {
         if (mOpTimes > 0 ){
             FileUtil.albumUpdate(this, saveFilePath);
-            shareImage(saveFilePath);
+            imageSavedDialog(saveFilePath);
         }else if(mOpTimes <= 0 && requestCode == 1 ){
-            shareImage(filePath);
+            imageSavedDialog(filePath);
         }else {
             final AlertDialog.Builder discardChangesDialogBuilder = new AlertDialog.Builder(EditImageActivity.this, getDialogStyle());
             AlertDialogsHelper.getTextDialog(EditImageActivity.this, discardChangesDialogBuilder, R.string.discard_changes_header, R.string.exit_without_edit, null);
@@ -735,5 +735,32 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
                 onRedoPressed();
                 break;
         }
+    }
+
+    /**
+     * Appears when user saves the image, asking him to share the image or not.
+     * @param path - path of the image
+     */
+    private  void imageSavedDialog(final String path){
+
+        final AlertDialog.Builder imageSavedDialogBuilder = new AlertDialog.Builder(EditImageActivity.this, getDialogStyle());
+        AlertDialogsHelper.getTextDialog(EditImageActivity.this, imageSavedDialogBuilder, R.string.image_saved, R.string.share_image, null);
+        imageSavedDialogBuilder.setPositiveButton(getString(R.string.share).toUpperCase(), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                shareImage(path);
+            }
+        });
+        imageSavedDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                if(dialog != null)
+                    onBackPressed();
+
+            }
+        });
+
+        AlertDialog alertDialog = imageSavedDialogBuilder.create();
+        alertDialog.show();
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -749,7 +749,9 @@
     <string name="materialcolorpicker__errHex">Hex Code Format incorrect</string>
     <string name="materialcolorpicker__inputColor">Color:</string>
     <string name="materialcolorpicker__btnSelectColor">Select</string>
-    <string name="saving_image">save...</string>
+    <string name="saving_image">Saving...</string>
+    <string name="image_saved">Saved!</string>
+    <string name="share_image">Share this with others?</string>
     <string name="input_hint">input text ...</string>
 
     <string name="no_choose">please choose a image for edit</string>


### PR DESCRIPTION
Fix #1190 Prompting dialog to share the image.

Changes: Earlier on clicking save, the user was redirected to share the image, now he is asked first by using a dialog.

Screenshots for the change: 
![giphy](https://user-images.githubusercontent.com/21143936/30743653-31fe6610-9fbc-11e7-9267-85be59dc9711.gif)

Please review @anantprsd5 @mohitmanuja @vinaysajjanapu 