### PR TITLE
Fix#1237 App doesn't crash on selecting filter

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/RecyclerMenuFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/RecyclerMenuFragment.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.SimpleItemAnimator;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -235,14 +236,21 @@ public class RecyclerMenuFragment extends BaseEditFragment {
 
         private void highlightSelectedOption(int position, View v) {
             int color = ContextCompat.getColor(v.getContext(), R.color.md_grey_200);
-            if(currentSelection != -1)
-                ((mRecyclerAdapter.mViewHolder) recyclerView.findViewHolderForAdapterPosition(currentSelection))
-                        .wrapper
-                        .setBackgroundColor(Color.TRANSPARENT);
+
+            if(currentSelection != position){
+                notifyItemChanged(currentSelection);
+                ((SimpleItemAnimator) recyclerView.getItemAnimator()).setSupportsChangeAnimations(false);
+            }
+
+            if(currentSelection != -1 && recyclerView.findViewHolderForAdapterPosition(currentSelection) != null) {
+                    ((mRecyclerAdapter.mViewHolder) recyclerView.findViewHolderForAdapterPosition(currentSelection))
+                            .wrapper
+                            .setBackgroundColor(Color.TRANSPARENT);
+            }
 
             ((mViewHolder) recyclerView.findViewHolderForAdapterPosition(position))
-                    .wrapper
-                    .setBackgroundColor(color);
+                 .wrapper
+                 .setBackgroundColor(color);
 
             currentSelection = position;
         }


### PR DESCRIPTION
Fix #1237 

Changes: 
Earlier the app was crashing after we selected a certain filter and then without applying it selected another filter by scrolling the horizontal recycler view to the right.This problem had arised because of the use of findViewHolderForAdapterPosition() returned null as the colour Transparent was being applied on a viewholder which wasn't present on the screen after scrolling.