### PR TITLE
Fixes #1277 Disable swipeRefreshLayout on item selection

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -882,9 +882,12 @@ public class LFMainActivity extends SharedMediaActivity {
             if(getAlbums().getSelectedCount()==0) {
                 clearOverlay();
                 checkForReveal = true;
+                swipeRefreshLayout.setEnabled(true);
             }
-            else
+            else {
                 appBarOverlay();
+                swipeRefreshLayout.setEnabled(false);
+            }
             if (editMode)
                 toolbar.setTitle(getAlbums().getSelectedCount() + "/" + getAlbums().dispAlbums.size());
             else {
@@ -903,9 +906,12 @@ public class LFMainActivity extends SharedMediaActivity {
             if(getAlbum().getSelectedCount()==0) {
                 clearOverlay();
                 checkForReveal = true;
+                swipeRefreshLayout.setEnabled(true);
             }
-            else
+            else {
                 appBarOverlay();
+                swipeRefreshLayout.setEnabled(false);
+            }
             if (editMode)
                 if (!all_photos)
                     toolbar.setTitle(getAlbum().getSelectedCount() + "/" + getAlbum().getMedia().size());


### PR DESCRIPTION
Fix #1277

Changes: When any item(s) is selected, then swipe to refresh is disabled, and as soon as the total item selected = 0, swipeRefreshLayout is enabled again.

Screenshots for the change: 
![giphy](https://user-images.githubusercontent.com/21143936/31319647-ec58779c-ac84-11e7-8203-639c87a7cd45.gif)

