### PR TITLE
Fix #1558-Added option to password secure particular folders.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -30,6 +30,7 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.ActivityOptionsCompat;
 import android.support.design.widget.Snackbar;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.print.PrintHelper;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.widget.DrawerLayout;
@@ -123,6 +124,8 @@ import static org.fossasia.phimpme.gallery.data.base.SortingMode.DATE;
 import static org.fossasia.phimpme.gallery.data.base.SortingMode.NAME;
 import static org.fossasia.phimpme.gallery.data.base.SortingMode.NUMERIC;
 import static org.fossasia.phimpme.gallery.data.base.SortingMode.SIZE;
+
+import static android.R.attr.bitmap;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -409,38 +412,171 @@ public class LFMainActivity extends SharedMediaActivity {
     };
 
     private View.OnLongClickListener albumOnLongCLickListener = new View.OnLongClickListener() {
+
         @Override
         public boolean onLongClick(View v) {
-            if(checkForReveal) {
-                enterReveal();
-                checkForReveal = false;
-            }
-            albumsAdapter.notifyItemChanged(getAlbums().toggleSelectAlbum(((Album) v.findViewById(R.id.album_name).getTag())));
-            editMode = true;
-            invalidateOptionsMenu();
-            if(getAlbums().getSelectedCount()==0)
-                getNavigationBar();
-            else
-            {
-                hideNavigationBar();
-                hidenav=true;
+            final Album album = (Album) v.findViewById(R.id.album_name).getTag();
+            if(securityObj.isActiveSecurity() && securityObj.isPasswordOnfolder()) {
+                if (check(album.getPath())) {
+                    AlertDialog.Builder passwordDialogBuilder =
+                            new AlertDialog.Builder(LFMainActivity.this, getDialogStyle());
+                    final EditText editTextPassword =
+                            securityObj.getInsertPasswordDialog(LFMainActivity.this, passwordDialogBuilder);
+                    passwordDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
+
+                    passwordDialogBuilder.setPositiveButton(getString(R.string.ok_action).toUpperCase(),
+                            new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    //This should br empty it will be overwrite later
+                                    //to avoid dismiss of the dialog on wrong password
+                                }
+                            });
+
+                    final AlertDialog passwordDialog = passwordDialogBuilder.create();
+                    passwordDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+                    passwordDialog.show();
+                    AlertDialogsHelper.setButtonTextColor(
+                            new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE},
+                            getAccentColor(), passwordDialog);
+                    passwordDialog.getButton(AlertDialog.BUTTON_POSITIVE)
+                            .setOnClickListener(new View.OnClickListener() {
+                                @Override
+                                public void onClick(View v) {
+                                    if (securityObj.checkPassword(editTextPassword.getText().toString())) {
+                                        passwordDialog.dismiss();
+                                        if(checkForReveal) {
+                                            enterReveal();
+                                            checkForReveal = false;
+                                        }
+                                        albumsAdapter.notifyItemChanged(getAlbums().toggleSelectAlbum(album));
+                                        editMode = true;
+                                        invalidateOptionsMenu();
+                                        if(getAlbums().getSelectedCount()==0)
+                                            getNavigationBar();
+                                        else
+                                        {
+                                            hideNavigationBar();
+                                            hidenav=true;
+                                        }
+                                    }
+                                    // if password is incorrect, notify user of incorrect password
+                                    else {
+                                        SnackBarHandler
+                                                .showWithBottomMargin(mDrawerLayout, getString(R.string.wrong_password),
+                                                        navigationView.getHeight());
+                                        editTextPassword.getText().clear();
+                                        editTextPassword.requestFocus();
+                                    }
+                                }
+                            });
+                } else {
+                    if(checkForReveal) {
+                        enterReveal();
+                        checkForReveal = false;
+                    }
+                    albumsAdapter.notifyItemChanged(getAlbums().toggleSelectAlbum(album));
+                    editMode = true;
+                    invalidateOptionsMenu();
+                    if(getAlbums().getSelectedCount()==0)
+                        getNavigationBar();
+                    else
+                    {
+                        hideNavigationBar();
+                        hidenav=true;
+                    }
+                }
+            }else{
+                if(checkForReveal) {
+                    enterReveal();
+                    checkForReveal = false;
+                }
+                albumsAdapter.notifyItemChanged(getAlbums().toggleSelectAlbum(album));
+                editMode = true;
+                invalidateOptionsMenu();
+                if(getAlbums().getSelectedCount()==0)
+                    getNavigationBar();
+                else
+                {
+                    hideNavigationBar();
+                    hidenav=true;
+                }
             }
             return true;
         }
     };
 
