### PR TITLE
Fix #1411 affix dialog has coloured buttons

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1651,7 +1651,10 @@ public class LFMainActivity extends SharedMediaActivity {
                     }
                 });
                 builder.setNegativeButton(this.getString(R.string.cancel).toUpperCase(), null);
-                builder.show();
+
+                AlertDialog affixDialog = builder.create();
+                affixDialog.show();
+                AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, getAccentColor(), affixDialog);
 
 
                 return true;


### PR DESCRIPTION
Fix #1411

Changes: affix dialog has coloured buttons
![screenshot_20171026-000111](https://user-images.githubusercontent.com/20878145/32016402-7e3b0df0-b9e1-11e7-9824-dedb71be89d5.png)

Screenshots for the change: 
