### PR TITLE
Fix #1370 - Moving or deleting preview image is reflected in the album.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/data/Album.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/data/Album.java
@@ -44,8 +44,25 @@ public class Album implements Serializable {
 
 	private ArrayList<Media> media;
 	public ArrayList<Media> selectedMedias;
-
+	private boolean isPreviewSelected;
+	private String previewPath;
     private int selectedCount;
+
+	public void setPreviewPath(String previewPath) {
+		this.previewPath = previewPath;
+	}
+
+	public String getPreviewPath() {
+		return previewPath;
+	}
+
+	public boolean isPreviewSelected() {
+		return isPreviewSelected;
+	}
+
+	public void setPreviewSelected(boolean previewSelected) {
+		isPreviewSelected = previewSelected;
+	}
 
 	private Album() {
 		media = new ArrayList<Media>();
@@ -59,6 +76,7 @@ public class Album implements Serializable {
 		this.count = count;
 		this.id = id;
 		settings = AlbumSettings.getSettings(context, this);
+		setPreviewPath(getCoverPath());
 	}
 
 	public Album(Context context, @NotNull File mediaPath) {
@@ -254,11 +272,18 @@ public class Album implements Serializable {
 
 	public void removeCoverAlbum(Context context) {
 		settings.changeCoverPath(context, null);
+		setPreviewSelected(false);
+		setPreviewPath(null);
 	}
 
 	public void setSelectedPhotoAsPreview(Context context) {
 		if (selectedMedias.size() > 0)
 			settings.changeCoverPath(context, selectedMedias.get(0).getPath());
+		setPreviewPath(getCoverPath());
+	}
+
+	public String getCoverPath() {
+		return settings.getCoverPath();
 	}
 
 	private void setCurrentPhoto(String path) {
@@ -287,10 +312,16 @@ public class Album implements Serializable {
 	private int toggleSelectPhoto(int index) {
 		if (media.get(index) != null) {
 			media.get(index).setSelected(!media.get(index).isSelected());
-			if (media.get(index).isSelected())
+			if (media.get(index).isSelected()) {
 				selectedMedias.add(media.get(index));
-			else
+				if(getPreviewPath() != null && getPreviewPath().equals(media.get(index).getPath()))
+					setPreviewSelected(true);
+			}
+			else {
 				selectedMedias.remove(media.get(index));
+				if(getPreviewPath() != null && getPreviewPath().equals(media.get(index).getPath()))
+					setPreviewSelected(false);
+			}
 		}
 		return index;
 	}
@@ -312,6 +343,8 @@ public class Album implements Serializable {
 			if (success = moveMedia(context, from, targetDir)) {
 				scanFile(context, new String[]{ from, StringUtils.getPhotoPathMoved(getCurrentMedia().getPath(), targetDir) });
 				media.remove(getCurrentMediaIndex());
+				if(getPreviewPath() != null && from.equals(getPreviewPath()))
+					removeCoverAlbum(context);
 				setCount(media.size());
 			}
 		} catch (Exception e) { e.printStackTrace(); }
@@ -334,6 +367,8 @@ public class Album implements Serializable {
 										}
 									});
 					media.remove(selectedMedias.get(i));
+					if(getPreviewPath() != null && from.equals(getPreviewPath()))
+						removeCoverAlbum(context);
 					n++;
 				}
 			}
@@ -386,6 +421,8 @@ public class Album implements Serializable {
 					if (!media.get(index).isSelected()) {
 						media.get(index).setSelected(true);
 						selectedMedias.add(media.get(index));
+						if(getPreviewPath() != null && media.get(index).equals(getPreviewPath()))
+							setPreviewSelected(true);
 						adapter.notifyItemChanged(index);
 					}
 				}
@@ -400,6 +437,7 @@ public class Album implements Serializable {
 			m.setSelected(false);
 		if (selectedMedias!=null)
 		selectedMedias.clear();
+		setPreviewSelected(false);
 	}
 
 	public void sortPhotos() {
@@ -430,6 +468,8 @@ public class Album implements Serializable {
 		boolean success = deleteMedia(context, getCurrentMedia());
 		if (success) {
 			media.remove(getCurrentMediaIndex());
+			if(getPreviewPath() != null && getCurrentMedia().getPath().equals(getPreviewPath()))
+				removeCoverAlbum(context);
 			setCount(media.size());
 		}
 		return success;
@@ -438,8 +478,11 @@ public class Album implements Serializable {
 	private boolean deleteMedia(Context context, Media media) {
 		boolean success;
 		File file = new File(media.getPath());
-		if (success = ContentHelper.deleteFile(context, file))
-			scanFile(context, new String[]{ file.getAbsolutePath() });
+		if (success = ContentHelper.deleteFile(context, file)) {
+			scanFile(context, new String[]{file.getAbsolutePath()});
+			if(getPreviewPath() != null && media.getPath().equals(getPreviewPath()))
+				removeCoverAlbum(context);
+		}
 		return success;
 	}
 
@@ -457,6 +500,8 @@ public class Album implements Serializable {
 			if (deleteMedia(context, selectedMedia))
 				media.remove(selectedMedia);
 			else success = false;
+			if(getPreviewPath() != null && selectedMedia.getPath().equals(getPreviewPath()))
+				removeCoverAlbum(context);
 		}
 		if (success) {
 			clearSelectedPhotos();


### PR DESCRIPTION
Fix #1370 

Changes: Add `previewPath` and `isPreviewSelected` properties to **Album**.
Whenever an image is moved or deleted check if it is the preview image. If yes then clear the preview for the album.

Screenshots for the change: 
Actually the whole sequence cannot be properly covered in a GIF so how should I share the screen recording?