### PR TITLE
Fix #1491 - Bottom navbar animation works fine for photos.

### DIFF
--- a/app/src/main/res/layout/activity_leafpic.xml
+++ b/app/src/main/res/layout/activity_leafpic.xml
@@ -50,6 +50,7 @@
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"
                             android:layout_gravity="center_horizontal"
+                            android:clipToPadding="false"
                             android:paddingBottom="@dimen/height_bottombar"
                             android:scrollbarThumbVertical="@drawable/ic_scrollbar"
                             android:scrollbars="vertical" />


### PR DESCRIPTION
Fix #1491 

Changes: Set ` clipToPadding = false ` for photos recycler view 

Screenshots for the change: 
![23552911_1881020248593447_6635434506192945152_n](https://user-images.githubusercontent.com/22395998/33238377-79c2c2e2-d2b2-11e7-9651-7a46bb106bbc.gif)

