### PR TITLE
Fix #1265 Paint doesn't cross the photo boundary

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/PaintFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/PaintFragment.java
@@ -148,6 +148,8 @@ public class PaintFragment extends BaseEditFragment implements View.OnClickListe
     public void onShow() {
         activity.changeMode(EditImageActivity.MODE_PAINT);
         activity.mainImage.setImageBitmap(activity.mainBitmap);
+        activity.mPaintView.mainBitmap=activity.mainBitmap;
+        activity.mPaintView.mainImage=activity.mainImage;
         this.mPaintView.setVisibility(View.VISIBLE);
     }
 

--- a/app/src/main/java/org/fossasia/phimpme/editor/view/CustomPaintView.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/view/CustomPaintView.java
@@ -12,6 +12,7 @@ import android.support.annotation.RequiresApi;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
+import org.fossasia.phimpme.editor.view.imagezoom.ImageViewTouch;
 
 /**
  * Created by panyi on 17/2/11.
@@ -30,6 +31,9 @@ public class CustomPaintView extends View {
 
     private int mColor;
 
+    public Bitmap mainBitmap;
+    public ImageViewTouch mainImage;
+    private float leftX,rightX,topY,bottomY;
     public CustomPaintView(Context context) {
         super(context);
         init(context);
@@ -54,7 +58,12 @@ public class CustomPaintView extends View {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-        //System.out.println("width = "+getMeasuredWidth()+"     height = "+getMeasuredHeight());
+        int displayW=mainBitmap.getWidth()*getMeasuredHeight()/mainBitmap.getHeight();
+        int displayH=mainBitmap.getHeight()*getMeasuredWidth()/mainBitmap.getWidth();
+        leftX=(mainImage.getMeasuredWidth()-displayW)>>1;
+        rightX=leftX+displayW;
+        topY=(mainImage.getMeasuredHeight()-displayH)>>1;
+        bottomY=topY+displayH;
         if (mDrawBit == null) {
             generatorBit();
         }
@@ -98,6 +107,7 @@ public class CustomPaintView extends View {
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
         if (mDrawBit != null) {
+            canvas.clipRect(leftX,topY,rightX,bottomY);
             canvas.drawBitmap(mDrawBit, 0, 0, null);
         }
     }


### PR DESCRIPTION
Fix #1265

Changes:
The canvas size which was too large earlier is now clipped to the photo on which editing is to be done.

Screenshots for the change: 
As shown in the image shown below , it is still in editing mode and the paint doesn't go outside the image.

@mohitmanuja @anantprsd5 Kindly review the P.R Thankyou! 
![image 19](https://user-images.githubusercontent.com/20684618/31315859-94875cea-ac3e-11e7-9f61-736794594949.jpg)
