### PR TITLE
Fix #1266-Hint visible along with underline below text property

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/share/SharingActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/share/SharingActivity.java
@@ -612,7 +612,10 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
         final EditText captionEditText = new EditText(this);
         AlertDialogsHelper.getInsertTextDialog(SharingActivity.this, captionDialogBuilder, captionEditText, R.string.caption_head ,null);
         captionDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
-        captionEditText.setBackground(null);
+        captionEditText.setHint(R.string.description_hint);
+        captionEditText.setHintTextColor(getResources().getColor(R.color.grey, null));
+        captionEditText.setSelectAllOnFocus(true);
+        captionEditText.selectAll();
         captionEditText.setSingleLine(false);
         if(caption!=null) {
             captionEditText.setText(caption);


### PR DESCRIPTION
Fix #1266 

Changes: Hint visible along with underline below text property.

Screenshots for the change: 
![screenshot_2017-10-03-21-12-32-766_org fossasia phimpme](https://user-images.githubusercontent.com/20841578/31134744-a35dd918-a880-11e7-8809-a201389be243.png)
