### PR TITLE
Fix #1446-Appropriate message is displayed for description and Exif a…

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -775,9 +775,21 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                         imgResolution.setText(mediaDetailsMap.get("Resolution"));
                         imgPath.setText(mediaDetailsMap.get("Path").toString());
                         imgOrientation.setText(mediaDetailsMap.get("Orientation"));
-                        imgDesc.setText(mediaDetailsMap.get("Description"));
-                        imgExif.setText(mediaDetailsMap.get("EXIF"));
-                        imgLocation.setText(mediaDetailsMap.get("Location").toString());
+                         if(mediaDetailsMap.get("Description") == null) {
+                             imgDesc.setText(R.string.no_description);
+                         } else{
+                             imgDesc.setText(mediaDetailsMap.get("Description"));
+                         }
+                         if(mediaDetailsMap.get("EXIF") == null){
+                             imgExif.setText(R.string.no_exif_data);
+                         } else {
+                             imgExif.setText(mediaDetailsMap.get("EXIF"));
+                         }
+                         if(mediaDetailsMap.get("Location") == null){
+                             imgLocation.setText(R.string.no_location);
+                         } else{
+                             imgLocation.setText(mediaDetailsMap.get("Location").toString());
+                         }
                     }
                     catch (Exception e){
                         //Raised if null values is found, no need to handle

--- a/app/src/main/res/layout/image_description.xml
+++ b/app/src/main/res/layout/image_description.xml
@@ -112,9 +112,8 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:text="No Location"
-                android:id="@+id/image_desc_loc"
                 android:textColor="@color/md_grey_500"
+                android:id="@+id/image_desc_loc"
                 android:textSize="@dimen/medium_text"/>
 
         </LinearLayout>
@@ -296,6 +295,8 @@
                     <TextView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:textSize="@dimen/medium_text"
+                        android:textColor="@color/md_grey_500"
                         android:id="@+id/image_desc_exif"
                         android:layout_marginLeft="5dp"/>
 
@@ -318,6 +319,8 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:id="@+id/image_desc"
+                        android:textSize="@dimen/medium_text"
+                        android:textColor="@color/md_grey_500"
                         android:layout_marginLeft="5dp"/>
 
                 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -694,6 +694,9 @@
     <string name="device">Device</string>
     <string name="orientation">Orientation</string>
     <string name="location">Location</string>
+    <string name="no_description">No description added.</string>
+    <string name="no_location">No location</string>
+    <string name="no_exif_data">No data found.</string>
 
     <!--ALBUM DETAILS-->
     <string name="total_photos">Total photos</string>


### PR DESCRIPTION
…ttributes

Fix #1446 

Changes: Appropriate message is displayed for Exif and description attributes.

Screenshots for the change: 
![screenshot_2017-10-31-02-46-56-224_org fossasia phimpme](https://user-images.githubusercontent.com/20841578/32196167-c8edf7e2-bde5-11e7-9dc2-9f918c76d02e.png)
