### PR TITLE
Toolbar doesn't expand when soft keyboard appears

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -184,6 +184,7 @@
         <activity
             android:name=".gallery.activities.LFMainActivity"
             android:configChanges="orientation|screenSize"
+            android:windowSoftInputMode="adjustPan"
             android:theme="@style/Theme.AppCompat.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.albumsAct" />


### PR DESCRIPTION
Fix #1201
Earlier when input was prompted the toolbar would expand.
Now the toolbar doesn't expand.
