### PR TITLE
Fix #1501 - Fix album card glitch for horizontal orientation.

### DIFF
--- a/app/src/main/res/layout/card_album.xml
+++ b/app/src/main/res/layout/card_album.xml
@@ -43,7 +43,7 @@
         <LinearLayout
             android:id="@+id/linear_card_text"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
             android:layout_alignParentLeft="true"
             android:layout_alignParentStart="true"


### PR DESCRIPTION
Fix #1501 

Changes: Change `layout_height` from `match_parent` to `wrap_content`

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/22395998/33487852-b33dc9b0-d6d4-11e7-86a3-676620bcbace.png)
