### PR TITLE
Fix #1322 - Add animation for bottom navigation bar visibility changes.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/base/BaseActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/base/BaseActivity.java
@@ -1,5 +1,7 @@
 package org.fossasia.phimpme.base;
 
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.ColorStateList;
@@ -162,8 +164,38 @@ public abstract class BaseActivity extends AppCompatActivity implements BottomNa
         navigationView.setBackgroundColor(color);
         setIconColor(color);
     }
-    public void hideNavigationBar() {
-        navigationView.setVisibility(View.GONE);
+
+    /**
+     * Animate bottom navigation bar from GONE to VISIBLE
+     */
+    public void showNavigationBar() {
+        navigationView.animate()
+                .translationY(0)
+                .alpha(1.0f)
+                .setDuration(400)
+                .setListener(new AnimatorListenerAdapter() {
+                    @Override
+                    public void onAnimationStart(Animator animation) {
+                        super.onAnimationStart(animation);
+                        navigationView.setVisibility(View.VISIBLE);
+                    }
+                });
     }
 
+    /**
+     * Animate bottom navigation bar from VISIBLE to GONE
+     */
+    public void hideNavigationBar() {
+        navigationView.animate()
+                .alpha(0.0f)
+                .translationYBy(navigationView.getHeight())
+                .setDuration(400)
+                .setListener(new AnimatorListenerAdapter() {
+                    @Override
+                    public void onAnimationEnd(Animator animation) {
+                        super.onAnimationEnd(animation);
+                        navigationView.setVisibility(View.GONE);
+                    }
+                });
+    }
 }

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -719,7 +719,6 @@ public class LFMainActivity extends SharedMediaActivity {
         else{
             toolbar.setTitle(getString(R.string.hidden_folder));
         }
-
         /**** SWIPE TO REFRESH ****/
         swipeRefreshLayout.setColorSchemeColors(getAccentColor());
         swipeRefreshLayout.setProgressBackgroundColorSchemeColor(getBackgroundColor());
@@ -1676,9 +1675,9 @@ public class LFMainActivity extends SharedMediaActivity {
                             finishEditMode();
                             invalidateOptionsMenu();
                             if(numberOfImagesMoved > 1)
-                                SnackBarHandler.show(coordinatorLayoutMainContent, getString(R.string.photos_moved_successfully));
+                                SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.photos_moved_successfully), navigationView.getHeight());
                             else
-                                SnackBarHandler.show(coordinatorLayoutMainContent, getString(R.string.photo_moved_successfully));
+                                SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.photo_moved_successfully), navigationView.getHeight());
                         } else requestSdCardPermissions();
 
                         swipeRefreshLayout.setRefreshing(false);
@@ -1700,7 +1699,7 @@ public class LFMainActivity extends SharedMediaActivity {
                         if (!success)
                             requestSdCardPermissions();
                         else
-                            SnackBarHandler.show(coordinatorLayoutMainContent, getString(R.string.copied_successfully));
+                            SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.copied_successfully), navigationView.getHeight());
                     }
                 });
                 bottomSheetDialogFragment.show(getSupportFragmentManager(), bottomSheetDialogFragment.getTag());
