### PR TITLE
Fix#1396 Sharing via Whatsapp bug

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/share/SharingActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/share/SharingActivity.java
@@ -408,8 +408,7 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
                 uploadHistory.setStatus("FAIL");
                 realm.commitTransaction();
             }
-        }
-        else {
+        } else {
             Intent result = new Intent();
             result.putExtra(Constants.SHARE_RESULT, code);
             setResult(RESULT_OK, result);
@@ -824,6 +823,7 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
     }
 
     private void shareToWhatsapp() {
+        triedUploading=false;
         Uri uri = Uri.fromFile(new File(saveFilePath));
         Intent share = new Intent(Intent.ACTION_SEND);
         share.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
@@ -1055,8 +1055,10 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
                 return;
         }
         if (requestCode == SHARE_WHATSAPP) {
-            if(responseCode == -1)
+            if(responseCode == RESULT_OK) {
+                triedUploading=true;
                 sendResult(SUCCESS);
+            }
             else
                 sendResult(FAIL);
         }


### PR DESCRIPTION
Fix #1396 

Changes: The boolean **triedUploading** was set to false while sharing via whatsapp . If the result status after sharing was RESULT_OK then **triedUploading** was set to true.

@anantprsd5 @mohitmanuja Kindly review!