### PR TITLE
Fixes 1421 Action button color changed to accent color

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1987,7 +1987,8 @@ public class LFMainActivity extends SharedMediaActivity {
                                     public void onClick(View view) {
                                      finishAffinity();
                                     }
-                                });
+                                })
+                                .setActionTextColor(getAccentColor());
                         snackbar.show();
 
                         new Handler().postDelayed(new Runnable() {

--- a/app/src/main/java/org/fossasia/phimpme/utilities/SnackBarHandler.java
+++ b/app/src/main/java/org/fossasia/phimpme/utilities/SnackBarHandler.java
@@ -6,6 +6,8 @@ import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
+import org.fossasia.phimpme.gallery.util.ThemeHelper;
+
 /**
  * Created by pa1pal on 16/7/17.
  */
@@ -17,6 +19,7 @@ public class SnackBarHandler  {
 
     public static void show(View view, String text, int duration) {
         final Snackbar snackbar = Snackbar.make(view, text, duration);
+        ThemeHelper themeHelper=new ThemeHelper(ActivitySwitchHelper.getContext());
         View sbView = snackbar.getView();
         TextView textView = (TextView) sbView.findViewById(android.support.design.R.id
                 .snackbar_text);
@@ -28,10 +31,12 @@ public class SnackBarHandler  {
                 snackbar.dismiss();
             }
         });
+        snackbar.setActionTextColor(themeHelper.getAccentColor());
         snackbar.show();
     }
 
     public static void showWithBottomMargin(View view, String text,int bottomMargin, int duration) {
+        ThemeHelper themeHelper=new ThemeHelper(ActivitySwitchHelper.getContext());
         final Snackbar snackbar = Snackbar.make(view, text, duration);
         View sbView = snackbar.getView();
         final FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) sbView.getLayoutParams();
@@ -51,6 +56,7 @@ public class SnackBarHandler  {
                 snackbar.dismiss();
             }
         });
+        snackbar.setActionTextColor(themeHelper.getAccentColor());
         snackbar.show();
     }
 


### PR DESCRIPTION
Fix #1421 

Changes: Color of action button of snackbar changed to Accent color.

Screenshots for the change: 
![screenshot_20171026-144503](https://user-images.githubusercontent.com/25134501/32046583-1e6d1f32-ba61-11e7-8a98-c17d673b6f94.jpg)
