### PR TITLE
Fixes #1222 Bottom navbar hides when albums or photos are selected

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -112,7 +112,7 @@ public class LFMainActivity extends SharedMediaActivity {
     private Toolbar toolbar;
     private SelectAlbumBottomSheet bottomSheetDialogFragment;
     private SwipeRefreshLayout swipeRefreshLayout;
-    private boolean hidden = false, pickMode = false, editMode = false, albumsMode = true, firstLaunch = true,localFolder=true;
+    private boolean hidden = false, pickMode = false, editMode = false, albumsMode = true, firstLaunch = true,localFolder=true,hidenav=false;
 
     //To handle all photos/Album conditions
     public boolean all_photos = false;
@@ -143,6 +143,8 @@ public class LFMainActivity extends SharedMediaActivity {
         public boolean onLongClick(View v) {
             Media m = (Media) v.findViewById(R.id.photo_path).getTag();
             //If first long press, turn on selection mode
+            hideNavigationBar();
+            hidenav=true;
             if (!all_photos) {
                 appBarOverlay();
                 if (!editMode) {
@@ -169,6 +171,7 @@ public class LFMainActivity extends SharedMediaActivity {
                 selectedMedias.remove(m);
         }
         if (selectedMedias.size() == 0) {
+            getNavigationBar();
             editMode = false;
             toolbar.setTitle(getString(R.string.all));
         } else {
@@ -239,6 +242,9 @@ public class LFMainActivity extends SharedMediaActivity {
                     if (editMode) {
                         appBarOverlay();
                         mediaAdapter.notifyItemChanged(getAlbum().toggleSelectPhoto(m));
+                        if(selectedMedias.size()==0)
+                            getNavigationBar();
+
                         invalidateOptionsMenu();
                     } else {
                         getAlbum().setCurrentPhotoIndex(m);
@@ -273,6 +279,8 @@ public class LFMainActivity extends SharedMediaActivity {
             albumsAdapter.notifyItemChanged(getAlbums().toggleSelectAlbum(((Album) v.findViewById(R.id.album_name).getTag())));
             editMode = true;
             invalidateOptionsMenu();
+            hideNavigationBar();
+            hidenav=true;
             return true;
         }
     };
@@ -284,6 +292,8 @@ public class LFMainActivity extends SharedMediaActivity {
             //int index = Integer.parseInt(v.findViewById(R.id.album_name).getTag().toString());
             if (editMode) {
                 albumsAdapter.notifyItemChanged(getAlbums().toggleSelectAlbum(album));
+                if(getAlbums().getSelectedCount()==0)
+                    getNavigationBar();
                 invalidateOptionsMenu();
             } else {
                 getAlbums().setCurrentAlbum(album);
@@ -545,6 +555,7 @@ public class LFMainActivity extends SharedMediaActivity {
         swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
             public void onRefresh() {
+                getNavigationBar();
                 if (albumsMode) {
                     getAlbums().clearSelectedAlbums();
                     new PrepareAlbumTask().execute();
@@ -875,6 +886,7 @@ public class LFMainActivity extends SharedMediaActivity {
             toolbar.setNavigationOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
+                    getNavigationBar();
                     finishEditMode();
                     clearSelectedPhotos();
                 }
@@ -1012,7 +1024,7 @@ public class LFMainActivity extends SharedMediaActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-
+        getNavigationBar();
         switch (item.getItemId()) {
 
             case R.id.all_photos:
@@ -1116,6 +1128,7 @@ public class LFMainActivity extends SharedMediaActivity {
                 return true;
 
             case R.id.delete_action:
+                getNavigationBar();
                 class DeletePhotos extends AsyncTask<String, Integer, Boolean> {
                     @Override
                     protected void onPreExecute() {
@@ -1740,6 +1753,13 @@ public class LFMainActivity extends SharedMediaActivity {
             return null;
         }
     }
+    public void getNavigationBar() {
+        if(editMode && hidenav)
+        {
+            navigationView.setVisibility(View.VISIBLE);
+            hidenav=false;
+        }
+    }
 
     /**
      * If we are in albumsMode, make the albums recyclerView visible. If we are not, make media recyclerView visible.
@@ -1764,6 +1784,7 @@ public class LFMainActivity extends SharedMediaActivity {
     public void onBackPressed() {
         if(editMode && all_photos)
             clearSelectedPhotos();
+        getNavigationBar();
         if (editMode) finishEditMode();
         else {
             if (albumsMode) {


### PR DESCRIPTION
Fix #1222 

Changes: BottomNavigationBar is hidden when the user selects albums or photos and becomes again visible when the user presses the back button ,deselects all the selected media or clicks on any menu item.

Screenshots for the change: 

![ezgif com-video-to-gif 7](https://user-images.githubusercontent.com/20878145/30930150-5b7cc2cc-a3de-11e7-8b87-13b9f64503d1.gif)
