### PR TITLE
Fixes #1219, Use phimpme logo as gh-page favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" />
   <link rel="stylesheet" href="_static/fossasia.css" type="text/css" />
   <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
+  <link href="./_images/logo.png" rel="icon" type="image/x-icon">
   <script type="text/javascript">
     var DOCUMENTATION_OPTIONS = {
       URL_ROOT:    './',


### PR DESCRIPTION
Fix #1219 

Changes: Used phimpme logo as the page favicon.

Screenshots for the change: 
![150651728656407](https://user-images.githubusercontent.com/21009455/30914559-bbcbdc08-a3b1-11e7-8664-5d3a98b0b7c1.png)
