### PR TITLE
Fix #1412: Upload History reversed

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
@@ -58,7 +58,9 @@ public class UploadHistory extends ThemedActivity {
         uploadHistoryAdapter = new UploadHistoryAdapter(getPrimaryColor());
         realm = Realm.getDefaultInstance();
         uploadResults = realm.where(UploadHistoryRealmModel.class);
-        RecyclerView.LayoutManager layoutManager = new LinearLayoutManager(this);
+        LinearLayoutManager layoutManager = new LinearLayoutManager(this);
+        layoutManager.setReverseLayout(true);
+        layoutManager.setStackFromEnd(true);
         uploadHistoryRecyclerView.setLayoutManager(layoutManager);
         uploadHistoryRecyclerView.setAdapter(uploadHistoryAdapter);
         uploadHistoryAdapter.setResults(uploadResults);


### PR DESCRIPTION
Fix #1412 
Changes: Now the latest changes can be seen at the top of upload history.

Screenshots for the change: 
Take a look at the time!
![image 28](https://user-images.githubusercontent.com/20684618/32007755-151514b0-b9c8-11e7-9e24-37d26a39409b.jpg)

