### PR TITLE
Fix #1371 - Pinning or Unpinning album clears selection mode.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1185,8 +1185,8 @@ public class LFMainActivity extends SharedMediaActivity {
                 getAlbums().getSelectedAlbum(0).settings.togglePin(getApplicationContext());
                 getAlbums().sortAlbums(getApplicationContext());
                 getAlbums().clearSelectedAlbums();
-                albumsAdapter.swapDataSet(getAlbums().dispAlbums);
                 invalidateOptionsMenu();
+                albumsAdapter.notifyDataSetChanged();
                 return true;
 
             case R.id.settings:


### PR DESCRIPTION
Fix #1371 

Changes: Clear selection when album is pinned or un-pinned

Screenshots for the change: 
![22551335_1853348788027260_5504657947453554688_n](https://user-images.githubusercontent.com/22395998/32273316-f7027b60-bf27-11e7-8db0-e8c4aa5cb47e.gif)
