### PR TITLE
Fix #1387 - Improve UI of details screen.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,8 @@ android {
         ndk {
             abiFilters 'armeabi-v7a','x86'
         }
+        renderscriptTargetApi 19
+        renderscriptSupportModeEnabled true
     }
 
     buildTypes {

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -13,6 +13,7 @@ import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.PorterDuff;
+import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
@@ -70,6 +71,7 @@ import org.fossasia.phimpme.gallery.data.AlbumSettings;
 import org.fossasia.phimpme.gallery.data.Media;
 import org.fossasia.phimpme.gallery.data.base.MediaDetailsMap;
 import org.fossasia.phimpme.gallery.util.AlertDialogsHelper;
+import org.fossasia.phimpme.gallery.util.BlurImageUtil;
 import org.fossasia.phimpme.gallery.util.ColorPalette;
 import org.fossasia.phimpme.gallery.util.ContentHelper;
 import org.fossasia.phimpme.gallery.util.Measure;
@@ -742,10 +744,14 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
             case R.id.action_details:
                 handler.removeCallbacks(slideShowRunnable);
                 details=true;
-                View v = getLayoutInflater().inflate(R.layout.image_description,mViewPager,false);
+                final View v = getLayoutInflater().inflate(R.layout.image_description,mViewPager,false);
                 LinearLayout linearLayout = (LinearLayout)v;
                 Media media = getAlbum().getCurrentMedia();
                 MediaDetailsMap<String,String> mediaDetailsMap = media.getMainDetails(this);
+
+                // Set current image as a blurred background
+                Bitmap blurBackground = BlurImageUtil.blur(context, BitmapFactory.decodeFile(media.getPath()));
+                v.setBackground(new BitmapDrawable(getResources(), blurBackground));
 
                 /* Getting all the viewgroups and views of the image description layout */
 
@@ -761,13 +767,12 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 TextView  imgDesc = (TextView) linearLayout.findViewById(R.id.image_desc);
                 ImageButton imgBack = (ImageButton) linearLayout.findViewById(R.id.img_desc_back_arrow);
 
-                LinearLayout linearLayoutTop = (LinearLayout) linearLayout.findViewById(R.id.image_desc_top);
-                linearLayoutTop.setBackgroundColor(this.getPrimaryColor());
-
                 imgBack.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
                         setContentView(parentView);
+                        details = false;
+                        toggleSystemUI();
                     }
                 });
 
@@ -800,6 +805,8 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                     catch (Exception e){
                         //Raised if null values is found, no need to handle
                     }
+
+                toggleSystemUI();
                 setContentView(v);
                 break;
 
@@ -1057,6 +1064,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
     public void onBackPressed() {
         if (details) {
             setContentView(parentView);
+            toggleSystemUI();
             details = false;
         } else
             super.onBackPressed();

--- a/app/src/main/java/org/fossasia/phimpme/gallery/util/BlurImageUtil.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/util/BlurImageUtil.java
@@ -1,0 +1,49 @@
+package org.fossasia.phimpme.gallery.util;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.support.v8.renderscript.Allocation;
+import android.support.v8.renderscript.Element;
+import android.support.v8.renderscript.RenderScript;
+import android.support.v8.renderscript.ScriptIntrinsicBlur;
+import android.view.View;
+
+/**
+ * Created by mayank on 3/11/17.
+ */
+
+public class BlurImageUtil {
+    private static final float BITMAP_SCALE = 0.1f;
+    private static final float BLUR_RADIUS = 7.5f;
+
+    public static Bitmap blur(View v) {
+        return blur(v.getContext(), getScreenshot(v));
+    }
+
+    public static Bitmap blur(Context ctx, Bitmap image) {
+        int width = Math.round(image.getWidth() * BITMAP_SCALE);
+        int height = Math.round(image.getHeight() * BITMAP_SCALE);
+
+        Bitmap inputBitmap = Bitmap.createScaledBitmap(image, width, height, false);
+        Bitmap outputBitmap = Bitmap.createBitmap(inputBitmap);
+
+        RenderScript rs = RenderScript.create(ctx);
+        ScriptIntrinsicBlur theIntrinsic = ScriptIntrinsicBlur.create(rs, Element.U8_4(rs));
+        Allocation tmpIn = Allocation.createFromBitmap(rs, inputBitmap);
+        Allocation tmpOut = Allocation.createFromBitmap(rs, outputBitmap);
+        theIntrinsic.setRadius(BLUR_RADIUS);
+        theIntrinsic.setInput(tmpIn);
+        theIntrinsic.forEach(tmpOut);
+        tmpOut.copyTo(outputBitmap);
+
+        return outputBitmap;
+    }
+
+    private static Bitmap getScreenshot(View v) {
+        Bitmap b = Bitmap.createBitmap(v.getWidth(), v.getHeight(), Bitmap.Config.ARGB_8888);
+        Canvas c = new Canvas(b);
+        v.draw(c);
+        return b;
+    }
+}

--- a/app/src/main/res/layout/image_description.xml
+++ b/app/src/main/res/layout/image_description.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app2="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -11,10 +12,8 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:id="@+id/image_desc_top"
-        android:paddingBottom="@dimen/small_spacing"
         android:paddingLeft="@dimen/sub_small_spacing"
-        android:paddingRight="@dimen/sub_small_spacing"
-        android:paddingTop="@dimen/big_spacing">
+        android:paddingRight="@dimen/sub_small_spacing">
 
         <ImageButton
             android:layout_width="48dp"
@@ -24,12 +23,10 @@
             android:background="@drawable/back_arrow"/>
 
         <TextView
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center"
             android:layout_gravity="center"
-            android:textAlignment="center"
-            android:padding="@dimen/alternate_padding"
             android:textSize="@dimen/sub_big_text"
             android:textColor="@color/white"
             android:textStyle="bold"
@@ -71,8 +68,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:id="@+id/image_desc_date"
-                android:text="28/September/2018"
-                android:textColor="@color/md_grey_500"
+                tools:text="28/September/2018"
+                android:textColor="@color/md_grey_400"
                 android:textSize="@dimen/medium_text"/>
 
         </LinearLayout>
@@ -112,8 +109,9 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:textColor="@color/md_grey_500"
+                android:text="No Location"
                 android:id="@+id/image_desc_loc"
+                android:textColor="@color/md_grey_400"
                 android:textSize="@dimen/medium_text"/>
 
         </LinearLayout>
@@ -296,7 +294,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:textSize="@dimen/medium_text"
-                        android:textColor="@color/md_grey_500"
+                        android:textColor="@color/md_grey_400"
                         android:id="@+id/image_desc_exif"
                         android:layout_marginLeft="5dp"/>
 
@@ -320,7 +318,7 @@
                         android:layout_height="wrap_content"
                         android:id="@+id/image_desc"
                         android:textSize="@dimen/medium_text"
-                        android:textColor="@color/md_grey_500"
+                        android:textColor="@color/md_grey_400"
                         android:layout_marginLeft="5dp"/>
 
                 </LinearLayout>


### PR DESCRIPTION
Fix #1387 
Changes: Use blurred version of current image as the background

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/22395998/32404560-a1f0e90c-c177-11e7-8499-69e9773655f5.png)
