### PR TITLE
Fix #1215 - Keyboard issue with Hidden Folders

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -770,6 +770,7 @@ public class LFMainActivity extends SharedMediaActivity {
                     passwordDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
 
                     final AlertDialog passwordDialog = passwordDialogBuilder.create();
+                    passwordDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
                     passwordDialog.show();
 
                     passwordDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View


### PR DESCRIPTION
Fix #1215 

Changes: Keyboard now comes automatically when user clicks on a password protected hidden folders

Screenshots for the change: 
![giphy](https://user-images.githubusercontent.com/21143936/30928697-e94c0590-a3d9-11e7-8233-b78579a526e4.gif)

