### PR TITLE
Fix: #1143 Navigation bar color issue

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
@@ -251,7 +251,7 @@ public class SettingsActivity extends ThemedActivity {
 
         /*** SW COLORED NAV BAR ***/
         swNavBar = (SwitchCompat) findViewById(R.id.SetColoredNavBar);
-        swNavBar.setChecked(SP.getBoolean(getString(R.string.preference_colored_nav_bar), false));
+        swNavBar.setChecked(SP.getBoolean(getString(R.string.preference_colored_nav_bar), true));
         swNavBar.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {


### PR DESCRIPTION
**Fix #1143**

**Changes:**
*Modifies a simple boolean logic  
Now app starts with colored nav bar and in settings, colored-nav-bar option is also enabled.*  

**Screenshots for the change:**

>Nav color is blue and option is also enabled by default when app start for the very first time
<img src="https://i.imgur.com/Fbix05K.png" width="200" >  

>Disabling nav bar color option still works fine
<img src="https://i.imgur.com/L8Ar8S3.png" width="200">