+    private boolean check(String path){
+        boolean dr=false;
+        for(String s: securityObj.getSecuredfolders()){
+            if(s.equals(path)){
+                dr=true;
+                break;
+            }
+        }
+        return dr;
+    }
+
     private View.OnClickListener albumOnClickListener = new View.OnClickListener() {
         @Override
         public void onClick(View v) {
             fromOnClick=true;
-            Album album = (Album) v.findViewById(R.id.album_name).getTag();
+            final Album album = (Album) v.findViewById(R.id.album_name).getTag();
             //int index = Integer.parseInt(v.findViewById(R.id.album_name).getTag().toString());
             if (editMode) {
                 albumsAdapter.notifyItemChanged(getAlbums().toggleSelectAlbum(album));
                 if(getAlbums().getSelectedCount()==0)
                     getNavigationBar();
                 invalidateOptionsMenu();
-            } else {
+            } else if(securityObj.isActiveSecurity() && securityObj.isPasswordOnfolder()){
+                if (check(album.getPath())) {
+                    AlertDialog.Builder passwordDialogBuilder =
+                            new AlertDialog.Builder(LFMainActivity.this, getDialogStyle());
+                    final EditText editTextPassword =
+                            securityObj.getInsertPasswordDialog(LFMainActivity.this, passwordDialogBuilder);
+                    passwordDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
+
+                    passwordDialogBuilder.setPositiveButton(getString(R.string.ok_action).toUpperCase(),
+                            new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    //This should br empty it will be overwrite later
+                                    //to avoid dismiss of the dialog on wrong password
+                                }
+                            });
+
+                    final AlertDialog passwordDialog = passwordDialogBuilder.create();
+                    passwordDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+                    passwordDialog.show();
+                    AlertDialogsHelper.setButtonTextColor(
+                            new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE},
+                            getAccentColor(), passwordDialog);
+                    passwordDialog.getButton(AlertDialog.BUTTON_POSITIVE)
+                            .setOnClickListener(new View.OnClickListener() {
+                                @Override
+                                public void onClick(View v) {
+                                    if (securityObj.checkPassword(editTextPassword.getText().toString())) {
+                                        passwordDialog.dismiss();
+                                        getAlbums().setCurrentAlbum(album);
+                                        displayCurrentAlbumMedia(true);
+                                    }
+                                    // if password is incorrect, notify user of incorrect password
+                                    else {
+                                        SnackBarHandler
+                                                .showWithBottomMargin(mDrawerLayout, getString(R.string.wrong_password),
+                                                        navigationView.getHeight());
+                                        editTextPassword.getText().clear();
+                                        editTextPassword.requestFocus();
+                                    }
+                                }
+                            });
+                }
+                else{
+                    getAlbums().setCurrentAlbum(album);
+                    displayCurrentAlbumMedia(true);
+                }
+
+            }else {
                 getAlbums().setCurrentAlbum(album);
                 displayCurrentAlbumMedia(true);
             }
