### PR TITLE
Fix #1307 check if the album name is same

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1667,6 +1667,7 @@ public class LFMainActivity extends SharedMediaActivity {
                 AlertDialog.Builder renameDialogBuilder = new AlertDialog.Builder(LFMainActivity.this, getDialogStyle());
                 final EditText editTextNewName = new EditText(getApplicationContext());
                 editTextNewName.setText(albumsMode ? getAlbums().getSelectedAlbum(0).getName() : getAlbum().getName());
+                final String albumName=albumsMode ? getAlbums().getSelectedAlbum(0).getName() : getAlbum().getName();
 
                 AlertDialogsHelper.getInsertTextDialog(LFMainActivity.this, renameDialogBuilder,
                         editTextNewName, R.string.rename_album, null);
@@ -1688,15 +1689,21 @@ public class LFMainActivity extends SharedMediaActivity {
                 renameDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View dialog) {
+                        boolean rename=false;
                         if (editTextNewName.length() != 0) {
                             swipeRefreshLayout.setRefreshing(true);
                             boolean success = false;
                             if (albumsMode) {
-                                int index = getAlbums().dispAlbums.indexOf(getAlbums().getSelectedAlbum(0));
-                                getAlbums().getAlbum(index).updatePhotos(getApplicationContext());
-                                success = getAlbums().getAlbum(index).renameAlbum(getApplicationContext(),
-                                        editTextNewName.getText().toString());
-                                albumsAdapter.notifyItemChanged(index);
+                                if (!editTextNewName.getText().toString().equals(albumName)) {
+                                    int index = getAlbums().dispAlbums.indexOf(getAlbums().getSelectedAlbum(0));
+                                    getAlbums().getAlbum(index).updatePhotos(getApplicationContext());
+                                    success = getAlbums().getAlbum(index).renameAlbum(getApplicationContext(),
+                                            editTextNewName.getText().toString());
+                                    albumsAdapter.notifyItemChanged(index);
+                                } else {
+                                    SnackBarHandler.show(mDrawerLayout, getString(R.string.rename_no_change));
+                                    rename = true;
+                                }
                             } else {
                                 success = getAlbum().renameAlbum(getApplicationContext(), editTextNewName.getText().toString());
                                 toolbar.setTitle(getAlbum().getName());
@@ -1707,7 +1714,7 @@ public class LFMainActivity extends SharedMediaActivity {
                                 SnackBarHandler.show(getWindow().getDecorView().getRootView(), getString(R.string.rename_succes));
                                 getAlbums().clearSelectedAlbums();
                                 invalidateOptionsMenu();
-                            } else {
+                            } else if(!rename){
                                 SnackBarHandler.show(getWindow().getDecorView().getRootView(), getString(R.string.rename_error));
                                 requestSdCardPermissions();
                             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -414,6 +414,7 @@
 
     <string name="rename_error">File Rename Failed</string>
     <string name="rename_succes">File renamed</string>
+    <string name="rename_no_change">No change in file name</string>
 
     <!-- ACTIONS -->
     <string name="sort">Sort</string>


### PR DESCRIPTION
Fix #1307 

Changes: There will be a snackbar message if the album name is already same and internally it will not make a new file. Now if you rename phimp.me camera with the same name and click a new picture , it will get added to the same folder.

Screenshots for the change: 
![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/20878145/31349414-d25f0916-ad40-11e7-90a2-c6475a333e19.gif)
