### PR TITLE
Fixes #1372 Bottom nav hidden

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -270,7 +270,7 @@ public class LFMainActivity extends SharedMediaActivity {
                     if (editMode) {
                         appBarOverlay();
                         mediaAdapter.notifyItemChanged(getAlbum().toggleSelectPhoto(m));
-                        if(selectedMedias.size()==0)
+                        if(getAlbum().selectedMedias.size()==0)
                             getNavigationBar();
 
                         invalidateOptionsMenu();

--- a/app/src/main/java/org/fossasia/phimpme/gallery/data/Album.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/data/Album.java
@@ -43,7 +43,7 @@ public class Album implements Serializable {
 	public AlbumSettings settings = null;
 
 	private ArrayList<Media> media;
-	private ArrayList<Media> selectedMedias;
+	public ArrayList<Media> selectedMedias;
 
     private int selectedCount;
 


### PR DESCRIPTION
Fix #1372 

Changes: Bottom Navigation View remains hidden when photos are selected and is visible when all photos are deselected.

Screenshots for the change: 

![20171020_173051](https://user-images.githubusercontent.com/25134501/31821404-a8042b1c-b5c2-11e7-8bce-e25e50022bca.gif)