@@ -1361,6 +1497,7 @@ public class LFMainActivity extends SharedMediaActivity {
         menu.findItem(R.id.action_copy).setVisible(visible);
         menu.findItem(R.id.action_move).setVisible((visible || editMode)&&!fav_photos);
         menu.findItem(R.id.action_add_favourites).setVisible((visible || editMode)&&(!albumsMode&&!fav_photos));
+        menu.findItem(R.id.print).setVisible(visible);
         menu.findItem(R.id.excludeAlbumButton).setVisible(editMode && !all_photos && albumsMode && !fav_photos);
         menu.findItem(R.id.zipAlbumButton).setVisible(editMode && !all_photos&&albumsMode &&!fav_photos && !hidden &&
                 getAlbums().getSelectedCount() == 1);
@@ -1378,7 +1515,6 @@ public class LFMainActivity extends SharedMediaActivity {
         menu.findItem(R.id.set_pin_album).setVisible(albumsMode && getAlbums().getSelectedCount() == 1);
         menu.findItem(R.id.setAsAlbumPreview).setVisible(!albumsMode && !all_photos && getAlbum()
                 .getSelectedCount() == 1);
-
         menu.findItem(R.id.affixPhoto).setVisible((!albumsMode && (getAlbum().getSelectedCount() > 1) ||
                 selectedMedias.size() > 1) && !fav_photos);
         return super.onPrepareOptionsMenu(menu);
@@ -1419,6 +1555,19 @@ public class LFMainActivity extends SharedMediaActivity {
                     }});
                 detailsDialog.show();
                 AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE}, getAccentColor(), detailsDialog);
+                return true;
+
+            case R.id.print:
+                if(!all_photos){
+                    for(int i = 0; i < getAlbum().getSelectedMedia().size(); i++){
+                        PrintHelper photoPrinter = new PrintHelper(this);
+                        photoPrinter.setScaleMode(PrintHelper.SCALE_MODE_FIT);
+                        Bitmap bitmap = BitmapFactory.decodeFile(getAlbum().getSelectedMedia(i).getPath(), new
+                                BitmapFactory.Options
+                                ());
+                        photoPrinter.printBitmap(getString(R.string.print), bitmap);
+                    }
+                }
                 return true;
 
             case R.id.select_all:
@@ -1585,7 +1734,6 @@ public class LFMainActivity extends SharedMediaActivity {
                                         }
                                     }
                                 });
-
                                succ=true;
                             }
 

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -1,5 +1,7 @@
 package org.fossasia.phimpme.gallery.activities;
 
+import java.util.ArrayList;
+
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.graphics.Color;
@@ -7,6 +9,8 @@ import android.graphics.PorterDuff;
 import android.os.Bundle;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.CardView;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.SwitchCompat;
 import android.support.v7.widget.Toolbar;
 import android.text.Editable;
@@ -14,7 +18,9 @@ import android.text.InputType;
 import android.text.TextWatcher;
 import android.text.method.HideReturnsTransformationMethod;
 import android.text.method.PasswordTransformationMethod;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
@@ -23,12 +29,15 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.google.gson.Gson;
 import com.mikepenz.google_material_typeface_library.GoogleMaterial;
 import com.mikepenz.iconics.IconicsDrawable;
 import com.mikepenz.iconics.view.IconicsImageView;
 
 import org.fossasia.phimpme.R;
 import org.fossasia.phimpme.base.ThemedActivity;
+import org.fossasia.phimpme.gallery.data.Album;
+import org.fossasia.phimpme.gallery.data.providers.MediaStoreProvider;
 import org.fossasia.phimpme.gallery.util.AlertDialogsHelper;
 import org.fossasia.phimpme.gallery.util.PreferenceUtil;
 import org.fossasia.phimpme.gallery.util.SecurityHelper;
