### PR TITLE
Fix #1279 - Add save option to discard changes dialog.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
@@ -687,6 +687,12 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
                         dialog.dismiss();
                 }
             });
+            discardChangesDialogBuilder.setNeutralButton(getString(R.string.save_action).toUpperCase(), new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    doSaveImage();
+                }
+            });
 
             AlertDialog alertDialog = discardChangesDialogBuilder.create();
             alertDialog.show();


### PR DESCRIPTION
Fix #1279 

Changes: Add option to save in the discard changes warning dialog

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/22395998/31216108-f8c68ada-a9cf-11e7-8a7c-9b2c1dec1268.png)
