### PR TITLE
Fix #1424 correct snackbar message is displayed on renaming

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1760,9 +1760,14 @@ public class LFMainActivity extends SharedMediaActivity {
                                     rename = true;
                                 }
                             } else {
-                                success = getAlbum().renameAlbum(getApplicationContext(), editTextNewName.getText().toString());
-                                toolbar.setTitle(getAlbum().getName());
-                                mediaAdapter.notifyDataSetChanged();
+                                if (!editTextNewName.getText().toString().equals(albumName)) {
+                                    success = getAlbum().renameAlbum(getApplicationContext(), editTextNewName.getText().toString());
+                                    toolbar.setTitle(getAlbum().getName());
+                                    mediaAdapter.notifyDataSetChanged();
+                                } else {
+                                    SnackBarHandler.show(coordinatorLayoutMainContent, getString(R.string.rename_no_change));
+                                    rename = true;
+                                }
                             }
                             renameDialog.dismiss();
                             if (success) {

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1796,7 +1796,7 @@ public class LFMainActivity extends SharedMediaActivity {
                                     toolbar.setTitle(getAlbum().getName());
                                     mediaAdapter.notifyDataSetChanged();
                                 } else {
-                                    SnackBarHandler.show(coordinatorLayoutMainContent, getString(R.string.rename_no_change));
+                                    SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.rename_no_change), navigationView.getHeight());
                                     rename = true;
                                 }
                             }


### PR DESCRIPTION
Fix #1424 

Changes: Correct snackbar message is displayed when an album is renamed with the same name(after opening an album)


Screenshots for the change: 

![ezgif com-video-to-gif 13](https://user-images.githubusercontent.com/20878145/32072571-a4aa9940-bab0-11e7-9ebf-5d86b08f191b.gif)



