### PR TITLE
Fix #1468-Upload History UI enhanced.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
@@ -2,6 +2,7 @@ package org.fossasia.phimpme.uploadhistory;
 
 import android.graphics.Color;
 import android.os.Bundle;
+import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
@@ -60,9 +61,8 @@ public class UploadHistory extends ThemedActivity {
         uploadHistoryAdapter = new UploadHistoryAdapter(getPrimaryColor());
         realm = Realm.getDefaultInstance();
         uploadResults = realm.where(UploadHistoryRealmModel.class);
-        LinearLayoutManager layoutManager = new LinearLayoutManager(this);
-        layoutManager.setReverseLayout(true);
-        layoutManager.setStackFromEnd(true);
+        GridLayoutManager layoutManager = new GridLayoutManager(getApplicationContext(), 2);
+        layoutManager.setReverseLayout(false);
         uploadHistoryRecyclerView.setLayoutManager(layoutManager);
         uploadHistoryRecyclerView.setAdapter(uploadHistoryAdapter);
         uploadHistoryAdapter.setResults(uploadResults);

--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistoryAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistoryAdapter.java
@@ -91,7 +91,6 @@ public class UploadHistoryAdapter extends RecyclerView.Adapter<UploadHistoryAdap
                     , getContext().getPackageName());
 
             holder.accountImageShare.setColorFilter(ContextCompat.getColor(getContext(), id));
-            holder.uploadHistoryTitle.setBackgroundColor(color);
         }
     }
 
@@ -118,9 +117,6 @@ public class UploadHistoryAdapter extends RecyclerView.Adapter<UploadHistoryAdap
 
         @BindView(R.id.account_image_share)
         ImageView accountImageShare;
-
-        @BindView(R.id.upload_history_title)
-        LinearLayout uploadHistoryTitle;
 
         public ViewHolder(View itemView) {
             super(itemView);

--- a/app/src/main/res/layout/upload_history_activity.xml
+++ b/app/src/main/res/layout/upload_history_activity.xml
@@ -14,6 +14,7 @@
         android:id="@+id/upload_history_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/md_grey_200"
         android:layout_below="@id/toolbar"
         android:visibility="visible" />
 

--- a/app/src/main/res/layout/upload_history_item_view.xml
+++ b/app/src/main/res/layout/upload_history_item_view.xml
@@ -1,97 +1,99 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    app:cardCornerRadius="5dp"
-    app:cardElevation="5dp"
-    app:cardMaxElevation="5dp"
-    app:cardUseCompatPadding="true">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:card_view="http://schemas.android.com/apk/res-auto"
+              xmlns:app="http://schemas.android.com/tools"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content">
 
-    <LinearLayout
-        android:id="@+id/title_bar"
+    <android.support.v7.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:gravity="center"
-        android:orientation="vertical">
+        app:cardCornerRadius="7dp"
+        app:cardElevation="3dp"
+        app:cardMaxElevation="3dp"
+        android:layout_gravity="center"
+        android:foreground="@drawable/ripple"
+        android:layout_margin="3dp">
 
-        <LinearLayout
-            android:id="@+id/upload_history_title"
+        <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="40dp"
-            android:gravity="center"
-            android:orientation="horizontal">
+            android:layout_height="match_parent"
+            android:background="@color/md_grey_300">
 
             <ImageView
-                android:id="@+id/account_image_share"
-                android:layout_width="25dp"
-                android:layout_height="25dp"
+                android:id="@+id/upload_image"
+                android:layout_width="match_parent"
+                android:layout_height="160dp"
                 android:layout_gravity="center"
-                app:srcCompat="@drawable/ic_launcher_vector" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+                android:scaleType="centerCrop"/>
 
             <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
+                android:layout_below="@+id/upload_image"
                 android:orientation="vertical">
 
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="10dp"
-                    android:orientation="horizontal">
+                <LinearLayout android:layout_width="wrap_content"
+                              android:layout_marginTop="5dp"
+                              android:layout_marginRight="5dp"
+                              android:layout_marginLeft="5dp"
+                              android:orientation="horizontal"
+                              android:layout_height="wrap_content">
 
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/upload_date"
-                        android:textSize="18sp"
-                        android:textStyle="bold" />
+                        android:textSize="14sp"
+                        android:textStyle="bold"/>
 
                     <TextView
                         android:id="@+id/upload_date"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:textSize="18sp" />
+                        android:textSize="14sp"/>
+
                 </LinearLayout>
 
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="10dp"
-                    android:orientation="horizontal">
+                <LinearLayout android:layout_width="wrap_content"
+                              android:layout_marginTop="5dp"
+                              android:layout_marginLeft="5dp"
+                              android:layout_marginRight="5dp"
+                              android:layout_marginBottom="5dp"
+                              android:orientation="horizontal"
+                              android:layout_height="wrap_content">
 
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/upload_time"
-                        android:textSize="18sp"
-                        android:textStyle="bold" />
+                        android:textSize="14sp"
+                        android:textStyle="bold"/>
 
                     <TextView
                         android:id="@+id/upload_time"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:textSize="18sp" />
+                        android:textSize="14sp"/>
+
                 </LinearLayout>
+
             </LinearLayout>
 
             <ImageView
-                android:id="@+id/upload_image"
-                android:layout_width="80dp"
-                android:layout_height="80dp"
+                android:id="@+id/account_image_share"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
                 android:layout_gravity="center"
-                android:layout_marginRight="15dp"
-                app:srcCompat="@drawable/ic_launcher_vector" />
-        </LinearLayout>
-    </LinearLayout>
+                app:srcCompat="@drawable/ic_launcher_vector"
+                android:layout_below="@+id/upload_image"
+                android:layout_alignParentEnd="true"
+                android:layout_marginEnd="10dp"
+                android:layout_marginTop="14dp"/>
 
-</android.support.v7.widget.CardView>
+        </RelativeLayout>
+
+    </android.support.v7.widget.CardView>
+
+</LinearLayout>


### PR DESCRIPTION
Fix #1468 

Changes: The items are displayed in GridLayout with spancount 2, enlarged center-croped version of the shared image is displayed, spacing between the attributes is properly managed.

Screenshots for the change: 
![screenshot_2017-12-11-21-34-46-673_org fossasia phimpme](https://user-images.githubusercontent.com/20841578/33840544-3dfd94f2-debb-11e7-9afd-5accc011bb3e.png)

