### PR TITLE
Fix #1289-Favourite collection photos displayed to the users.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -68,6 +68,7 @@ import com.mikepenz.iconics.view.IconicsImageView;
 
 import org.fossasia.phimpme.R;
 import org.fossasia.phimpme.base.SharedMediaActivity;
+import org.fossasia.phimpme.data.local.FavouriteImagesModel;
 import org.fossasia.phimpme.data.local.UploadHistoryRealmModel;
 import org.fossasia.phimpme.gallery.SelectAlbumBottomSheet;
 import org.fossasia.phimpme.gallery.adapters.AlbumsAdapter;
@@ -111,6 +112,9 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import io.realm.Realm;
+import io.realm.RealmQuery;
+import io.realm.RealmResults;
+
 import static org.fossasia.phimpme.gallery.data.base.SortingMode.DATE;
 import static org.fossasia.phimpme.gallery.data.base.SortingMode.NAME;
 import static org.fossasia.phimpme.gallery.data.base.SortingMode.NUMERIC;
@@ -119,12 +123,13 @@ import static org.fossasia.phimpme.gallery.data.base.SortingMode.SIZE;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 
+
 public class LFMainActivity extends SharedMediaActivity {
 
     private static String TAG = "AlbumsAct";
     private int REQUEST_CODE_SD_CARD_PERMISSIONS = 42;
     private static final int BUFFER = 80000;
-    private boolean about=false,settings=false,uploadHistory=false;
+    private boolean about=false,settings=false,uploadHistory=false, favourites=false;
     private CustomAlbumsHelper customAlbumsHelper = CustomAlbumsHelper.getInstance(LFMainActivity.this);
     private PreferenceUtil SP;
     private SecurityHelper securityObj;
@@ -149,6 +154,12 @@ public class LFMainActivity extends SharedMediaActivity {
     private ArrayList<Media> media;
     private ArrayList<Media> selectedMedias = new ArrayList<>();
     public boolean visible;
+
+    //To handle favourite collection
+    private Realm realm;
+    private ArrayList<Media> favouriteslist;
+    public boolean fav_photos=false;
+    private IconicsImageView favicon;
 
     // To handle back pressed
     boolean doubleBackToExitPressedOnce = false;
@@ -198,17 +209,23 @@ public class LFMainActivity extends SharedMediaActivity {
             //If first long press, turn on selection mode
             hideNavigationBar();
             hidenav=true;
-            if (!all_photos) {
+            if (!all_photos && !fav_photos) {
                 appBarOverlay();
                 if (!editMode) {
                     mediaAdapter.notifyItemChanged(getAlbum().toggleSelectPhoto(m));
                     editMode = true;
                 } else getAlbum().selectAllPhotosUpTo(getAlbum().getIndex(m), mediaAdapter);
-
                 invalidateOptionsMenu();
-            } else if (!editMode) {
-                mediaAdapter.notifyItemChanged(toggleSelectPhoto(m));
-                editMode = true;
+            } else if(all_photos && !fav_photos) {
+                if (!editMode) {
+                    mediaAdapter.notifyItemChanged(toggleSelectPhoto(m));
+                    editMode = true;
+                }
+            }else if(fav_photos && !all_photos){
+                if(!editMode){
+                    mediaAdapter.notifyItemChanged(toggleSelectPhoto(m));
+                    editMode = true;
+                }
             } else selectAllPhotosUpTo(getImagePosition(m.getPath()), mediaAdapter);
             return true;
         }
@@ -246,7 +263,11 @@ public class LFMainActivity extends SharedMediaActivity {
             editMode = false;
             toolbar.setTitle(getString(R.string.all));
         } else {
-            toolbar.setTitle(selectedMedias.size() + "/" + size);
+            if(!fav_photos){
+                toolbar.setTitle(selectedMedias.size() + "/" + size);
+            }else if(fav_photos){
+                toolbar.setTitle(selectedMedias.size() + "/" + favouriteslist.size());
+            }
         }
         invalidateOptionsMenu();
         return getImagePosition(m.getPath());
@@ -263,13 +284,21 @@ public class LFMainActivity extends SharedMediaActivity {
 
 
     public void selectAllPhotos() {
-        for (Media m : listAll) {
-            m.setSelected(true);
-            selectedMedias.add(m);
+        if(all_photos && !fav_photos){
+            for (Media m : listAll) {
+                m.setSelected(true);
+                selectedMedias.add(m);
+            }
+            toolbar.setTitle(selectedMedias.size() + "/" + size);
+        }else if(!all_photos && fav_photos){
+            for (Media m : favouriteslist) {
+                m.setSelected(true);
+                if(m.isSelected())
+                selectedMedias.add(m);
+            }
+            toolbar.setTitle(selectedMedias.size() + "/" + favouriteslist.size());
         }
-        toolbar.setTitle(selectedMedias.size() + "/" + size);
     }
-
 
     public void selectAllPhotosUpTo(int targetIndex, MediaAdapter adapter) {
         int indexRightBeforeOrAfter = -1;
@@ -307,7 +336,10 @@ public class LFMainActivity extends SharedMediaActivity {
             if (all_photos) {
                 pos = getImagePosition(m.getPath());
             }
-            if (!all_photos) {
+            if(fav_photos){
+                pos = getImagePosition(m.getPath());
+            }
+            if (!all_photos && !fav_photos) {
                 if (!pickMode) {
                     //if in selection mode, toggle the selected/unselect state of photo
                     if (editMode) {
@@ -315,7 +347,6 @@ public class LFMainActivity extends SharedMediaActivity {
                         mediaAdapter.notifyItemChanged(getAlbum().toggleSelectPhoto(m));
                         if(getAlbum().selectedMedias.size()==0)
                             getNavigationBar();
-
                         invalidateOptionsMenu();
                     } else {
                         v.setTransitionName(getString(R.string.transition_photo));
@@ -331,7 +362,7 @@ public class LFMainActivity extends SharedMediaActivity {
                     setResult(RESULT_OK, new Intent().setData(m.getUri()));
                     finish();
                 }
-            } else {
+            } else if(all_photos && !fav_photos){
                 if (!editMode) {
                     Intent intent = new Intent(REVIEW_ACTION, Uri.fromFile(new File(m.getPath())));
                     intent.putExtra(getString(R.string.all_photo_mode), true);
@@ -345,7 +376,21 @@ public class LFMainActivity extends SharedMediaActivity {
                 } else {
                     mediaAdapter.notifyItemChanged(toggleSelectPhoto(m));
                 }
-
+            }else if(!all_photos && fav_photos){
+                if(!editMode) {
+                    Intent intent = new Intent(REVIEW_ACTION, Uri.fromFile(new File(m.getPath())));
+                    intent.putExtra("fav_photos", true);
+                    intent.putExtra(getString(R.string.position), pos);
+                    intent.putParcelableArrayListExtra("favouriteslist", favouriteslist);
+                    intent.putExtra(getString(R.string.allMediaSize), favouriteslist.size());
+                    v.setTransitionName(getString(R.string.transition_photo));
+                    ActivityOptionsCompat options = ActivityOptionsCompat.
+                            makeSceneTransitionAnimation(LFMainActivity.this, v, v.getTransitionName());
+                    intent.setClass(getApplicationContext(), SingleMediaActivity.class);
+                    startActivity(intent, options.toBundle());
+                }else{
+                    mediaAdapter.notifyItemChanged(toggleSelectPhoto(m));
+                }
             }
         }
     };
@@ -407,10 +452,22 @@ public class LFMainActivity extends SharedMediaActivity {
 
     public int getImagePosition(String path) {
         int pos = 0;
-        for (int i = 0; i < listAll.size(); i++) {
-            if (listAll.get(i).getPath().equals(path)) {
-                pos = i;
-                break;
+        if(all_photos){
+            for (int i = 0; i < listAll.size(); i++) {
+                if (listAll.get(i).getPath().equals(path)) {
+                    pos = i;
+                    break;
+                }
+            }
+        }
+        else if(fav_photos){
+            Collections.sort(favouriteslist, MediaComparators.getComparator(getAlbum().settings.getSortingMode(), getAlbum().settings
+                    .getSortingOrder()));
+            for (int i = 0; i < favouriteslist.size(); i++) {
+                if (favouriteslist.get(i).getPath().equals(path)) {
+                    pos = i;
+                    break;
+                }
             }
         }
         return pos;
@@ -420,10 +477,10 @@ public class LFMainActivity extends SharedMediaActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Log.e("TAG", "lfmain");
-
         ButterKnife.bind(this);
 
         BottomNavigationView navigationView = (BottomNavigationView)findViewById(R.id.bottombar);
+        favicon = (IconicsImageView) findViewById(R.id.Drawer_favourite_Icon);
 
         SP = PreferenceUtil.getInstance(getApplicationContext());
         albumsMode = true;
@@ -434,6 +491,7 @@ public class LFMainActivity extends SharedMediaActivity {
         SP.putBoolean(getString(R.string.preference_use_alternative_provider), false);
         initUI();
         new initAllPhotos().execute();
+        new SortModeSet().execute(DATE);
         displayData(getIntent().getExtras());
         checkNothing();
 
@@ -452,7 +510,6 @@ public class LFMainActivity extends SharedMediaActivity {
                 return LFMainActivity.super.onNavigationItemSelected(item);
             }
         });
-
     }
 
     @Override
@@ -461,9 +518,13 @@ public class LFMainActivity extends SharedMediaActivity {
         ActivitySwitchHelper.setContext(this);
         securityObj.updateSecuritySetting();
         setupUI();
-        if (all_photos)
+        if (all_photos && !fav_photos){
             mediaAdapter.swapDataSet(listAll);
-        if (!all_photos) {
+        }
+        if(!all_photos && fav_photos){
+            new FavouritePhotos().execute();
+        }
+        if (!all_photos && !fav_photos) {
             if (SP.getBoolean("auto_update_media", false)) {
                 if (albumsMode) {
                     if (!firstLaunch) new PrepareAlbumTask().execute();
@@ -510,8 +571,51 @@ public class LFMainActivity extends SharedMediaActivity {
         invalidateOptionsMenu();
     }
 
+    private void getfavouriteslist(){
+        favouriteslist = new ArrayList<Media>();
+        realm = Realm.getDefaultInstance();
+        RealmQuery<FavouriteImagesModel> favouriteImagesModelRealmQuery = realm.where(FavouriteImagesModel.class);
+        int count = Integer.parseInt(String.valueOf(favouriteImagesModelRealmQuery.count()));
+        for(int i = 0; i < count; i++){
+            final String path = favouriteImagesModelRealmQuery.findAll().get(i).getPath();
+            if(new File(favouriteImagesModelRealmQuery.findAll().get(i).getPath()).exists()){
+                favouriteslist.add(new Media(new File(favouriteImagesModelRealmQuery.findAll().get(i).getPath())));
+            }
+            else{
+                realm.executeTransaction(new Realm.Transaction() {
+                    @Override public void execute(Realm realm) {
+                        RealmResults<FavouriteImagesModel> result = realm.where(FavouriteImagesModel.class).equalTo
+                                ("path", path).findAll();
+                        result.deleteAllFromRealm();
+                    }
+                });
+            }
+        }
+    }
+
+    private void displayfavourites(){
+        toolbar.setTitle(getResources().getString(R.string.favourite_title));
+        getfavouriteslist();
+        toolbar.setNavigationIcon(getToolbarIcon(GoogleMaterial.Icon.gmd_arrow_back));
+        mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
+        fav_photos=true;
+        mediaAdapter.swapDataSet(favouriteslist);
+        if(fav_photos){
+            new FavouritePhotos().execute();
+        }
+        toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                displayAlbums();
+            }
+        });
+        albumsMode=editMode=all_photos=false;
+        invalidateOptionsMenu();
+    }
+
     private void displayAlbums() {
         all_photos = false;
+        fav_photos = false;
         displayAlbums(true);
     }
 
@@ -539,7 +643,6 @@ public class LFMainActivity extends SharedMediaActivity {
         mediaAdapter.swapDataSet(new ArrayList<Media>());
         rvMedia.scrollToPosition(0);
     }
-
 
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
@@ -603,7 +706,6 @@ public class LFMainActivity extends SharedMediaActivity {
         rvMedia.setHasFixedSize(true);
         rvMedia.setItemAnimator(new DefaultItemAnimator());
 
-
         albumsAdapter = new AlbumsAdapter(getAlbums().dispAlbums, LFMainActivity.this);
 
         albumsAdapter.setOnClickListener(albumOnClickListener);
@@ -638,11 +740,17 @@ public class LFMainActivity extends SharedMediaActivity {
                     getAlbums().clearSelectedAlbums();
                     new PrepareAlbumTask().execute();
                 } else {
-                    if (!all_photos) {
+                    if (!all_photos && !fav_photos) {
                         getAlbum().clearSelectedPhotos();
                         new PreparePhotosTask().execute();
                     } else {
-                        new PrepareAllPhotos().execute();
+                        if(all_photos && !fav_photos){
+                            new PrepareAllPhotos().execute();
+                        }
+                        else if(!all_photos && fav_photos){
+                            new FavouritePhotos().execute();
+                        }
+
                     }
                 }
             }
@@ -667,8 +775,10 @@ public class LFMainActivity extends SharedMediaActivity {
                     intent = new Intent(LFMainActivity.this, UploadHistory.class);
                     startActivity(intent);
                     uploadHistory=false;
+                } else if(favourites){
+                    displayfavourites();
+                    favourites=false;
                 }
-
             }
 
             public void onDrawerOpened(View drawerView) {
@@ -843,6 +953,15 @@ public class LFMainActivity extends SharedMediaActivity {
         drawerShareText.setTextColor(color);
         drawerRateText.setTextColor(color);
         drawerUploadText.setTextColor(color);
+        ((TextView) findViewById(R.id.Drawer_Default_Item)).setTextColor(color);
+        ((TextView) findViewById(R.id.Drawer_Setting_Item)).setTextColor(color);
+
+        ((TextView) findViewById(R.id.Drawer_About_Item)).setTextColor(color);
+        ((TextView) findViewById(R.id.Drawer_hidden_Item)).setTextColor(color);
+        ((TextView) findViewById(R.id.Drawer_share_Item)).setTextColor(color);
+        ((TextView) findViewById(R.id.Drawer_rate_Item)).setTextColor(color);
+        ((TextView) findViewById(R.id.Drawer_Upload_Item)).setTextColor(color);
+        ((TextView) findViewById(R.id.Drawer_favourite_Item)).setTextColor(color);
 
         /** ICONS **/
         color = getIconColor();
@@ -853,6 +972,7 @@ public class LFMainActivity extends SharedMediaActivity {
         drawerShareIcon.setColor(color);
         drawerRateIcon.setColor(color);
         drawerUploadIcon.setColor(color);
+        favicon.setColor(color);
 
         // Default setting
         if(localFolder)
@@ -874,7 +994,14 @@ public class LFMainActivity extends SharedMediaActivity {
             public void onClick(View v) {
                 about=true;
                 mDrawerLayout.closeDrawer(GravityCompat.START);
+            }
+        });
 
+        findViewById(R.id.ll_drawer_favourites).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                favourites=true;
+                mDrawerLayout.closeDrawer(GravityCompat.START);
             }
         });
 
@@ -1010,15 +1137,23 @@ public class LFMainActivity extends SharedMediaActivity {
                 appBarOverlay();
                 swipeRefreshLayout.setEnabled(false);
             }
-            if (editMode)
-                if (!all_photos)
+            if (editMode){
+                if (!all_photos && !fav_photos)
                     toolbar.setTitle(getAlbum().getSelectedCount() + "/" + getAlbum().getMedia().size());
-                else {
+                else if(!fav_photos && all_photos){
                     toolbar.setTitle(selectedMedias.size() + "/" + size);}
+                else if(fav_photos && !all_photos){
+                    toolbar.setTitle(selectedMedias.size() + "/" + favouriteslist.size());
+                }
+            }
             else {
-                if (!all_photos)
+                if (!all_photos && !fav_photos)
                     toolbar.setTitle(getAlbum().getName());
-                else toolbar.setTitle(getString(R.string.all_media));
+                else if(all_photos && !fav_photos){
+                    toolbar.setTitle(getString(R.string.all_media));
+                }else if(fav_photos && !all_photos){
+                    toolbar.setTitle(getResources().getString(R.string.favourite_title));
+                }
                 toolbar.setNavigationIcon(getToolbarIcon(GoogleMaterial.Icon.gmd_arrow_back));
                 toolbar.setNavigationOnClickListener(new View.OnClickListener() {
                     @Override
@@ -1063,7 +1198,14 @@ public class LFMainActivity extends SharedMediaActivity {
 
     private void checkNothing() {
         nothingToShow.setTextColor(getTextColor());
-        nothingToShow.setVisibility((albumsMode && getAlbums().dispAlbums.size() == 0) || (!albumsMode && getAlbum().getMedia().size() == 0) ? View.VISIBLE : View.GONE);
+        nothingToShow.setVisibility((albumsMode && getAlbums().dispAlbums.size() == 0) ||
+                (!albumsMode && getAlbum().getMedia().size() == 0) ? View.VISIBLE : View.GONE);
+        TextView a = (TextView) findViewById(R.id.nothing_to_show);
+        a.setTextColor(getTextColor());
+        a.setVisibility((albumsMode && getAlbums().dispAlbums.size() == 0 && !fav_photos) || (!albumsMode && getAlbum
+                ().getMedia().size() == 0 && !fav_photos) || (fav_photos && favouriteslist.size() == 0) ? View
+                .VISIBLE : View
+                .GONE);
     }
 
     //region MENU
@@ -1075,9 +1217,7 @@ public class LFMainActivity extends SharedMediaActivity {
 
         if (albumsMode) {
             menu.findItem(R.id.select_all).setTitle(
-                    getString(getAlbums().getSelectedCount() == albumsAdapter.getItemCount()
-                            ? R.string.clear_selected
-                            : R.string.select_all));
+                    getString(getAlbums().getSelectedCount() == albumsAdapter.getItemCount() ? R.string.clear_selected : R.string.select_all));
             menu.findItem(R.id.ascending_sort_action).setChecked(getAlbums().getSortingOrder() == SortingOrder.ASCENDING);
             switch (getAlbums().getSortingMode()) {
                 case NAME:
@@ -1096,11 +1236,13 @@ public class LFMainActivity extends SharedMediaActivity {
             }
 
         } else {
-            menu.findItem(R.id.select_all).setTitle(getString(
-                    getAlbum().getSelectedCount() == mediaAdapter.getItemCount()
-                            || selectedMedias.size() == size
-                            ? R.string.clear_selected
-                            : R.string.select_all));
+            getfavouriteslist();
+            menu.findItem(R.id.select_all).setTitle(getString(getAlbum().getSelectedCount() == mediaAdapter
+                    .getItemCount() || selectedMedias.size() == size || (selectedMedias.size() == favouriteslist.size
+                    () && fav_photos) ? R
+                    .string
+                    .clear_selected :
+                    R.string.select_all));
             menu.findItem(R.id.ascending_sort_action).setChecked(getAlbum().settings.getSortingOrder() == SortingOrder.ASCENDING);
             switch (getAlbum().settings.getSortingMode()) {
                 case NAME:
@@ -1137,18 +1279,24 @@ public class LFMainActivity extends SharedMediaActivity {
             if(getAlbums().getSelectedCount() > 1)
                 menu.findItem(R.id.album_details).setVisible(false);
         } else {
-            if (!all_photos) {
+            if (!all_photos && !fav_photos) {
                 editMode = getAlbum().areMediaSelected();
                 menu.setGroupVisible(R.id.photos_option_men, editMode);
                 menu.setGroupVisible(R.id.album_options_menu, !editMode);
                 menu.findItem(R.id.all_photos).setVisible(false);
                 menu.findItem(R.id.album_details).setVisible(false);
-            } else {
+            } else if(all_photos && !fav_photos){
                 editMode = selectedMedias.size() != 0;
                 menu.setGroupVisible(R.id.photos_option_men, editMode);
                 menu.setGroupVisible(R.id.album_options_menu, !editMode);
                 menu.findItem(R.id.all_photos).setVisible(false);
                 menu.findItem(R.id.album_details).setVisible(false);
+            } else if(!all_photos && fav_photos){
+                editMode = selectedMedias.size() != 0;
+                menu.setGroupVisible(R.id.photos_option_men, editMode);
+                menu.setGroupVisible(R.id.album_options_menu, !editMode);
+                menu.findItem(R.id.album_details).setVisible(false);
+                menu.findItem(R.id.all_photos).setVisible(false);
             }
         }
 
@@ -1156,20 +1304,25 @@ public class LFMainActivity extends SharedMediaActivity {
         updateSelectedStuff();
         visible = getAlbum().getSelectedCount() > 0;
         menu.findItem(R.id.action_copy).setVisible(visible);
-        menu.findItem(R.id.action_move).setVisible(visible || editMode);
-        menu.findItem(R.id.excludeAlbumButton).setVisible(editMode && !all_photos && albumsMode);
-        menu.findItem(R.id.zipAlbumButton).setVisible(editMode && !all_photos&&albumsMode);
+        menu.findItem(R.id.action_move).setVisible((visible || editMode));
+        menu.findItem(R.id.excludeAlbumButton).setVisible(editMode && !all_photos && albumsMode && !fav_photos);
+        menu.findItem(R.id.zipAlbumButton).setVisible(editMode && !all_photos&&albumsMode &&!fav_photos);
         menu.findItem(R.id.select_all).setVisible(editMode);
-        menu.findItem(R.id.delete_action).setVisible((!albumsMode || editMode) && (!all_photos || editMode));
-        menu.findItem(R.id.hideAlbumButton).setVisible(!all_photos && getAlbums().getSelectedCount() > 0);
+        menu.findItem(R.id.delete_action).setVisible((!albumsMode || editMode) && (!all_photos || editMode) &&
+                (!fav_photos || editMode));
+        menu.findItem(R.id.hideAlbumButton).setVisible(!all_photos && !fav_photos && getAlbums().getSelectedCount() >
+                0);
 
-        menu.findItem(R.id.clear_album_preview).setVisible(!albumsMode && getAlbum().hasCustomCover());
-        menu.findItem(R.id.renameAlbum).setVisible(((albumsMode && getAlbums().getSelectedCount() == 1) || (!albumsMode && !editMode)) && !all_photos);
+        menu.findItem(R.id.clear_album_preview).setVisible(!albumsMode && getAlbum().hasCustomCover() && !fav_photos);
+        menu.findItem(R.id.renameAlbum).setVisible(((albumsMode && getAlbums().getSelectedCount() == 1) ||
+                (!albumsMode && !editMode)) && (!all_photos && !fav_photos));
         if (getAlbums().getSelectedCount() == 1)
             menu.findItem(R.id.set_pin_album).setTitle(getAlbums().getSelectedAlbum(0).isPinned() ? getString(R.string.un_pin) : getString(R.string.pin));
         menu.findItem(R.id.set_pin_album).setVisible(albumsMode && getAlbums().getSelectedCount() == 1);
-        menu.findItem(R.id.setAsAlbumPreview).setVisible(!albumsMode && !all_photos && getAlbum().getSelectedCount() == 1);
-        menu.findItem(R.id.affixPhoto).setVisible(!albumsMode && (getAlbum().getSelectedCount() > 1) || selectedMedias.size() > 1);
+        menu.findItem(R.id.setAsAlbumPreview).setVisible(!albumsMode && !all_photos && getAlbum()
+                .getSelectedCount() == 1);
+        menu.findItem(R.id.affixPhoto).setVisible((!albumsMode && (getAlbum().getSelectedCount() > 1) ||
+                selectedMedias.size() > 1) && !fav_photos);
         return super.onPrepareOptionsMenu(menu);
     }
 
@@ -1221,7 +1374,7 @@ public class LFMainActivity extends SharedMediaActivity {
                     else getAlbums().selectAllAlbums();
                     albumsAdapter.notifyDataSetChanged();
                 } else {
-                    if (!all_photos) {
+                    if (!all_photos && !fav_photos) {
                         //if all photos are already selected, unselect all of them
                         if (getAlbum().getSelectedCount() == mediaAdapter.getItemCount()) {
                             editMode = false;
@@ -1230,7 +1383,7 @@ public class LFMainActivity extends SharedMediaActivity {
                         // else, select all photos
                         else getAlbum().selectAllPhotos();
                         mediaAdapter.notifyDataSetChanged();
-                    } else {
+                    } else if(all_photos && !fav_photos){
 
                         if (selectedMedias.size() == size) {
                             editMode = false;
@@ -1242,6 +1395,18 @@ public class LFMainActivity extends SharedMediaActivity {
                             selectAllPhotos();
                         }
                         mediaAdapter.notifyDataSetChanged();
+                    }
+                    else if(fav_photos && !all_photos){
+                        if (selectedMedias.size() == favouriteslist.size()) {
+                            editMode = false;
+                            clearSelectedPhotos();
+                        }
+                        // else, select all photos
+                        else {
+                            clearSelectedPhotos();
+                            selectAllPhotos();
+                        }
+                        mediaAdapter.swapDataSet(favouriteslist);
                     }
                 }
                 invalidateOptionsMenu();
@@ -1306,6 +1471,8 @@ public class LFMainActivity extends SharedMediaActivity {
             case R.id.delete_action:
                 getNavigationBar();
                 class DeletePhotos extends AsyncTask<String, Integer, Boolean> {
+
+                    private boolean succ=false;
                     @Override
                     protected void onPreExecute() {
                         swipeRefreshLayout.setRefreshing(true);
@@ -1317,13 +1484,12 @@ public class LFMainActivity extends SharedMediaActivity {
                     protected Boolean doInBackground(String... arg0) {
                         //if in album mode, delete selected albums
                         if (albumsMode)
-                            return getAlbums().deleteSelectedAlbums(LFMainActivity.this);
+                            succ = getAlbums().deleteSelectedAlbums(LFMainActivity.this);
                         else {
                             // if in selection mode, delete selected media
-                            if (editMode && !all_photos)
-                                return getAlbum().deleteSelectedMedia(getApplicationContext());
-                            else if (all_photos) {
-                                Boolean succ = false;
+                            if (editMode && !all_photos && !fav_photos)
+                                succ=getAlbum().deleteSelectedMedia(getApplicationContext());
+                            else if (all_photos && !fav_photos) {
                                 for (Media media : selectedMedias) {
                                     String[] projection = {MediaStore.Images.Media._ID};
 
@@ -1334,11 +1500,13 @@ public class LFMainActivity extends SharedMediaActivity {
                                     // Query for the ID of the media matching the file path
                                     Uri queryUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
                                     ContentResolver contentResolver = getContentResolver();
-                                    Cursor c = contentResolver.query(queryUri, projection, selection, selectionArgs, null);
+                                    Cursor c =
+                                            contentResolver.query(queryUri, projection, selection, selectionArgs, null);
                                     if (c.moveToFirst()) {
                                         // We found the ID. Deleting the item via the content provider will also remove the file
                                         long id = c.getLong(c.getColumnIndexOrThrow(MediaStore.Images.Media._ID));
-                                        Uri deleteUri = ContentUris.withAppendedId(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, id);
+                                        Uri deleteUri = ContentUris
+                                                .withAppendedId(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, id);
                                         contentResolver.delete(deleteUri, null, null);
                                         succ = true;
                                     } else {
@@ -1347,15 +1515,29 @@ public class LFMainActivity extends SharedMediaActivity {
                                     }
                                     c.close();
                                 }
-                                return succ;
+                            } else if(fav_photos && !all_photos){
+                                realm = Realm.getDefaultInstance();
+                                realm.executeTransaction(new Realm.Transaction() {
+                                    @Override public void execute(Realm realm) {
+                                        for(int i = 0; i < selectedMedias.size(); i++){
+                                            RealmResults<FavouriteImagesModel> favouriteImagesModels = realm.where
+                                                    (FavouriteImagesModel.class).equalTo("path", selectedMedias.get
+                                                    (i).getPath()).findAll();
+                                            favouriteImagesModels.deleteAllFromRealm();
+                                        }
+                                    }
+                                });
+
+                               succ=true;
                             }
+
                             // if not in selection mode, delete current album entirely
-                            else {
-                                boolean succ = getAlbums().deleteAlbum(getAlbum(), getApplicationContext());
+                            else if (!editMode) {
+                                succ = getAlbums().deleteAlbum(getAlbum(), getApplicationContext());
                                 getAlbum().getMedia().clear();
-                                return succ;
                             }
                         }
+                        return succ;
                     }
 
                     @Override
@@ -1366,7 +1548,7 @@ public class LFMainActivity extends SharedMediaActivity {
                                 getAlbums().clearSelectedAlbums();
                                 albumsAdapter.notifyDataSetChanged();
                             } else {
-                                if (!all_photos) {
+                                if (!all_photos && !fav_photos) {
                                     //if all media in current album have been deleted, delete current album too.
                                     if (getAlbum().getMedia().size() == 0) {
                                         getAlbums().removeCurrentAlbum();
@@ -1375,12 +1557,17 @@ public class LFMainActivity extends SharedMediaActivity {
                                         swipeRefreshLayout.setRefreshing(true);
                                     } else
                                         mediaAdapter.swapDataSet(getAlbum().getMedia());
-                                } else {
+                                } else if(all_photos && !fav_photos){
                                     clearSelectedPhotos();
                                     listAll = StorageProvider.getAllShownImages(LFMainActivity.this);
                                     media = listAll;
                                     size = listAll.size();
                                     mediaAdapter.swapDataSet(listAll);
+                                }
+                                else if(fav_photos && !all_photos){
+                                    clearSelectedPhotos();
+                                    getfavouriteslist();
+                                    new FavouritePhotos().execute();
                                 }
                             }
                         } else requestSdCardPermissions();
@@ -1504,17 +1691,21 @@ public class LFMainActivity extends SharedMediaActivity {
 
                 // list of all selected media in current album
                 ArrayList<Uri> files = new ArrayList<Uri>();
-                if (!all_photos) {
+                if (!all_photos && !fav_photos) {
                     for (Media f : getAlbum().getSelectedMedia())
                         files.add(f.getUri());
-                } else {
+                } else if(all_photos && !fav_photos) {
                     for (Media f : selectedMedias)
                         files.add(f.getUri());
+                } else if(fav_photos && !all_photos){
+                    for(Media m : selectedMedias){
+                        files.add(m.getUri());
+                    }
                 }
 
-                if(!all_photos){
-                    Realm realm = Realm.getDefaultInstance();
+                if(!all_photos && !fav_photos){
                     for(Media f: getAlbum().getSelectedMedia()){
+                        Realm realm = Realm.getDefaultInstance();
                         realm.beginTransaction();
                         UploadHistoryRealmModel uploadHistory;
                         uploadHistory = realm.createObject(UploadHistoryRealmModel.class);
@@ -1527,14 +1718,14 @@ public class LFMainActivity extends SharedMediaActivity {
                         result.putExtra(Constants.SHARE_RESULT, 0);
                         setResult(RESULT_OK, result);
                     }
-                }else{
-                    Realm realm = Realm.getDefaultInstance();
-                    for(Media f: selectedMedias){
+                }else if(all_photos || fav_photos){
+                    for(Media m: selectedMedias){
+                        Realm realm = Realm.getDefaultInstance();
                         realm.beginTransaction();
                         UploadHistoryRealmModel uploadHistory;
                         uploadHistory = realm.createObject(UploadHistoryRealmModel.class);
                         uploadHistory.setName("OTHERS");
-                        uploadHistory.setPathname(f.getPath());
+                        uploadHistory.setPathname(m.getPath());
                         uploadHistory.setDatetime(new SimpleDateFormat("dd/MM/yyyy HH:mm:ss").format(new Date()));
                         uploadHistory.setStatus(getString(R.string.upload_done));
                         realm.commitTransaction();
@@ -1549,9 +1740,12 @@ public class LFMainActivity extends SharedMediaActivity {
                 String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
 
                 intent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, files);
-                if (!all_photos)
+                if (!all_photos && !fav_photos)
                     intent.setType(StringUtils.getGenericMIME(getAlbum().getSelectedMedia(0).getMimeType()));
-                else intent.setType(mimeType);
+                else if(all_photos && !fav_photos)
+                    intent.setType(mimeType);
+                else if(fav_photos && !all_photos)
+                    intent.setType(mimeType);
                 finishEditMode();
                 startActivity(Intent.createChooser(intent, getResources().getText(R.string.send_to)));
                 return true;
@@ -1563,11 +1757,12 @@ public class LFMainActivity extends SharedMediaActivity {
                     new SortingUtilsAlbums().execute();
                 } else {
                     new SortModeSet().execute(NAME);
-                    if(!all_photos){
+                    if(!all_photos && !fav_photos){
                         new SortingUtilsPhtots().execute();
-                    }
-                    else {
+                    }else if (all_photos && !fav_photos) {
                         new SortingUtilsListAll().execute();
+                    }else if(fav_photos && !all_photos){
+                        new SortingUtilsFavouritelist().execute();
                     }
                 }
                 item.setChecked(true);
@@ -1579,11 +1774,13 @@ public class LFMainActivity extends SharedMediaActivity {
                     new SortingUtilsAlbums().execute();
                 } else {
                     new SortModeSet().execute(DATE);
-                    if(!all_photos){
+                    if(!all_photos && !fav_photos){
                         new SortingUtilsPhtots().execute();
                     }
-                    else {
+                    else if (all_photos && !fav_photos) {
                         new SortingUtilsListAll().execute();
+                    }else if(fav_photos && !all_photos){
+                        new SortingUtilsFavouritelist().execute();
                     }
                 }
                 item.setChecked(true);
@@ -1595,11 +1792,13 @@ public class LFMainActivity extends SharedMediaActivity {
                     new SortingUtilsAlbums().execute();
                 } else {
                     new SortModeSet().execute(SIZE);
-                    if(!all_photos){
+                    if(!all_photos && !fav_photos){
                         new SortingUtilsPhtots().execute();
                     }
-                    else  {
+                    else if (all_photos && !fav_photos) {
                         new SortingUtilsListAll().execute();
+                    }else if(fav_photos && !all_photos){
+                        new SortingUtilsFavouritelist().execute();
                     }
                 }
                 item.setChecked(true);
@@ -1611,11 +1810,13 @@ public class LFMainActivity extends SharedMediaActivity {
                     new SortingUtilsAlbums().execute();
                 } else {
                     new SortModeSet().execute(NUMERIC);
-                    if(!all_photos){
+                    if(!all_photos && !fav_photos){
                         new SortingUtilsPhtots().execute();
                     }
-                    else {
+                    else if (all_photos && !fav_photos) {
                         new SortingUtilsListAll().execute();
+                    }else if(fav_photos && !all_photos){
+                        new SortingUtilsFavouritelist().execute();
                     }
                 }
                 item.setChecked(true);
@@ -1627,11 +1828,13 @@ public class LFMainActivity extends SharedMediaActivity {
                     new SortingUtilsAlbums().execute();
                 } else {
                     getAlbum().setDefaultSortingAscending(getApplicationContext(), item.isChecked() ? SortingOrder.DESCENDING : SortingOrder.ASCENDING);
-                    if(!all_photos){
+                    if(!all_photos && !fav_photos){
                         new SortingUtilsPhtots().execute();
                     }
-                    else  {
+                    else if (all_photos && !fav_photos) {
                         new SortingUtilsListAll().execute();
+                    }else if(fav_photos && !all_photos){
+                        new SortingUtilsFavouritelist().execute();
                     }
                 }
                 item.setChecked(!item.isChecked());
@@ -2026,7 +2229,6 @@ public class LFMainActivity extends SharedMediaActivity {
     private class SortModeSet extends AsyncTask<SortingMode, Void, Void> {
 
         @Override protected Void doInBackground(SortingMode... sortingModes) {
-
             for(Album a: getAlbums().dispAlbums){
                 if(a.settings.getSortingMode().getValue()!=sortingModes[0].getValue()){
                     a.setDefaultSortingMode(getApplicationContext(), sortingModes[0]);
@@ -2035,7 +2237,7 @@ public class LFMainActivity extends SharedMediaActivity {
             return null;
         }
     }
-
+    
     private Bitmap getBitmap(String path) {
 
         Uri uri = Uri.fromFile(new File(path));
@@ -2140,7 +2342,7 @@ public class LFMainActivity extends SharedMediaActivity {
     @Override
     public void onBackPressed() {
         checkForReveal = true;
-        if(editMode && all_photos)
+        if((editMode && all_photos) || (editMode && fav_photos))
             clearSelectedPhotos();
         getNavigationBar();
         if (editMode) finishEditMode();
@@ -2338,6 +2540,35 @@ public class LFMainActivity extends SharedMediaActivity {
         }
     }
 
+    private class FavouritePhotos extends AsyncTask<Void, Void, Void> {
+
+        @Override
+        protected void onPreExecute() {
+            swipeRefreshLayout.setRefreshing(true);
+            toggleRecyclersVisibility(false);
+            super.onPreExecute();
+        }
+
+        @Override
+        protected Void doInBackground(Void... arg0) {
+            getAlbum().updatePhotos(getApplicationContext());
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(Void result) {
+            Collections.sort(favouriteslist, MediaComparators.getComparator(getAlbum().settings.getSortingMode(), getAlbum()
+                    .settings.getSortingOrder()));
+            mediaAdapter.swapDataSet(favouriteslist);
+            checkNothing();
+            swipeRefreshLayout.setRefreshing(false);
+            invalidateOptionsMenu();
+            finishEditMode();
+            toolbar.setTitle(getResources().getString(R.string.favourite_title));
+            clearSelectedPhotos();
+        }
+    }
+
     /*
     Async Class for Sorting Photos - NOT listAll
      */
@@ -2384,6 +2615,33 @@ public class LFMainActivity extends SharedMediaActivity {
             super.onPostExecute(aVoid);
             swipeRefreshLayout.setRefreshing(false);
             mediaAdapter.swapDataSet(listAll);
+        }
+    }
+
+    /*
+    Async Class for Sorting Favourites
+     */
+
+    private class SortingUtilsFavouritelist extends AsyncTask<Void, Void, Void> {
+
+        @Override
+        protected void onPreExecute() {
+            super.onPreExecute();
+            swipeRefreshLayout.setRefreshing(true);
+        }
+
+        @Override
+        protected Void doInBackground(Void... aVoid) {
+            Collections.sort(favouriteslist, MediaComparators.getComparator(getAlbum().settings.getSortingMode(), getAlbum()
+                    .settings.getSortingOrder()));
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(Void aVoid) {
+            super.onPostExecute(aVoid);
+            swipeRefreshLayout.setRefreshing(false);
+            mediaAdapter.swapDataSet(favouriteslist);
         }
     }
 

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -98,6 +98,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.realm.Realm;
 import io.realm.RealmQuery;
+import io.realm.RealmResults;
 
 import static org.fossasia.phimpme.R.string.media;
 import static org.fossasia.phimpme.gallery.activities.LFMainActivity.listAll;
@@ -132,6 +133,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
     public static final String EXTRA_OUTPUT = "extra_output";
     public static String pathForDescription;
     public Boolean allPhotoMode;
+    public Boolean favphotomode;
     public int all_photo_pos;
     public int size_all;
     public int current_image_pos;
@@ -143,6 +145,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
     private Runnable runnable;
     boolean slideshow=false;
     private boolean details=false;
+    private ArrayList<Media> favouriteslist;
 
     ImageDescModel temp;
     private final int REQ_CODE_SPEECH_INPUT = 100;
@@ -178,11 +181,13 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
         @Override
         public void run() {
             try{
-                if(!allPhotoMode){
+                if(!allPhotoMode && !favphotomode){
                     mViewPager.scrollToPosition((getAlbum().getCurrentMediaIndex() + 1) % getAlbum().getMedia().size());
                 }
-                else{
+                else if(allPhotoMode && !favphotomode) {
                     mViewPager.scrollToPosition((current_image_pos + 1) % listAll.size());
+                }else if(favphotomode && !allPhotoMode){
+                    mViewPager.scrollToPosition((current_image_pos + 1) % favouriteslist.size());
                 }
             }
             catch (Exception e) {
@@ -215,9 +220,13 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
         overridePendingTransition(R.anim.media_zoom_in,0);
         SP = PreferenceUtil.getInstance(getApplicationContext());
         securityObj = new SecurityHelper(SingleMediaActivity.this);
+        favphotomode = getIntent().getBooleanExtra("fav_photos", false);
         allPhotoMode = getIntent().getBooleanExtra(getString(R.string.all_photo_mode), false);
         all_photo_pos = getIntent().getIntExtra(getString(R.string.position), 0);
         size_all = getIntent().getIntExtra(getString(R.string.allMediaSize), getAlbum().getCount());
+        if(getIntent().hasExtra("favouriteslist")){
+            favouriteslist = getIntent().getParcelableArrayListExtra("favouriteslist");
+        }
 
         String path2 = getIntent().getStringExtra("path");
         pathForDescription = path2;
@@ -233,9 +242,11 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 if (path != null)
                     file = new File(path);
 
-                if (file != null && file.isFile())
+                if (file != null && file.isFile()){
                     //the image is stored in the storage
                     album = new Album(getApplicationContext(), file);
+                }
+
                 else {
                     //try to show with Uri
                     album = new Album(getApplicationContext(), getIntent().getData());
@@ -305,13 +316,10 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
             }
         };
 
-        if (!allPhotoMode) {
+        if (!allPhotoMode && !favphotomode) {
             adapter = new ImageAdapter(getAlbum().getMedia(), basicCallBack, this, this);
-
             getSupportActionBar().setTitle((getAlbum().getCurrentMediaIndex() + 1) + " " + getString(R.string.of) + " " + getAlbum().getMedia().size());
 //            toolbar.setTitle((mViewPager.getCurrentItem() + 1) + " " + getString(R.string.of) + " " + getAlbum().getMedia().size());
-
-
             mViewPager.setOnPageChangeListener(new PagerRecyclerView.OnPageChangeListener() {
                 @Override
                 public void onPageChanged(int oldPosition, int position) {
@@ -322,14 +330,10 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 }
             });
             mViewPager.scrollToPosition(getAlbum().getCurrentMediaIndex());
-
-
-        } else {
-
+        } else if(allPhotoMode && !favphotomode){
             adapter = new ImageAdapter(LFMainActivity.listAll, basicCallBack, this, this);
             getSupportActionBar().setTitle(all_photo_pos + 1 + " " + getString(R.string.of) + " " + size_all);
             current_image_pos = all_photo_pos;
-
             mViewPager.setOnPageChangeListener(new PagerRecyclerView.OnPageChangeListener() {
                 @Override
                 public void onPageChanged(int oldPosition, int position) {
@@ -338,6 +342,21 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                     toolbar.setTitle((position + 1) + " " + getString(R.string.of) + " " + size_all);
                     invalidateOptionsMenu();
                     pathForDescription = listAll.get(position).getPath();
+                }
+            });
+            mViewPager.scrollToPosition(all_photo_pos);
+        } else if(!allPhotoMode && favphotomode){
+            adapter = new ImageAdapter(favouriteslist, basicCallBack, this, this);
+            getSupportActionBar().setTitle(all_photo_pos + 1 + " " + getString(R.string.of) + " " + size_all);
+            current_image_pos = all_photo_pos;
+            mViewPager.setOnPageChangeListener(new PagerRecyclerView.OnPageChangeListener() {
+                @Override
+                public void onPageChanged(int oldPosition, int position) {
+                    current_image_pos = position;
+                    getAlbum().setCurrentPhotoIndex(getAlbum().getCurrentMediaIndex());
+                    toolbar.setTitle((position + 1) + " " + getString(R.string.of) + " " + size_all);
+                    invalidateOptionsMenu();
+                    pathForDescription = favouriteslist.get(position).getPath();
                 }
             });
             mViewPager.scrollToPosition(all_photo_pos);
@@ -466,8 +485,16 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
 
     @Override
     public boolean onPrepareOptionsMenu(final Menu menu) {
-        if (!allPhotoMode)
+        if (!allPhotoMode && !favphotomode){
             menu.setGroupVisible(R.id.only_photos_options, true);
+        }
+        else if(!allPhotoMode && favphotomode){
+            menu.findItem(R.id.action_favourites).setVisible(false);
+            menu.findItem(R.id.action_cover).setVisible(false);
+            menu.findItem(R.id.action_description).setVisible(false);
+            menu.findItem(R.id.action_copy).setVisible(false);
+            menu.findItem(R.id.action_move).setVisible(false);
+        }
 
         if (customUri) {
             menu.setGroupVisible(R.id.on_internal_storage, false);
@@ -553,7 +580,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
     }
 
     private void deleteCurrentMedia() {
-        if (!allPhotoMode) {
+        if (!allPhotoMode && !favphotomode) {
             boolean success = getAlbum().deleteCurrentMedia(getApplicationContext());
             if(!success){
 
@@ -580,13 +607,37 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
             }
             adapter.notifyDataSetChanged();
             getSupportActionBar().setTitle((getAlbum().getCurrentMediaIndex() + 1) + " " + getString(R.string.of) + " " + getAlbum().getMedia().size());
-        } else {
+        } else if(allPhotoMode && !favphotomode) {
             deleteMedia(listAll.get(current_image_pos).getPath());
             LFMainActivity.listAll.remove(current_image_pos);
             size_all = LFMainActivity.listAll.size();
             adapter.notifyDataSetChanged();
 //            mViewPager.setCurrentItem(current_image_pos);
 //            toolbar.setTitle((mViewPager.getCurrentItem() + 1) + " " + getString(R.string.of) + " " + size_all);
+        } else if(favphotomode && !allPhotoMode){
+            int c = current_image_pos;
+            //deleteMedia(favouriteslist.get(current_image_pos).getPath());
+            realm = Realm.getDefaultInstance();
+            realm.executeTransaction(new Realm.Transaction() {
+                @Override public void execute(Realm realm) {
+                    RealmResults<FavouriteImagesModel> favouriteImagesModels = realm.where(FavouriteImagesModel
+                            .class).equalTo("path", favouriteslist.get(current_image_pos).getPath()).findAll();
+                    favouriteImagesModels.deleteAllFromRealm();
+                }
+            });
+            deletefromfavouriteslist(favouriteslist.get(current_image_pos).getPath());
+            size_all = favouriteslist.size();
+            adapter.notifyDataSetChanged();
+            getSupportActionBar().setTitle((c + 1) + " " + getString(R.string.of) + " " + size_all);
+        }
+    }
+
+    private void deletefromfavouriteslist(String path){
+        for (int i = 0; i < favouriteslist.size(); i++){
+            if(favouriteslist.get(i).getPath().equals(path)){
+                favouriteslist.remove(i);
+                break;
+            }
         }
     }
 
@@ -612,8 +663,9 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
 
+
+        switch (item.getItemId()) {
             case android.R.id.home:
                 supportFinishAfterTransition();
                 return true;
@@ -689,8 +741,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
 
             case R.id.action_favourites:
                 realm = Realm.getDefaultInstance();
-                uri = Uri.fromFile(new File(getAlbum().getCurrentMedia().getPath()));
-                String realpath = String.valueOf(uri);
+                String realpath = getAlbum().getCurrentMedia().getPath();
                 RealmQuery<FavouriteImagesModel> query = realm.where(FavouriteImagesModel.class).equalTo("path",
                         realpath);
                 if(query.count() == 0){
@@ -809,10 +860,12 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 details=true;
                 final View v = findViewById(R.id.layout_image_description);
                 LinearLayout linearLayout = (LinearLayout)v;
-                if(!allPhotoMode){
+                if(!allPhotoMode && !favphotomode){
                     media = getAlbum().getCurrentMedia();
-                }else if(allPhotoMode){
+                }else if(allPhotoMode && !favphotomode){
                     media = new Media(new File(listAll.get(current_image_pos).getPath()));
+                }else if(!allPhotoMode && favphotomode){
+                    media = new Media(new File(favouriteslist.get(current_image_pos).getPath()));
                 }
                 MediaDetailsMap<String,String> mediaDetailsMap = media.getMainDetails(this);
 
@@ -1182,15 +1235,12 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
             slideshow=false;
         }
     }
-
-
+    
     @Override
     public void startPostponedTransition() {
         getWindow().setSharedElementEnterTransition(new ChangeBounds().setDuration(300));
         startPostponedEnterTransition();
-
     }
-
 
     private void setSlideShowDialog() {
 

--- a/app/src/main/res/layout/activity_drawer.xml
+++ b/app/src/main/res/layout/activity_drawer.xml
@@ -100,6 +100,35 @@
                         android:textSize="16sp"/>
                 </LinearLayout>
 
+                <!--Favourites Folder-->
+                <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                              android:id="@+id/ll_drawer_favourites"
+                              android:layout_width="match_parent"
+                              android:layout_height="wrap_content"
+                              android:background="@drawable/ripple"
+                              android:clickable="true"
+                              android:orientation="horizontal">
+
+                    <com.mikepenz.iconics.view.IconicsImageView
+                        android:id="@+id/Drawer_favourite_Icon"
+                        android:layout_width="@dimen/icon_width_height"
+                        android:layout_height="@dimen/icon_width_height"
+                        android:layout_gravity="center_vertical"
+                        android:layout_marginLeft="@dimen/big_spacing"
+                        android:layout_marginRight="@dimen/big_spacing"
+                        app:iiv_icon="gmd_grade"/>
+
+                    <TextView
+                        android:id="@+id/Drawer_favourite_Item"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingBottom="16dp"
+                        android:paddingTop="16dp"
+                        android:text="@string/favourite_folder"
+                        android:textColor="@color/md_dark_background"
+                        android:textSize="16sp"/>
+                </LinearLayout>
+
                 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
                               android:id="@+id/ll_drawer_uploadhistory"
                               android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -472,6 +472,7 @@
     <string name="move_to">Move to</string>
     <string name="use_as">Use as</string>
     <string name="favourite">Add to favourites</string>
+    <string name="favourite_title">Favourite Photos</string>
     <string name="edit">Edit</string>
     <string name="fix_date">Fix date</string>
     <string name="rename">Rename</string>
@@ -734,6 +735,7 @@
     <!--DRAWER ITEMS -->
     <string name="local_folder">Local Folders</string>
     <string name="hidden_folder">Hidden Folders</string>
+    <string name="favourite_folder">Favourites</string>
     <string name="tags">Tags</string>
     <string name="timeline">Timeline</string>
     <string name="wallpapers">Wallpapers</string>


### PR DESCRIPTION
Second step for issue #1289 

Changes: Favourite collection photos displayed to the users, actions such as sharing, deletion etc can be performed on them.

Screenshots for the change: 
![videotogif_2017 12 22_16 34 41](https://user-images.githubusercontent.com/20841578/34296040-9640171a-e736-11e7-9653-94d82a5f036f.gif)



