### PR TITLE
Fix #1204-Generate Unsigned release APK.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ script:
   - ./copy_opencv.sh
   - ./gradlew build
   - ./gradlew build connectedAndroidTest --stacktrace
+  - ./gradlew assembleRelease
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Fix #1204 

Changes: Add to .travis.yml
./gradlew assembleRelease 
