### PR TITLE
Fix #1431 snackbar messages are now visible

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -51,6 +51,7 @@ import android.view.WindowManager;
 import android.webkit.MimeTypeMap;
 import android.widget.CompoundButton;
 import android.widget.EditText;
+import android.widget.FrameLayout;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.ScrollView;
@@ -708,7 +709,8 @@ public class LFMainActivity extends SharedMediaActivity {
                 // Persist URI in shared preference so that you can use it later.
                 ContentHelper.saveSdCardInfo(getApplicationContext(), treeUri);
                 getContentResolver().takePersistableUriPermission(treeUri, Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-                SnackBarHandler.show(coordinatorLayoutMainContent, R.string.got_permission_wr_sdcard);
+                SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.got_permission_wr_sdcard), 0);
+
             }
         }
     }
@@ -870,7 +872,7 @@ public class LFMainActivity extends SharedMediaActivity {
                                 new PrepareAlbumTask().execute();
                                 passwordDialog.dismiss();
                             } else {
-                                SnackBarHandler.show(coordinatorLayoutMainContent, R.string.wrong_password);
+                                SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.wrong_password), 0);
                                 editTextPassword.getText().clear();
                                 editTextPassword.requestFocus();
                             }
@@ -1357,7 +1359,7 @@ public class LFMainActivity extends SharedMediaActivity {
                                     }
                                     // if password is incorrect, don't delete and notify user of incorrect password
                                     else {
-                                        SnackBarHandler.show(coordinatorLayoutMainContent, R.string.wrong_password);
+                                        SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.wrong_password), navigationView.getHeight());
                                         editTextPassword.getText().clear();
                                         editTextPassword.requestFocus();
                                     }
@@ -1563,7 +1565,8 @@ public class LFMainActivity extends SharedMediaActivity {
                         else runOnUiThread(new Runnable() {
                             @Override
                             public void run() {
-                                SnackBarHandler.show(coordinatorLayoutMainContent, R.string.affix_error);
+                                SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.affix_error), navigationView.getHeight());
+
                             }
                         });
                         return null;
@@ -1751,7 +1754,8 @@ public class LFMainActivity extends SharedMediaActivity {
                         }
                         if(getAlbum().getSelectedMedia().size() == 0){
                             bottomSheetDialogFragment.dismiss();
-                            SnackBarHandler.show(coordinatorLayoutMainContent, getString(R.string.photos_already_there));
+                            SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.photos_already_there), navigationView.getHeight());
+
                         }
                         else{
                             boolean success = getAlbum().copySelectedPhotos(getApplicationContext(), path);
@@ -1760,7 +1764,7 @@ public class LFMainActivity extends SharedMediaActivity {
                             if (!success)
                                 requestSdCardPermissions();
                             else
-                                SnackBarHandler.show(coordinatorLayoutMainContent, getString(R.string.copied_successfully));
+                                SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.copied_successfully), navigationView.getHeight());
                         }
                     }
 
@@ -1842,7 +1846,7 @@ public class LFMainActivity extends SharedMediaActivity {
                                             editTextNewName.getText().toString());
                                     albumsAdapter.notifyItemChanged(index);
                                 } else {
-                                    SnackBarHandler.show(coordinatorLayoutMainContent, getString(R.string.rename_no_change));
+                                    SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.rename_no_change), navigationView.getHeight());
                                     rename = true;
                                 }
                             } else {
@@ -1857,16 +1861,16 @@ public class LFMainActivity extends SharedMediaActivity {
                             }
                             renameDialog.dismiss();
                             if (success) {
-                                SnackBarHandler.show(coordinatorLayoutMainContent, getString(R.string.rename_succes));
+                                SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.rename_succes), navigationView.getHeight());
                                 getAlbums().clearSelectedAlbums();
                                 invalidateOptionsMenu();
                             } else if(!rename){
-                                SnackBarHandler.show(coordinatorLayoutMainContent, getString(R.string.rename_error));
+                                SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.rename_error), navigationView.getHeight());
                                 requestSdCardPermissions();
                             }
                             swipeRefreshLayout.setRefreshing(false);
                         } else {
-                            SnackBarHandler.show(coordinatorLayoutMainContent, R.string.insert_something);
+                            SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.insert_something), navigationView.getHeight());
                             editTextNewName.requestFocus();
                         }
                     }
@@ -2016,7 +2020,7 @@ public class LFMainActivity extends SharedMediaActivity {
                     {
                         doubleBackToExitPressedOnce = true;
                         Snackbar snackbar = Snackbar
-                                .make(coordinatorLayoutMainContent, R.string.press_back_again_to_exit, Snackbar.LENGTH_LONG)
+                                .make(mDrawerLayout, R.string.press_back_again_to_exit, Snackbar.LENGTH_LONG)
                                 .setAction(R.string.exit, new View.OnClickListener() {
                                     @Override
                                     public void onClick(View view) {
@@ -2024,6 +2028,13 @@ public class LFMainActivity extends SharedMediaActivity {
                                     }
                                 })
                                 .setActionTextColor(getAccentColor());
+                        View sbView = snackbar.getView();
+                        final FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) sbView.getLayoutParams();
+                        params.setMargins(params.leftMargin,
+                                params.topMargin,
+                                params.rightMargin,
+                                params.bottomMargin + navigationView.getHeight());
+                        sbView.setLayoutParams(params);
                         snackbar.show();
 
                         new Handler().postDelayed(new Runnable() {


### PR DESCRIPTION
Fix #1431 

Changes: snackbar messages are now visible in LFMainActivity

Screenshots for the change: 
![screenshot_20171031-230202](https://user-images.githubusercontent.com/20878145/32239246-0b260e9c-be90-11e7-9ed0-725706250080.png)
![screenshot_20171031-225831](https://user-images.githubusercontent.com/20878145/32239248-0c536314-be90-11e7-8e95-f12d221367f5.png)
