### PR TITLE
Fixes #1550 App stop working when pressing "Use as" in selected picture

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/MyApplication.java
+++ b/app/src/main/java/org/fossasia/phimpme/MyApplication.java
@@ -2,6 +2,7 @@ package org.fossasia.phimpme;
 
 import android.app.Application;
 import android.content.Context;
+import android.os.StrictMode;
 import android.support.multidex.MultiDex;
 import android.util.Log;
 
@@ -51,6 +52,9 @@ public class MyApplication extends Application {
 
     @Override
     public void onCreate() {
+
+        StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder();
+        StrictMode.setVmPolicy(builder.build());
 
         if (LeakCanary.isInAnalyzerProcess(this)) {
             // This process is dedicated to LeakCanary for heap analysis.


### PR DESCRIPTION
Fix #1550

Changes:  android **below API 23** does not check for file uri exposure while above API 24 device checks this.So we can disable it by setting a new [VmPolicy](https://stackoverflow.com/a/40674771
).

Screenshots for the change:
![screenshot_20171226-223745](https://user-images.githubusercontent.com/16614355/34361145-97b08cf6-ea8d-11e7-9b60-2b864295be84.png)



