### PR TITLE
Fix #1565-SD card icon displayed for albums present in the external s…

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
@@ -7,6 +7,7 @@ import android.graphics.PorterDuff;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.os.Environment;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.RecyclerView;
 import android.text.Html;
@@ -74,6 +75,12 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
     public void onBindViewHolder(final AlbumsAdapter.ViewHolder holder, int position) {
         Album a = SharedMediaActivity.getAlbums().dispAlbums.get(position);
         Media f = a.getCoverAlbum();
+
+        if(a.getPath().contains(Environment.getExternalStorageDirectory().getPath())){
+            holder.storage.setVisibility(View.INVISIBLE);
+        }else{
+            holder.storage.setVisibility(View.VISIBLE);
+        }
 
         if (a.isPinned())
             holder.pin.setVisibility(View.VISIBLE);
@@ -178,6 +185,7 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
         private IconicsImageView selectedIcon;
         private TextView name, nPhotos;
         private ImageView pin;
+        private ImageView storage;
 
         ViewHolder(View itemView) {
             super(itemView);
@@ -187,6 +195,7 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
             name = (TextView) itemView.findViewById(R.id.album_name);
             nPhotos = (TextView) itemView.findViewById(R.id.album_photos_count);
             pin = (ImageView) itemView.findViewById(R.id.icon_pinned);
+            storage = (ImageView) itemView.findViewById(R.id.storage_icon);
         }
     }
 }

--- a/app/src/main/res/drawable/ic_sd_storage_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_sd_storage_black_24dp.xml
@@ -1,0 +1,4 @@
+<vector android:height="14dp" android:viewportHeight="24.0"
+    android:viewportWidth="24.0" android:width="14dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M18,2h-8L4.02,8 4,20c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,4c0,-1.1 -0.9,-2 -2,-2zM12,8h-2L10,4h2v4zM15,8h-2L13,4h2v4zM18,8h-2L16,4h2v4z"/>
+</vector>

--- a/app/src/main/res/layout/card_album.xml
+++ b/app/src/main/res/layout/card_album.xml
@@ -82,16 +82,34 @@
 
             </RelativeLayout>
 
-            <TextView
-                android:id="@+id/album_photos_count"
+            <RelativeLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:maxLines="1"
-                android:paddingBottom="10dp"
-                android:paddingEnd="10dp"
-                android:paddingStart="10dp"
-                android:textColor="@android:color/white"
-                android:textSize="14sp" />
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:id="@+id/album_photos_count"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:maxLines="1"
+                    android:paddingBottom="10dp"
+                    android:paddingEnd="10dp"
+                    android:paddingStart="10dp"
+                    android:textColor="@android:color/white"
+                    android:textSize="14sp" />
+
+                <ImageView android:layout_width="wrap_content"
+                           android:layout_height="wrap_content"
+                           android:id="@+id/storage_icon"
+                           android:layout_centerVertical="true"
+                           android:paddingLeft="10dp"
+                           android:paddingStart="10dp"
+                           android:paddingTop="10dp"
+                           android:paddingRight="10dp"
+                           android:visibility="visible"
+                           android:layout_alignParentRight="true"
+                           app2:srcCompat="@drawable/ic_sd_storage_black_24dp"/>
+
+            </RelativeLayout>
         </LinearLayout>
     </RelativeLayout>
 </android.support.v7.widget.CardView>


### PR DESCRIPTION
…torage.

Fix #1565 

Changes: SD card icon displayed along with album name and media count for albums present in the external storage.

Screenshots for the change: 
![screenshot_2017-12-30-04-30-48-836_org fossasia phimpme](https://user-images.githubusercontent.com/20841578/34449068-4f5ad198-ed1a-11e7-842d-bc20014b6e47.png)

