### PR TITLE
Fix #1432-Added cancel button in the create folder dialog

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/SelectAlbumBottomSheet.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/SelectAlbumBottomSheet.java
@@ -16,10 +16,14 @@ import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.text.Editable;
 import android.text.Html;
+import android.text.TextUtils;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.LinearLayout;
@@ -125,11 +129,12 @@ public class SelectAlbumBottomSheet extends BottomSheetDialogFragment {
 	  @Override
 	  public void onClick(View view) {
           final EditText editText = new EditText(getContext());
-          InputMethodManager inputMethodManager = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
-          inputMethodManager.toggleSoftInput(InputMethodManager.SHOW_FORCED, InputMethodManager.HIDE_IMPLICIT_ONLY);
+          editText.setHint(R.string.description_hint);
+          editText.setHintTextColor(ContextCompat.getColor(getContext(), R.color.grey));
           AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), theme.getDialogStyle());
           AlertDialogsHelper.getInsertTextDialog(((ThemedActivity) getActivity()), builder,
                   editText, R.string.new_folder, null);
+          builder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
 		builder.setPositiveButton(R.string.ok_action, new DialogInterface.OnClickListener() {
 		  @Override
 		  public void onClick(DialogInterface dialogInterface, int i) {
@@ -153,7 +158,44 @@ public class SelectAlbumBottomSheet extends BottomSheetDialogFragment {
                   Toast.makeText(getContext(),R.string.empty_folder_name,Toast.LENGTH_SHORT).show();
 		  }
 		});
-		builder.show();
+          final AlertDialog dialog1 = builder.create();
+          dialog1.show();
+		  AlertDialogsHelper.setButtonTextColor(new int[]{AlertDialog.BUTTON_POSITIVE, AlertDialog.BUTTON_NEGATIVE},
+		  theme.getAccentColor(), dialog1);
+          dialog1.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE | WindowManager
+                  .LayoutParams.FLAG_ALT_FOCUSABLE_IM);
+          dialog1.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+          dialog1.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+		  AlertDialogsHelper.setButtonTextColor(new int[]{AlertDialog.BUTTON_POSITIVE},
+				  getResources().getColor(R.color.grey, null), dialog1);
+          editText.addTextChangedListener(new TextWatcher() {
+              @Override public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+				  //empty method body
+
+              }
+
+              @Override public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+				  //empty method body
+
+              }
+
+              @Override public void afterTextChanged(Editable editable) {
+                  if (TextUtils.isEmpty(editable)) {
+                      // Disable ok button
+                      dialog1.getButton(
+                              AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+					  AlertDialogsHelper.setButtonTextColor(new int[]{AlertDialog.BUTTON_POSITIVE},
+							  getResources().getColor(R.color.grey, null), dialog1);
+                  } else {
+                      // Something into edit text. Enable the button.
+                      dialog1.getButton(
+                              AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+					  AlertDialogsHelper.setButtonTextColor(new int[]{AlertDialog.BUTTON_POSITIVE},
+							  theme.getAccentColor(), dialog1);
+                  }
+
+              }
+          });
 	  }
 	});
 

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -38,7 +38,10 @@ import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.SwitchCompat;
 import android.support.v7.widget.Toolbar;
+import android.text.Editable;
 import android.text.Html;