@@ -48,6 +57,10 @@ public class SecurityActivity extends ThemedActivity {
     private SwitchCompat swActiveSecurity;
     private SwitchCompat swApplySecurityDelete;
     private SwitchCompat swApplySecurityHidden;
+    private SwitchCompat swApplySecurityFolder;
+    public ArrayList<Album> albums;
+    public ArrayList<String> securedfol = new ArrayList<>();
+
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -57,12 +70,15 @@ public class SecurityActivity extends ThemedActivity {
         SP = PreferenceUtil.getInstance(getApplicationContext());
         securityObj = new SecurityHelper(SecurityActivity.this);
         toolbar = (Toolbar) findViewById(R.id.toolbar);
+        albums = new ArrayList<>();
+        albums = MediaStoreProvider.getAlbums(getApplicationContext());
         llbody = (LinearLayout) findViewById(R.id.ll_security_dialog_body);
         llroot = (LinearLayout) findViewById(R.id.root);
 
         swApplySecurityDelete = (SwitchCompat) findViewById(R.id.security_body_apply_delete_switch);
         swActiveSecurity = (SwitchCompat) findViewById(R.id.active_security_switch);
         swApplySecurityHidden = (SwitchCompat) findViewById(R.id.security_body_apply_hidden_switch);
+        swApplySecurityFolder = (SwitchCompat) findViewById(R.id.security_body_apply_folder_switch);
 
         /** - SWITCHES - **/
         /** - ACTIVE SECURITY - **/
@@ -71,7 +87,6 @@ public class SecurityActivity extends ThemedActivity {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 SharedPreferences.Editor editor = SP.getEditor();
-
                 securityObj.updateSecuritySetting();
                 updateSwitchColor(swActiveSecurity, getAccentColor());
                 llbody.setEnabled(swActiveSecurity.isChecked());
@@ -99,6 +114,53 @@ public class SecurityActivity extends ThemedActivity {
             }
         });
         updateSwitchColor(swApplySecurityHidden, getAccentColor());
+
+        /**ACTIVE SECURITY ON LOCAL FOLDERS**/
+        swApplySecurityFolder.setChecked(securityObj.isPasswordOnfolder());
+        swApplySecurityFolder.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                SP.putBoolean(getString(R.string.preference_use_password_on_folder), isChecked);
+                securityObj.updateSecuritySetting();
+                updateSwitchColor(swApplySecurityFolder, getAccentColor());
+                if(isChecked) {
+                    AlertDialog.Builder builder = new AlertDialog.Builder(SecurityActivity.this, getDialogStyle());
+                    View view = getLayoutInflater().inflate(R.layout.dialog_security_folder, null);
+                    TextView title = (TextView) view.findViewById(R.id.titlesecure);
+                    title.setText("Choose folders to secure");
+                    RecyclerView recyclerView = (RecyclerView) view.findViewById(R.id.secure_folder_recyclerview);
+                    recyclerView.setLayoutManager(new LinearLayoutManager(getApplicationContext()));
+                    SecureDialogAdapter s = new SecureDialogAdapter();
+                    recyclerView.setAdapter(s);
+                    builder.setView(view);
+                    AlertDialog ad = builder.create();
+                    ad.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string
+                            .ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            dialog.dismiss();
+                            if(securedfol.size()>0){
+                                SharedPreferences.Editor editor = SP.getEditor();
+                                Gson gson = new Gson();
+                                String securedfolders = gson.toJson(securedfol);
+                                editor.putString("SecuredLocalFolders", securedfolders);
+                                editor.commit();
+                            }else{
+                                SP.putBoolean(getString(R.string.preference_use_password_on_folder), false);
+                                securityObj.updateSecuritySetting();
+                                swApplySecurityFolder.setChecked(false);
+                                updateSwitchColor(swApplySecurityFolder, getAccentColor());
+                            }
+                        }});
+                    ad.show();
+                }else{
+                    SP.putBoolean(getString(R.string.preference_use_password_on_folder), false);
+                    securityObj.updateSecuritySetting();
+                    updateSwitchColor(swApplySecurityFolder, getAccentColor());
+                }
+            }
+        });
+        updateSwitchColor(swApplySecurityFolder, getAccentColor());
 
         /**ACTIVE SECURITY ON DELETE ACTION**/
         swApplySecurityDelete.setChecked(securityObj.isPasswordOnDelete());
@@ -228,13 +290,16 @@ public class SecurityActivity extends ThemedActivity {
         AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, getAccentColor(), dialog);
     }
 
