### PR TITLE
Fix #1529 . Description dialog editText now extends downwards as text is entered.

### DIFF
--- a/app/src/main/res/layout/dialog_description.xml
+++ b/app/src/main/res/layout/dialog_description.xml
@@ -44,7 +44,9 @@
                         android:textColorHint="@color/grey"
                         android:layout_margin="20dp"
                         android:gravity="top|left"
-                        android:inputType="text"
+                        android:inputType="textCapSentences|textMultiLine"
+                        android:maxLength="2000"
+                        android:maxLines="4"
                         android:selectAllOnFocus="true"/>
                     <ImageButton
                         android:layout_width="@dimen/mic_image"


### PR DESCRIPTION
Fix #1529 

Changes:
I modified the editText of the description dialog box.
The editText now increases in height downwards as more text is entered. This way the text is not hidden and user can see entire text entered.

Screenshots for the change: 
![phimpme](https://user-images.githubusercontent.com/23417993/34167479-e353e1ac-e507-11e7-9e6d-bc34848522c3.png)
