### PR TITLE
Fix #1568-All photos delete issue fixed.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1357,7 +1357,7 @@ public class LFMainActivity extends SharedMediaActivity {
                         .ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        //empty method body
+                        finishEditMode();
                     }});
                 detailsDialog.show();
                 AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE}, getAccentColor(), detailsDialog);
@@ -1562,6 +1562,8 @@ public class LFMainActivity extends SharedMediaActivity {
                                     listAll = StorageProvider.getAllShownImages(LFMainActivity.this);
                                     media = listAll;
                                     size = listAll.size();
+                                    Collections.sort(listAll, MediaComparators.getComparator(getAlbum().settings
+                                            .getSortingMode(), getAlbum().settings.getSortingOrder()));
                                     mediaAdapter.swapDataSet(listAll);
                                 }
                                 else if(fav_photos && !all_photos){

--- a/app/src/main/res/layout/dialog_album_detail.xml
+++ b/app/src/main/res/layout/dialog_album_detail.xml
@@ -244,7 +244,7 @@
                       android:id="@+id/album_details_hidden"
                       android:textSize="17dp"
                       android:textColor="@color/icongrey"
-                      android:layout_marginLeft="55dp"/>
+                      android:layout_marginLeft="56dp"/>
           </LinearLayout>
           <View android:layout_width="match_parent"
                 android:layout_height="1dp"


### PR DESCRIPTION
Fix #1568 

Changes: The updated list is displayed in the same order after performing delete action as it was before. 