+
     private void toggleEnabledChild(boolean enable) {
         if (!enable) {
             swApplySecurityDelete.setChecked(enable);
             swApplySecurityHidden.setChecked(enable);
+            swApplySecurityFolder.setChecked(enable);
         }
         swApplySecurityDelete.setEnabled(enable);
         swApplySecurityHidden.setEnabled(enable);
+        swApplySecurityFolder.setEnabled(enable);
     }
 
     private void setupUI() {
@@ -262,6 +327,8 @@ public class SecurityActivity extends ThemedActivity {
         TextView txtApplySecurityHidden = (TextView) findViewById(R.id.security_body_apply_hidden_title);
         IconicsImageView imgApplySecurityDelete = (IconicsImageView) findViewById(R.id.security_body_apply_delete_icon);
         TextView txtApplySecurityDelete = (TextView) findViewById(R.id.security_body_apply_delete_title);
+        IconicsImageView folderActiveSecurity = (IconicsImageView) findViewById(R.id.security_body_apply_folder_icon);
+        TextView folActiveSecurity = (TextView) findViewById(R.id.security_body_apply_folders_title);
         CardView securityDialogCard = (CardView) findViewById(R.id.security_dialog_card);
         llroot.setBackgroundColor(getBackgroundColor());
         securityDialogCard.setCardBackgroundColor(getCardBackgroundColor());
@@ -271,6 +338,7 @@ public class SecurityActivity extends ThemedActivity {
         imgActiveSecurity.setColor(color);
         imgApplySecurityHidden.setColor(color);
         imgApplySecurityDelete.setColor(color);
+        folderActiveSecurity.setColor(color);
 
         /*TEXTVIEWS*/
         color = getTextColor();
@@ -278,5 +346,53 @@ public class SecurityActivity extends ThemedActivity {
         txtApplySecurity.setTextColor(color);
         txtApplySecurityHidden.setTextColor(color);
         txtApplySecurityDelete.setTextColor(color);
+        folActiveSecurity.setTextColor(color);
+    }
+
+    class SecureDialogAdapter extends RecyclerView.Adapter<SecureDialogAdapter.ViewHolder>{
+
+        SecureDialogAdapter(){}
+
+        @Override
+        public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+            View v = LayoutInflater
+                    .from(parent.getContext()).inflate(R.layout.secure_folder_dialog_item_view, parent, false);
+            return new ViewHolder(v);
+        }
+
+        @Override public void onBindViewHolder(ViewHolder holder, int position) {
+            final Album a = albums.get(position);
+            holder.foldername.setText(a.getName());
+            holder.foldername.setTextColor(getTextColor());
+            holder.foldercheckbox.setOnCheckedChangeListener(null);
+            holder.foldercheckbox.setChecked(a.getsecured());
+            holder.foldercheckbox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
+                    if(b){
+                        securedfol.add(a.getPath());
+                        a.setsecured(true);
+                    }else{
+                        securedfol.remove(a.getPath());
+                        a.setsecured(false);
+                    }
+                }
+            });
+        }
+
+        @Override public int getItemCount() {
+            return albums.size();
+        }
+
+        class ViewHolder extends RecyclerView.ViewHolder{
+
+            private TextView foldername;
+            private CheckBox foldercheckbox;
+
+            public ViewHolder(View itemView) {
+                super(itemView);
+                foldername = (TextView) itemView.findViewById(R.id.foldername);
+                foldercheckbox = (CheckBox) itemView.findViewById(R.id.secure_folder_checkbox);
+            }
+        }
     }
 }