@@ -1850,7 +1849,7 @@ public class LFMainActivity extends SharedMediaActivity {
     public void getNavigationBar() {
         if(editMode && hidenav)
         {
-            navigationView.setVisibility(View.VISIBLE);
+            showNavigationBar();
             hidenav=false;
         }
     }

--- a/app/src/main/java/org/fossasia/phimpme/utilities/SnackBarHandler.java
+++ b/app/src/main/java/org/fossasia/phimpme/utilities/SnackBarHandler.java
@@ -3,6 +3,7 @@ package org.fossasia.phimpme.utilities;
 import android.graphics.Color;
 import android.support.design.widget.Snackbar;
 import android.view.View;
+import android.widget.FrameLayout;
 import android.widget.TextView;
 
 /**
@@ -30,6 +31,29 @@ public class SnackBarHandler  {
         snackbar.show();
     }
 
+    public static void showWithBottomMargin(View view, String text,int bottomMargin, int duration) {
+        final Snackbar snackbar = Snackbar.make(view, text, duration);
+        View sbView = snackbar.getView();
+        final FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) sbView.getLayoutParams();
+        params.setMargins(params.leftMargin,
+                params.topMargin,
+                params.rightMargin,
+                params.bottomMargin + bottomMargin);
+        sbView.setLayoutParams(params);
+
+        TextView textView = (TextView) sbView.findViewById(android.support.design.R.id
+                .snackbar_text);
+        textView.setTextColor(Color.WHITE);
+        textView.setTextSize(12);
+        snackbar.setAction("OK", new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                snackbar.dismiss();
+            }
+        });
+        snackbar.show();
+    }
+
     public static void show(View view, int res, int duration) {
         show(view, ActivitySwitchHelper.getContext().getResources().getString(res), duration);
     }
@@ -40,5 +64,17 @@ public class SnackBarHandler  {
 
     public static void show(View view, int res) {
         show(view, ActivitySwitchHelper.getContext().getResources().getString(res));
+    }
+
+    public static void showWithBottomMargin(View view, int res, int duration, int bottomMargin) {
+        showWithBottomMargin(view, ActivitySwitchHelper.getContext().getResources().getString(res), bottomMargin, duration);
+    }
+
+    public static void showWithBottomMargin(View view, String text, int bottomMargin) {
+        showWithBottomMargin(view, text, bottomMargin, Snackbar.LENGTH_LONG);
+    }
+
+    public static void showWithBottomMargin(View view, int res, int bottomMargin) {
+        showWithBottomMargin(view, ActivitySwitchHelper.getContext().getResources().getString(res), bottomMargin);
     }
 }

--- a/app/src/main/res/layout/activity_leafpic.xml
+++ b/app/src/main/res/layout/activity_leafpic.xml
@@ -6,10 +6,10 @@
     android:layout_height="match_parent"
     tools:openDrawer="start">
 
-    <RelativeLayout
-        android:id="@+id/Relative_Album_layout"
+    <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/cl_main_content"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:theme="@style/Theme.AppCompat.NoActionBar">
         <!---->
         <android.support.design.widget.AppBarLayout
@@ -22,66 +22,73 @@
                 layout="@layout/toolbar" />
         </android.support.design.widget.AppBarLayout>
 
-        <LinearLayout
+        <android.support.v4.widget.NestedScrollView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_above="@+id/bottombar"
-            android:layout_below="@id/appbar_toolbar"
-            android:orientation="vertical"
+            android:layout_height="match_parent"
+            android:fillViewport="true"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-            <android.support.v4.widget.SwipeRefreshLayout
-                android:id="@+id/swipeRefreshLayout"
+            <FrameLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
-                <android.support.design.widget.CoordinatorLayout
-                    android:id="@+id/cl_main_content"
+                <android.support.v4.widget.SwipeRefreshLayout
+                    android:id="@+id/swipeRefreshLayout"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent">
 
-                    <android.support.v7.widget.RecyclerView
-                        android:id="@+id/grid_albums"
+                    <RelativeLayout
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:layout_gravity="center_horizontal"
                         android:clipToPadding="false"
                         android:scrollbarThumbVertical="@drawable/ic_scrollbar"
-                        android:scrollbars="vertical"
-                        />
+                        android:scrollbars="vertical">
 
-                    <android.support.v7.widget.RecyclerView
-                        android:id="@+id/grid_photos"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:layout_gravity="center_horizontal"
-                        android:scrollbarThumbVertical="@drawable/ic_scrollbar"
-                        android:scrollbars="vertical"/>
+                        <android.support.v7.widget.RecyclerView
+                            android:id="@+id/grid_photos"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:layout_gravity="center_horizontal"
+                            android:paddingBottom="@dimen/height_bottombar"
+                            android:scrollbarThumbVertical="@drawable/ic_scrollbar"
+                            android:scrollbars="vertical" />
 
-                    <TextView
-                        android:id="@+id/nothing_to_show"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_centerInParent="true"
-                        android:elevation="12dp"
-                        android:gravity="center"
-                        android:text="@string/there_is_nothing_to_show"
-                        android:textColor="@color/md_white_1000"
-                        android:textSize="18sp"
-                        android:visibility="invisible"
-                        tools:targetApi="lollipop" />
-                </android.support.design.widget.CoordinatorLayout>
-            </android.support.v4.widget.SwipeRefreshLayout>
+                        <android.support.v7.widget.RecyclerView
+                            android:id="@+id/grid_albums"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:clipToPadding="false"
+                            android:paddingBottom="@dimen/height_bottombar"
+                            android:scrollbarThumbVertical="@drawable/ic_scrollbar"
+                            android:scrollbars="vertical" />
 
-        </LinearLayout>
+                        <TextView
+                            android:id="@+id/nothing_to_show"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_centerInParent="true"
+                            android:elevation="12dp"
+                            android:gravity="center"
+                            android:text="@string/there_is_nothing_to_show"
+                            android:textColor="@color/md_white_1000"
+                            android:textSize="18sp"
+                            android:visibility="invisible"
+                            tools:targetApi="lollipop" />
+
+                    </RelativeLayout>
+                </android.support.v4.widget.SwipeRefreshLayout>
+            </FrameLayout>
+        </android.support.v4.widget.NestedScrollView>
 
         <include
             android:id="@+id/bottombar"
             layout="@layout/element_bottom_navigation"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true" />
-    </RelativeLayout>
+            android:layout_gravity="bottom"
+            app:elevation="4dp" />
+    </android.support.design.widget.CoordinatorLayout>
 
     <include
         android:id="@+id/drawer_items"

--- a/app/src/main/res/layout/element_bottom_navigation.xml
+++ b/app/src/main/res/layout/element_bottom_navigation.xml
@@ -4,7 +4,8 @@
     android:id="@+id/bottombar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/white70"
+    android:background="@null"
+    android:animateLayoutChanges="true"
     app:menu="@menu/navigation" />
 
 


### PR DESCRIPTION
Fix #1322 

Changes: Add methods in the base activity to animate fade in and fade out for bottom navigation bar.
Also fixed the toolbar scrolling issue.
Add new method in snackback handler for a snackbar with bottom margin

Screenshots for the change: 
![22163252_1832982473397225_9009999770986479616_n](https://user-images.githubusercontent.com/22395998/31514596-b80c471a-afaf-11e7-8389-7b9aabe8a5f3.gif)