+import android.text.TextUtils;
+import android.text.TextWatcher;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -1767,6 +1770,8 @@ public class LFMainActivity extends SharedMediaActivity {
                 final EditText editTextNewName = new EditText(getApplicationContext());
                 editTextNewName.setText(albumsMode ? getAlbums().getSelectedAlbum(0).getName() : getAlbum().getName());
                 editTextNewName.setSelectAllOnFocus(true);
+                editTextNewName.setHint(R.string.description_hint);
+                editTextNewName.setHintTextColor(ContextCompat.getColor(getApplicationContext(), R.color.grey));
                 editTextNewName.setHighlightColor(ContextCompat.getColor(getApplicationContext(), R.color.cardview_shadow_start_color));
                 editTextNewName.selectAll();
                 editTextNewName.setSingleLine(false);
@@ -1788,7 +1793,37 @@ public class LFMainActivity extends SharedMediaActivity {
                 renameDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_IS_FORWARD_NAVIGATION);
                 editTextNewName.setSelection(editTextNewName.getText().toString().length());
                 renameDialog.show();
-                AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, getAccentColor(), renameDialog);
+                AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface
+                        .BUTTON_NEGATIVE}, getAccentColor(), renameDialog);
+                renameDialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+                AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE}, getColor(R.color.grey), renameDialog);
+                editTextNewName.addTextChangedListener(new TextWatcher() {
+                    @Override public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                        //empty method body
+                    }
+
+                    @Override public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                        //empty method body
+
+                    }
+
+                    @Override public void afterTextChanged(Editable editable) {
+                        if (TextUtils.isEmpty(editable)) {
+                            // Disable ok button
+                            renameDialog.getButton(
+                                    AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+                            AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE}, getColor(R.color.grey), renameDialog);
+
+                        } else {
+                            // Something into edit text. Enable the button.
+                            renameDialog.getButton(
+                                    AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+                            AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE}, getAccentColor(),
+                                    renameDialog);
+                        }
+
+                    }
+                });
                 renameDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View dialog) {

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -31,6 +31,9 @@ import android.support.v7.widget.ActionMenuView;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.Toolbar;
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.TextWatcher;
 import android.transition.ChangeBounds;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -751,10 +754,42 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
 
                 final AlertDialog descriptionDialog = descriptionDialogBuilder.create();
                 descriptionDialog.show();
-                AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, getAccentColor(), descriptionDialog);
+                AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface
+                        .BUTTON_NEGATIVE}, getAccentColor(), descriptionDialog);
                 descriptionDialog.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE|WindowManager
                         .LayoutParams.FLAG_ALT_FOCUSABLE_IM);
                 descriptionDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+                descriptionDialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+                AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE},
+                        getColor(R.color.grey), descriptionDialog);
+                editTextDescription.addTextChangedListener(new TextWatcher() {
+                    @Override public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                        //empty method body
+
+                    }
+
+                    @Override public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                        //empty method body
+
+                    }
+
+                    @Override public void afterTextChanged(Editable editable) {
+                        if (TextUtils.isEmpty(editable)) {
+                            // Disable ok button
+                            descriptionDialog.getButton(
+                                    AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+                            AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE},
+                                    getColor(R.color.grey), descriptionDialog);
+                        } else {
+                            // Something into edit text. Enable the button.
+                            descriptionDialog.getButton(
+                                    AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+                            AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE},
+                                    getAccentColor(), descriptionDialog);
+                        }
+
+                    }
+                });
                 
                 descriptionDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
                     @Override

--- a/app/src/main/java/org/fossasia/phimpme/share/SharingActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/share/SharingActivity.java
@@ -21,6 +21,9 @@ import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
 import android.view.WindowManager;
@@ -675,7 +678,39 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
         final AlertDialog passwordDialog = captionDialogBuilder.create();
         passwordDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
         passwordDialog.show();
-        AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, getAccentColor(), passwordDialog);
+        AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface
+                .BUTTON_NEGATIVE}, getAccentColor(), passwordDialog);
+        passwordDialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+        AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE}, getColor(R.color.grey),
+                passwordDialog);
+        captionEditText.addTextChangedListener(new TextWatcher() {
+            @Override public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                //empty method body
+
+            }
+
+            @Override public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                //empty method body
+
+            }
+
+            @Override public void afterTextChanged(Editable editable) {
+                if (TextUtils.isEmpty(editable)) {
+                    // Disable ok button
+                    passwordDialog.getButton(
+                            AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+                    AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE},
+                            getColor(R.color.grey), passwordDialog);
+                } else {
+                    // Something into edit text. Enable the button.
+                    passwordDialog.getButton(
+                            AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+                    AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE},
+                            getAccentColor(), passwordDialog);
+                }
+
+            }
+        });
         passwordDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {


### PR DESCRIPTION
Fix #1432 

Changes: Cancel button is added to the dialog. Now on opening any of the dialoges the Ok button will appear disabled at first and will be enabled only if the user updates the text in the edittext.
