### PR TITLE
Fix #1235 resolution is given in megapixels too

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/data/MetadataItem.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/data/MetadataItem.java
@@ -165,8 +165,9 @@ class MetadataItem {
   }
 
   public String getResolution() {
+    float resolution=(float)(getWidth() *getHeight())/1000000; // 1MP is 1 million pixels
     if(width !=-1 && height != -1)
-      return String.format("%dx%d", getWidth(), getHeight());
+        return String.format("%dx%d (%.1f MP)", getWidth(), getHeight(),resolution);
     return null;
   }
 


### PR DESCRIPTION
Fix #1235 
Changes: Details dialog will show resolution in Megapixels also
Screenshots for the change: 
![screenshot_20170929-155412](https://user-images.githubusercontent.com/20878145/31012271-d1924f26-a52e-11e7-8bff-4e76c94a1cda.png)
