### PR TITLE
Fix #1490 - Accounts activity cards are now theme based.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
@@ -134,7 +134,7 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
         ButterKnife.bind(this);
         ActivitySwitchHelper.setContext(this);
         parentLayout.setBackgroundColor(getBackgroundColor());
-        accountAdapter = new AccountAdapter(getAccentColor(), getPrimaryColor());
+        accountAdapter = new AccountAdapter();
         accountPresenter = new AccountPresenter(realm);
         phimpmeProgressBarHandler = new PhimpmeProgressBarHandler(this);
         accountPresenter.attachView(this);
@@ -542,6 +542,8 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
         setStatusBarColor();
         setNavBarColor();
         accountPresenter.loadFromDatabase();
+        accountAdapter.updateTheme();
+        accountAdapter.notifyDataSetChanged();
     }
 
     private void boxAuthentication() {

--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountAdapter.java
@@ -1,6 +1,7 @@
 package org.fossasia.phimpme.accounts;
 
 import android.support.v4.content.ContextCompat;
+import android.support.v7.widget.CardView;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.SwitchCompat;
 import android.view.LayoutInflater;
@@ -33,10 +34,15 @@ public class AccountAdapter extends RecyclerView.Adapter<AccountAdapter.ViewHold
     public int switchBackgroundColor;
     private ThemeHelper themeHelper;
 
-    public AccountAdapter(int switchColor, int switchBackgroundColor) {
-        this.switchAccentColor = switchColor;
-        this.switchBackgroundColor = switchBackgroundColor;
+    public AccountAdapter() {
         themeHelper = new ThemeHelper(getContext());
+        updateTheme();
+        this.switchAccentColor = themeHelper.getAccentColor();
+        this.switchBackgroundColor = themeHelper.getPrimaryColor();
+    }
+
+    public void updateTheme() {
+        themeHelper.updateTheme();
     }
 
     @Override
@@ -88,6 +94,8 @@ public class AccountAdapter extends RecyclerView.Adapter<AccountAdapter.ViewHold
             holder.accountName.setTextColor(ContextCompat.getColor(getContext(), id));
             holder.accountAvatar.setColorFilter(ContextCompat.getColor(getContext(), id));
         }
+
+        holder.cardView.setCardBackgroundColor(themeHelper.getCardBackgroundColor());
     }
 
     @Override
@@ -117,6 +125,9 @@ public class AccountAdapter extends RecyclerView.Adapter<AccountAdapter.ViewHold
 
         @BindView(R.id.sign_in_sign_out_switch)
         SwitchCompat signInSignOutSwitch;
+
+        @BindView(R.id.card_view)
+        CardView cardView;
 
         public ViewHolder(View itemView) {
             super(itemView);


### PR DESCRIPTION
Fix #1490 

Changes: Make the cards theme based with proper background colour.

Screenshots for the change: 
![23552950_1870575292971276_5862482500495867904_n](https://user-images.githubusercontent.com/22395998/32937650-65d9e70c-cb9f-11e7-8c0e-ce87d621f8e5.gif)
