### PR TITLE
Fixes #1218, corrected badges orientation

### DIFF
--- a/_static/fossasia.css
+++ b/_static/fossasia.css
@@ -169,3 +169,11 @@ table > thead > tr > th {
 table > tbody > tr:nth-of-type(2n+1) {
     background-color: #f9f9f9;
 }
+
+.badges {
+    display: flex;
+}
+
+.badges > a {
+    margin: 5px;
+}

--- a/index.html
+++ b/index.html
@@ -164,7 +164,11 @@ filters, editing images and uploading them to social networks.</p>
 <div class="line"><br /></div>
 <div class="line"><br /></div>
 </div>
-<p><a class="reference external" href="https://travis-ci.org/fossasia/phimpme-android"><img alt="Build Status" src="https://travis-ci.org/fossasia/phimpme-android.svg?branch=master" /></a> <a class="reference external" href="https://codecov.io/gh/fossasia/phimpme-android"><img alt="codecov" src="https://codecov.io/gh/fossasia/phimpme-android/branch/master/graph/badge.svg" /></a> <a class="reference external" href="https://www.codacy.com/app/harshithdwivedi/phimpme-android?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=fossasia/phimpme-android&amp;utm_campaign=Badge_Grade"><img alt="Codacy Badge" src="https://api.codacy.com/project/badge/Grade/4584003e734343b3b8ce94bcae6e9ca4" /></a></p>
+<div class="badges">
+  <a class="reference external" href="https://travis-ci.org/fossasia/phimpme-android"><img alt="Build Status" src="https://travis-ci.org/fossasia/phimpme-android.svg?branch=master" /></a>
+  <a class="reference external" href="https://codecov.io/gh/fossasia/phimpme-android"><img alt="codecov" src="https://codecov.io/gh/fossasia/phimpme-android/branch/master/graph/badge.svg" /></a>
+  <a class="reference external" href="https://www.codacy.com/app/harshithdwivedi/phimpme-android?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=fossasia/phimpme-android&amp;utm_campaign=Badge_Grade"><img alt="Codacy Badge" src="https://api.codacy.com/project/badge/Grade/4584003e734343b3b8ce94bcae6e9ca4" /></a>
+</div>
 <div class="section" id="communication">
 <h2>Communication<a class="headerlink" href="#communication" title="Permalink to this headline">¶</a></h2>
 <p>Join Gitter channel: <a class="reference external" href="https://gitter.im/fossasia/phimpme">https://gitter.im/fossasia/phimpme</a></p>


### PR DESCRIPTION
Fix #1218 

Changes: 
Corrected badges orientation in gh-page.

Screenshots for the change: 
![c32369](https://user-images.githubusercontent.com/21009455/30914181-65d6668e-a3b0-11e7-84f7-0de2a0f024b5.png)
