### PR TITLE
fixes #1435 fixed issue with the overflow menu in the camera activity

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Preview/Preview.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Preview/Preview.java
@@ -2736,7 +2736,20 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
 				// now save
 				applicationInterface.setFlashPref(flash_value);
 			}
-		}
+ 		} else if (supported_flash_values != null && current_flash_index != -1 &&
+                current_flash_index != supported_flash_values.indexOf("flash_off")) {
+                        //called when the user clicks on the same flash button again to disable it
+                        current_flash_index = supported_flash_values.indexOf("flash_off");
+                        if (MyDebug.LOG)
+                            Log.d(TAG, "    current_flash_index is now " + current_flash_index);
+                        String[] flash_entries = getResources().getStringArray(R.array.flash_entries);
+                        showToast(flash_toast, flash_entries[0]);
+                        this.setFlash("flash_off");
+                        if (save) {
+                            // now save
+                            applicationInterface.setFlashPref("flash_off");
+                        }
+        }
 	}
 
 	private void setFlash(String flash_value) {
@@ -2850,7 +2863,27 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
 				// now save
 				applicationInterface.setFocusPref(focus_value, is_video);
 			}
-		}
+		} else if ( this.supported_focus_values != null && current_focus_index != 0){
+                //called when the user tries to deselect an selected focus value.
+                        current_focus_index = 0;
+                        if (MyDebug.LOG)
+                            Log.d(TAG, "    current_focus_index is now " + current_focus_index);
+                        String focus_value = supported_focus_values.get(current_focus_index);
+                        if (MyDebug.LOG)
+                            Log.d(TAG, "    focus_value: " + focus_value);
+                        if (!quiet) {
+                            String focus_entry = findFocusEntryForValue(focus_value);
+                            if (focus_entry != null) {
+                                showToast(focus_toast, focus_entry);
+                            }
+                        }
+                        this.setFocusValue(focus_value, auto_focus);
+
+                        if (save) {
+                            // now save
+                            applicationInterface.setFocusPref(focus_value, is_video);
+                        }
+        }
 	}
 
 	/** This returns the flash mode indicated by the UI, rather than from the camera parameters.


### PR DESCRIPTION
Fix #1435 

#### Changes: 
Fixed issue with the overflow menu in the ```CameraActivity```. On clicking on an already selected option, the value is deactivated and the default value is automatically selected. For eg. - On selecting torch after torch is already active, switches the torch off and set the flash to off automatically.
Added this feature for both focus and flash options.

#### Screenshots for the change: 
![giphy-downsized-large](https://user-images.githubusercontent.com/21277837/34067528-38663e68-e24e-11e7-9776-36eb46de0c6d.gif)

