### PR TITLE
Fix #1278: Pausing after click working

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/MyPreferenceFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/MyPreferenceFragment.java
@@ -68,6 +68,7 @@ public class MyPreferenceFragment extends PreferenceFragment implements OnShared
 		final String camera_api = bundle.getString("camera_api");
 		
 		final SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this.getActivity());
+		sharedPreferences.registerOnSharedPreferenceChangeListener(this);
 
 		final boolean supports_auto_stabilise = bundle.getBoolean("supports_auto_stabilise");
 		if( MyDebug.LOG )
@@ -95,6 +96,8 @@ public class MyPreferenceFragment extends PreferenceFragment implements OnShared
         	pg.removePreference(pref);
 		}
 
+		final boolean preference_pause_preview = bundle.getBoolean("preference_pause_preview");
+		Log.e(TAG, "onCreate: FRAGMENT" +preference_pause_preview);
 
 		final ArrayList<Integer> widths = bundle.getListInt("resolution_widths");
 		final ArrayList<Integer> heights = bundle.getListInt("resolution_heights");
@@ -387,7 +390,7 @@ public class MyPreferenceFragment extends PreferenceFragment implements OnShared
 	public void onSharedPreferenceChanged(SharedPreferences prefs, String key) {
 		if( MyDebug.LOG )
 			Log.d(TAG, "onSharedPreferenceChanged");
-	    Preference pref = findPreference(key);
+        Preference pref = findPreference(key);
 	    if( pref instanceof TwoStatePreference){
 	    	TwoStatePreference twoStatePref = (TwoStatePreference)pref;
 	    	twoStatePref.setChecked(prefs.getBoolean(key, true));

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -55,7 +55,7 @@
                 android:title="@string/preference_touch_capture" />
 
             <SwitchPreference
-                android:defaultValue="false"
+                android:defaultValue="true"
                 android:key="preference_pause_preview"
                 android:summary="@string/preference_pause_preview_summary"
                 android:title="@string/preference_pause_preview" />


### PR DESCRIPTION
Fix #1278  Pausing after click toggle option made working.

Changes: The value for the pausing after a click is set to true, that means the pic will always be shown after the click.
Now if the value is changed, the image is saved directly without pausing.


@mohitmanuja @anantprsd5 @mayank8318 @aditya98ak Review and merge!