### PR TITLE
Fix #1206 - Dialog title

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
@@ -502,7 +502,7 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
             imageSavedDialog(filePath);
         }else {
             final AlertDialog.Builder discardChangesDialogBuilder = new AlertDialog.Builder(EditImageActivity.this, getDialogStyle());
-            AlertDialogsHelper.getTextDialog(EditImageActivity.this, discardChangesDialogBuilder, R.string.discard_changes_header, R.string.exit_without_edit, null);
+            AlertDialogsHelper.getTextDialog(EditImageActivity.this, discardChangesDialogBuilder, R.string.no_changes_made, R.string.exit_without_edit, null);
             discardChangesDialogBuilder.setPositiveButton(getString(R.string.confirm).toUpperCase(), new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1012,5 +1012,6 @@
     <string name="photos_moved_successfully">Photos moved successfully</string>
     <string name="photo_moved_successfully">Photo moved successfully</string>
     <string name="copied_successfully">Copied successfully</string>
+    <string name="no_changes_made">No Changes Made!</string>
 
 </resources>


### PR DESCRIPTION
Fix #1206 

Changes: Earlier on saving an image, without editing dialog appears, with a title, "discard changes" though no changes were made, now its title is "No Changes Made!"

Screenshots for the change: 

![temp](https://user-images.githubusercontent.com/21143936/30794292-f7fa1fa6-a1e4-11e7-824b-1b914109c891.jpeg)