--- a/app/src/main/java/org/fossasia/phimpme/gallery/data/Album.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/data/Album.java
@@ -47,6 +47,7 @@ public class Album implements Serializable {
 
 	public ArrayList<Media> selectedMedias;
 	private boolean isPreviewSelected;
+	private boolean issecured=false;
 	private String previewPath;
     private int selectedCount;
 
@@ -61,6 +62,14 @@ public class Album implements Serializable {
 
 	public boolean isPreviewSelected() {
 		return isPreviewSelected;
+	}
+
+	public void setsecured(boolean set){
+		this.issecured=set;
+	}
+
+	public boolean getsecured(){
+		return issecured;
 	}
 
 	public void setPreviewSelected(boolean previewSelected) {

--- a/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
@@ -16,6 +16,8 @@ import android.widget.TextView;
 import org.fossasia.phimpme.R;
 import org.fossasia.phimpme.base.ThemedActivity;
 
+import com.google.gson.Gson;
+
 /**
  * Created by Jibo on 06/05/2016.
  */
@@ -24,7 +26,9 @@ public class SecurityHelper {
     private boolean activeSecurity;
     private boolean passwordOnDelete;
     private boolean passwordOnHidden;
+    private boolean passwordOnfolder;
     private String passwordValue;
+    private String[] securedfolders;
     private TextInputLayout passwordTextInputLayout;
 
     private Context context;
@@ -36,6 +40,7 @@ public class SecurityHelper {
     public boolean isActiveSecurity(){return activeSecurity;}
     public boolean isPasswordOnHidden(){return passwordOnHidden;}
     public boolean isPasswordOnDelete(){return passwordOnDelete;}
+    public boolean isPasswordOnfolder(){return passwordOnfolder;}
 
     public boolean checkPassword(String pass){
         return (isActiveSecurity() && pass.equals(passwordValue));
@@ -43,10 +48,18 @@ public class SecurityHelper {
 
     public void updateSecuritySetting(){
         PreferenceUtil SP = PreferenceUtil.getInstance(context);
+        String secur = SP.getString("SecuredLocalFolders", "");
+        Gson gson = new Gson();
+        String[] secfo = gson.fromJson(secur, String[].class);
+        if(secfo.length!=0){
+            this.securedfolders = secfo;
+        }
         this.activeSecurity = SP.getBoolean(context.getString(R.string.preference_use_password), false);
         this.passwordOnDelete = SP.getBoolean(context.getString(R.string.preference_use_password_on_delete), false);
         this.passwordOnHidden = SP.getBoolean(context.getString(R.string.preference_use_password_on_hidden), true);
         this.passwordValue = SP.getString(context.getString(R.string.preference_password_value), "");
+       // this.securedfolders = SP.get
+        this.passwordOnfolder = SP.getBoolean(context.getString(R.string.preference_use_password_on_folder), false);
     }
 
     public EditText getInsertPasswordDialog(final ThemedActivity activity, AlertDialog.Builder passwordDialog){
@@ -78,6 +91,10 @@ public class SecurityHelper {
         editxtPassword.setTextColor(activity.getTextColor());
         passwordDialog.setView(PasswordDialogLayout);
         return editxtPassword;
+    }
+
+    public String[] getSecuredfolders(){
+        return securedfolders;
     }
 
     public TextInputLayout getTextInputLayout(){

--- a/app/src/main/res/layout/activity_security_layout.xml
+++ b/app/src/main/res/layout/activity_security_layout.xml
@@ -225,6 +225,52 @@
                             android:hapticFeedbackEnabled="true" />
                     </RelativeLayout>
                 </LinearLayout>
+
+                <!--FOLDER ACTION-->
+                <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                              android:id="@+id/ll_security_body_apply_delete"
+                              android:layout_width="match_parent"
+                              android:layout_height="wrap_content"
+                              android:orientation="horizontal">
+
+                    <com.mikepenz.iconics.view.IconicsImageView
+                        android:id="@+id/security_body_apply_folder_icon"
+                        android:layout_width="@dimen/icon_width_height"
+                        android:layout_height="@dimen/icon_width_height"
+                        android:layout_gravity="center_vertical"
+                        android:layout_marginLeft="@dimen/big_spacing"
+                        android:layout_marginRight="@dimen/big_spacing"
+                        android:gravity="center_vertical"
+                        app:iiv_icon="gmd-folder" />
+
+                    <RelativeLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal"
+                        android:paddingBottom="@dimen/medium_spacing"
+                        android:paddingRight="@dimen/medium_spacing"
+                        android:paddingTop="@dimen/medium_spacing">
+
+                        <TextView
+                            android:id="@+id/security_body_apply_folders_title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/local_folder"
+                            android:textColor="@color/md_dark_background"
+                            android:textSize="@dimen/medium_text" />
+
+                        <android.support.v7.widget.SwitchCompat
+                            android:id="@+id/security_body_apply_folder_switch"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_alignParentEnd="true"
+                            android:layout_centerVertical="true"
+                            android:layout_gravity="center_vertical"
+                            android:button="@null"
+                            android:hapticFeedbackEnabled="true" />
+                    </RelativeLayout>
+                </LinearLayout>
             </LinearLayout>
         </LinearLayout>
     </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/dialog_security_folder.xml
+++ b/app/src/main/res/layout/dialog_security_folder.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+  <android.support.v7.widget.CardView
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:cardCornerRadius="2dp"
+      android:id="@+id/folder_security_dialog_card">
+
+    <LinearLayout android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:orientation="vertical">
+
+      <LinearLayout android:layout_width="match_parent"
+                    android:orientation="vertical"
+                    android:background="@color/accent_blue"
+                    android:layout_height="wrap_content">
+
+        <TextView android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:textSize="18dp"
+                  android:id="@+id/titlesecure"
+                  android:textStyle="bold"
+                  android:textColor="@color/accent_white"
+                  android:background="@color/accent_blue"
+                  android:text="Select folders to secure"
+                  android:layout_margin="20dp"/>
+
+      </LinearLayout>
+
+      <android.support.v7.widget.RecyclerView
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:scrollbars="vertical"
+          android:id="@+id/secure_folder_recyclerview">
+
+      </android.support.v7.widget.RecyclerView>
+
+    </LinearLayout>
+
+  </android.support.v7.widget.CardView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/secure_folder_dialog_item_view.xml
+++ b/app/src/main/res/layout/secure_folder_dialog_item_view.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              android:orientation="vertical"
+              android:background="@color/accent_white"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content">
+
+  <android.support.v7.widget.CardView
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:cardCornerRadius="2dp"
+      android:layout_marginLeft="3dp"
+      android:layout_marginTop="2dp"
+      android:background="@color/accent_white"
+      android:layout_marginRight="3dp"
+      android:id="@+id/folder_security_dialog_card">
+
+    <LinearLayout android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:background="@color/accent_white"
+                  android:weightSum="10"
+                  android:orientation="horizontal">
+
+      <TextView android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="10dp"
+                android:textStyle="italic"
+                android:textSize="18dp"
+                android:layout_weight="10"
+                android:textColor="@color/md_blue_grey_500"
+                android:id="@+id/foldername"
+                android:text=""/>
+
+      <CheckBox android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="2dp"
+                android:layout_weight="0"
+                android:buttonTint="@color/accent_black"
+                android:id="@+id/secure_folder_checkbox"/>
+
+    </LinearLayout>
+  </android.support.v7.widget.CardView>
+</LinearLayout>

--- a/app/src/main/res/layout/select_folder_bottom_sheet_item.xml
+++ b/app/src/main/res/layout/select_folder_bottom_sheet_item.xml
@@ -69,6 +69,7 @@
                     android:textSize="14sp"
                 />
             </LinearLayout>
+
         </LinearLayout>
 
     </android.support.v7.widget.CardView>

--- a/app/src/main/res/values/preferences-key.xml
+++ b/app/src/main/res/values/preferences-key.xml
@@ -21,6 +21,7 @@
     <string name="preference_use_password">active_security</string>
     <string name="preference_use_password_on_hidden">password_on_hidden</string>
     <string name="preference_use_password_on_delete">password_on_delete</string>
+    <string name="preference_use_password_on_folder">password on folder</string>
     <string name="preference_internal_uri_extsdcard_photos">uri_extsdcard_photos</string>
     <string name="preference_show_fab">show_fab</string>
     <string name="preference_sub_scaling">use_sub_scaling</string>


### PR DESCRIPTION
Fix #1558 

Changes: On enabling the security for albums(present in the local folders) through the security option in settings a dialog box pops up where the user can choose the albums which he/she wants to password secure, and after that for performing any operation on the chosen albums, entering the password is required.


