### PR TITLE
Fix #1535 - Fix the toolbar text size to default size.

### DIFF
--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -2,6 +2,7 @@
 <android.support.v7.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     style="@style/MyToolbar"
-    app:layout_scrollFlags="scroll|enterAlways"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content" />
+    android:layout_height="wrap_content"
+    app:layout_scrollFlags="scroll|enterAlways"
+    app:titleTextAppearance="@style/ToolbarTitle" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -70,6 +70,10 @@
         <item name="colorControlHighlight">#FFF</item>
     </style>
 
+    <style name="ToolbarTitle" parent="TextAppearance.Widget.AppCompat.Toolbar.Title">
+        <item name="android:textSize">20sp</item>
+    </style>
+
     <style name="fab_camera">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>


### PR DESCRIPTION
Fix #1535

Changes: Fix toolbar text size for all orientations.

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/22395998/34334927-fac0b26c-e970-11e7-9382-86ffc523d3bf.png)

![image](https://user-images.githubusercontent.com/22395998/34334931-0853859e-e971-11e7-9763-802aaafc332e.png)
