### PR TITLE
Fix #1385 bottom nav bar is now visible when no album is selected

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -311,8 +311,13 @@ public class LFMainActivity extends SharedMediaActivity {
             albumsAdapter.notifyItemChanged(getAlbums().toggleSelectAlbum(((Album) v.findViewById(R.id.album_name).getTag())));
             editMode = true;
             invalidateOptionsMenu();
-            hideNavigationBar();
-            hidenav=true;
+            if(getAlbums().getSelectedCount()==0)
+                getNavigationBar();
+            else
+            {
+                hideNavigationBar();
+                hidenav=true;
+            }
             return true;
         }
     };


### PR DESCRIPTION
Fix #1385 

Changes:if we deselect an album by long pressing it ,the bottom navigation bar does not get hidden

Screenshots for the change: 
![ezgif com-video-to-gif 7](https://user-images.githubusercontent.com/20878145/31875211-b51b4afe-b7ea-11e7-879e-c6c63e36ab31.gif)
