### PR TITLE
fixes #1436 Hides status and navigation bar in camera activity

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/CameraActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/CameraActivity.java
@@ -799,6 +799,10 @@ public class CameraActivity extends ThemedActivity implements AudioListener.Audi
             Log.d(TAG, "onResume");
             debug_time = System.currentTimeMillis();
         }
+
+        //hiding status bar
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+
         super.onResume();
 
         // Set black window background; also needed if we hide the virtual buttons in immersive mode

--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Preview/Preview.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Preview/Preview.java
@@ -614,10 +614,10 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
 		int longSide = (widthLonger ? previewWidth : previewHeight);
 		int shortSide = (widthLonger ? previewHeight : previewWidth);
 		if( longSide > shortSide * aspect_ratio ) {
-			longSide = (int) ((double) shortSide * aspect_ratio);
+		        shortSide = (int) ((double) longSide / aspect_ratio);
 		}
 		else {
-			shortSide = (int) ((double) longSide / aspect_ratio);
+		        longSide = (int) ((double) shortSide * aspect_ratio);
 		}
 		if( widthLonger ) {
 			previewWidth = longSide;

--- a/app/src/main/java/org/fossasia/phimpme/opencamera/UI/MainUI.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/UI/MainUI.java
@@ -160,8 +160,8 @@ public class MainUI {
 		main_activity.getPreview().setUIRotation(ui_rotation);
 		int align_left = RelativeLayout.ALIGN_LEFT;
 		int align_right = RelativeLayout.ALIGN_RIGHT;
-		//int align_top = RelativeLayout.ALIGN_TOP;
-		//int align_bottom = RelativeLayout.ALIGN_BOTTOM;
+		int align_top = RelativeLayout.ALIGN_TOP;
+		int align_bottom = RelativeLayout.ALIGN_BOTTOM;
 		int left_of = RelativeLayout.LEFT_OF;
 		int right_of = RelativeLayout.RIGHT_OF;
 		int above = RelativeLayout.ABOVE;
@@ -189,8 +189,8 @@ public class MainUI {
 			View view = main_activity.findViewById(R.id.gui_anchor);
 			RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) view.getLayoutParams();
 			layoutParams.addRule(align_parent_left, 0);
-			layoutParams.addRule(align_parent_right, RelativeLayout.TRUE);
-			layoutParams.addRule(align_parent_top, RelativeLayout.TRUE);
+			layoutParams.addRule(align_right, R.id.preview);
+			layoutParams.addRule(align_top,R.id.preview);
 			layoutParams.addRule(align_parent_bottom, 0);
 			layoutParams.addRule(left_of, 0);
 			layoutParams.addRule(right_of, 0);
@@ -200,7 +200,7 @@ public class MainUI {
 
 			view = main_activity.findViewById(R.id.popup);
 			layoutParams = (RelativeLayout.LayoutParams) view.getLayoutParams();
-			layoutParams.addRule(align_parent_top, RelativeLayout.TRUE);
+			layoutParams.addRule(align_top, R.id.preview);
 			layoutParams.addRule(align_parent_bottom, 0);
 			layoutParams.addRule(left_of, R.id.gui_anchor);
 			layoutParams.addRule(right_of, 0);
@@ -214,9 +214,9 @@ public class MainUI {
 			view = main_activity.findViewById(R.id.exposure);
 			layoutParams = (RelativeLayout.LayoutParams) view.getLayoutParams();
 			layoutParams.addRule(align_parent_top, 0);
-			layoutParams.addRule(align_parent_bottom, RelativeLayout.TRUE);
-			//layoutParams.addRule(left_of, R.id.popup);
-			layoutParams.addRule(align_parent_right, RelativeLayout.TRUE);
+			layoutParams.addRule(align_bottom, R.id.preview);
+			layoutParams.addRule(left_of, R.id.popup);
+			layoutParams.addRule(align_right, R.id.preview);
 			layoutParams.addRule(right_of, 0);
 			view.setLayoutParams(layoutParams);
 			layoutParams.setMargins(icon_margin, icon_margin, icon_margin, icon_margin);
@@ -226,10 +226,10 @@ public class MainUI {
 
 			view = main_activity.findViewById(R.id.switch_camera);
 			layoutParams = (RelativeLayout.LayoutParams) view.getLayoutParams();
-			layoutParams.addRule(align_parent_left, RelativeLayout.TRUE);
+			layoutParams.addRule(align_left, R.id.preview);
 			layoutParams.addRule(align_parent_right, 0);
 			layoutParams.addRule(align_parent_top, 0);
-			layoutParams.addRule(align_parent_bottom, RelativeLayout.TRUE);
+			layoutParams.addRule(align_bottom, R.id.preview);
 			layoutParams.addRule(left_of, 0);
 			layoutParams.addRule(right_of, 0);
 			view.setLayoutParams(layoutParams);
@@ -242,7 +242,7 @@ public class MainUI {
 			layoutParams = (RelativeLayout.LayoutParams) view.getLayoutParams();
 			layoutParams.addRule(align_parent_left, 0);
 			layoutParams.addRule(align_parent_right, 0);
-			layoutParams.addRule(align_parent_top, RelativeLayout.TRUE);
+			layoutParams.addRule(align_top, R.id.preview);
 			layoutParams.addRule(align_parent_bottom, 0);
 			layoutParams.addRule(left_of, R.id.switch_camera);
 			layoutParams.addRule(right_of, 0);
@@ -253,6 +253,8 @@ public class MainUI {
 			view = main_activity.findViewById(R.id.take_photo);
 			((ImageButton) view).setImageResource(R.drawable.ic_capture);
 			((ImageButton) view).setColorFilter(Color.WHITE);
+			layoutParams = (RelativeLayout.LayoutParams) view.getLayoutParams();
+			layoutParams.addRule(align_bottom, R.id.preview);
 			view.setBackgroundResource(bgresourceId);
 			setViewRotation(view, ui_rotation);
 
@@ -267,7 +269,7 @@ public class MainUI {
 			layoutParams.addRule(align_right, 0);
 			layoutParams.addRule(right_of, 0);
 			layoutParams.addRule(align_parent_top, 0);
-			layoutParams.addRule(align_parent_bottom, RelativeLayout.TRUE);
+			layoutParams.addRule(align_bottom,R.id.preview);
 			view.setLayoutParams(layoutParams);
 		}
 
@@ -322,7 +324,7 @@ public class MainUI {
 			//layoutParams.addRule(left_of, R.id.popup);
 			layoutParams.addRule(align_right, R.id.popup);
 			layoutParams.addRule(below, R.id.popup);
-			layoutParams.addRule(align_parent_bottom, RelativeLayout.TRUE);
+			layoutParams.addRule(align_bottom, R.id.preview);
 			layoutParams.addRule(above, 0);
 			layoutParams.addRule(align_parent_top, 0);
 			view.setLayoutParams(layoutParams);
@@ -360,7 +362,6 @@ public class MainUI {
 			Log.d(TAG, "layoutUI: total time: " + (System.currentTimeMillis() - debug_time));
 		}
 	}
-
 
 	/**
 	 * Set content description for switch camera button.

--- a/app/src/main/res/layout/activity_camera.xml
+++ b/app/src/main/res/layout/activity_camera.xml
@@ -15,7 +15,7 @@
         <FrameLayout
             android:id="@+id/preview"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerInParent="true"/>
 
@@ -23,7 +23,6 @@
             android:id="@+id/take_photo"
             android:layout_width="80dp"
             android:layout_height="80dp"
-            android:layout_alignParentBottom="true"
             android:layout_centerHorizontal="true"
             android:contentDescription="@string/take_photo"
             android:onClick="clickedTakePhoto"
@@ -246,27 +245,30 @@
             android:id="@+id/prefs_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_centerInParent="true"/>
+            android:layout_centerInParent="true"
+            android:layout_alignBottom="@+id/preview"/>
 
         <FrameLayout
             android:id="@+id/locker"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"/>
+            android:layout_height="match_parent"
+            android:layout_alignBottom="@+id/preview"/>
 
         <ScrollView
             android:id="@+id/popup_container"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content" />
 
         <ScrollView
             android:id="@+id/hide_container"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"/>
+            android:layout_height="match_parent"
+            android:layout_alignBottom="@+id/preview"/>
     </RelativeLayout>
 
     <include
         layout="@layout/element_bottom_navigation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="0dp"/>
+        android:layout_marginBottom="0dp" />
 </LinearLayout>


### PR DESCRIPTION
Closes #1436
 
#### Changes:
The status and navigation bar are now hidden inside the camera activity.

#### Screenshots for the change: 
![](https://user-images.githubusercontent.com/21277837/33750988-945f4d9c-dbfd-11e7-8211-6b82d14f2b2f.png)
