### PR TITLE
Fix #1405 app does not crash on delete

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1339,7 +1339,6 @@ public class LFMainActivity extends SharedMediaActivity {
                         } else new DeletePhotos().execute();
                     }
                 });
-                deleteDialog.show();
                 AlertDialog alertDialogDelete = deleteDialog.create();
                 alertDialogDelete.show();
                 AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, getAccentColor(), alertDialogDelete);


### PR DESCRIPTION
Fix #1405 

Changes: app doesn't crash when an album is deleted

Screenshots for the change: 
![ezgif com-video-to-gif 10](https://user-images.githubusercontent.com/20878145/31998981-525f4d9a-b9af-11e7-8044-8fbd077c6892.gif)
