### PR TITLE
Fixes #1228 create new folder will not make folders with no name

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/SelectAlbumBottomSheet.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/SelectAlbumBottomSheet.java
@@ -22,6 +22,7 @@ import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.mikepenz.community_material_typeface_library.CommunityMaterial;
 import com.mikepenz.iconics.view.IconicsImageView;
@@ -128,9 +129,24 @@ public class SelectAlbumBottomSheet extends BottomSheetDialogFragment {
 		builder.setPositiveButton(R.string.ok_action, new DialogInterface.OnClickListener() {
 		  @Override
 		  public void onClick(DialogInterface dialogInterface, int i) {
+              int folderCount=folders.size();
+              int check=1;
+              int filePosition=0;
+              while (filePosition<folderCount) {
+                  File f = folders.get(filePosition);
+                  filePosition++;
+                  if (editText.getText().toString().equals(f.getName()))
+                      check=0;
+              }
+              if(!editText.getText().toString().trim().isEmpty() && check!=0) {
 			File folderPath = new File(currentFolderPath.getText().toString() + File.separator + editText.getText().toString());
 			if (folderPath.mkdir()) displayContentFolder(folderPath);
+              }
+              else if(check==0)
+                  Toast.makeText(getContext(),R.string.folder_name_exists,Toast.LENGTH_SHORT).show();
 
+              else
+                  Toast.makeText(getContext(),R.string.empty_folder_name,Toast.LENGTH_SHORT).show();
 		  }
 		});
 		builder.show();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -855,6 +855,8 @@
     <string name="feature_not_present">Feature not present</string>
     <string name="sharedrupal">Drupal Account</string>
     <string name="drupal_link">Account not found</string>
+    <string name="empty_folder_name">Folder name cannot be empty</string>
+    <string name="folder_name_exists">Folder name already exists</string>
 
     <!--Imgur -->
     <string name="imgur">Imgur</string>


### PR DESCRIPTION
Fix #1228 

Changes: Folders with no name or folders which already exist will not be created instead the user will get a toast message
Screenshots for the change: 
![ezgif com-video-to-gif 8](https://user-images.githubusercontent.com/20878145/30955078-0febc1ce-a450-11e7-8cda-91f86da1b497.gif)
