### PR TITLE
Rectify the text orientation in the about page of the App

### DIFF
--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -78,7 +78,10 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
+                        android:gravity="center"
                         android:padding="@dimen/sub_small_spacing"
+                        android:layout_marginLeft="@dimen/medium_spacing"
+                        android:layout_marginRight="@dimen/medium_spacing"
                         android:text="@string/app_light_description"
                         android:textColor="@color/md_dark_primary_text"
                         android:textSize="@dimen/medium_text"/>


### PR DESCRIPTION
Fixes https://github.com/fossasia/phimpme-android/issues/1493

Screenshots :

![screenshot from 2017-11-17 16-45-49 1](https://user-images.githubusercontent.com/20770414/32939190-c0dc3524-cba4-11e7-98c1-0305f53d8437.png)