### PR TITLE
Fix #1581 snackbar messages are now visible

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -100,7 +100,6 @@ import io.realm.Realm;
 import io.realm.RealmQuery;
 import io.realm.RealmResults;
 
-import static org.fossasia.phimpme.R.string.media;
 import static org.fossasia.phimpme.gallery.activities.LFMainActivity.listAll;
 import static org.fossasia.phimpme.utilities.Utils.promptSpeechInput;
 
@@ -543,14 +542,14 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                             handleEditorImage(data);
                             if (ContentHelper.copyFile(getApplicationContext(), new File(imageUri.getPath()), new File(getAlbum().getPath()))) {
                                 //((ImageFragment) adapter.getRegisteredFragment(getAlbum().getCurrentMediaIndex())).displayMedia(true);
-                                SnackBarHandler.show(parentView, R.string.new_file_created);
+                                SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.new_file_created), bottomBar.getHeight());
                             }
                             //adapter.notifyDataSetChanged();
                         } catch (Exception e) {
                             Log.e("ERROS - uCrop", imageUri.toString(), e);
                         }
                     } else
-                        SnackBarHandler.show(parentView, "errori random");
+                        SnackBarHandler.showWithBottomMargin(parentView, "errori random", bottomBar.getHeight());
                     break;
                 default:
                     break;
@@ -694,7 +693,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                         else{
                             getAlbum().copyPhoto(getApplicationContext(), getAlbum().getCurrentMedia().getPath(), path);
                             bottomSheetDialogFragment.dismiss();
-                           SnackBarHandler.show(relativeLayout, getString(R.string.copied_successfully) + " to " + path);
+                            SnackBarHandler.showWithBottomMargin(relativeLayout, getString(R.string.copied_successfully) + " to " + path, bottomBar.getHeight());
                         }
                     }
                 });
@@ -725,7 +724,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                     editIntent.putExtra("requestCode", ACTION_REQUEST_EDITIMAGE);
                     startActivity(editIntent);
                 } else
-                    SnackBarHandler.show(parentView, R.string.image_invalid);
+                    SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.image_invalid), bottomBar.getHeight());
                 break;
 
             case R.id.action_use_as:
@@ -763,10 +762,9 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                         fav.setDescription(" ");
                     }
                     realm.commitTransaction();
-                    SnackBarHandler.show(parentView, R.string.add_favourite );
-                }
-                else{
-                    SnackBarHandler.show(parentView, R.string.check_favourite);
+                    SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.add_favourite), bottomBar.getHeight());
+                } else {
+                    SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.check_favourite), bottomBar.getHeight());
                 }
                 break;
 
@@ -791,7 +789,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                                     if (securityObj.checkPassword(editTextPassword.getText().toString())) {
                                         deleteCurrentMedia();
                                     } else
-                                        SnackBarHandler.show(parentView, R.string.wrong_password);
+                                        SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.wrong_password), bottomBar.getHeight());
 
                                 }
                             });
@@ -807,7 +805,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                                         deleteCurrentMedia();
                                         passwordDialog.dismiss();
                                     } else {
-                                        SnackBarHandler.show(parentView, R.string.wrong_password);
+                                        SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.wrong_password), bottomBar.getHeight());
                                         editTextPassword.getText().clear();
                                         editTextPassword.requestFocus();
                                     }
@@ -847,8 +845,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                         adapter.notifyDataSetChanged();
 //                        toolbar.setTitle((mViewPager.getCurrentItem() + 1) + " " + getString(R.string.of) + " " + getAlbum().getCount());
                         bottomSheetDialogFragment.dismiss();
-                        SnackBarHandler.show(relativeLayout, getString(R.string.photo_moved_successfully) + " to " +  path
-                        );
+                        SnackBarHandler.showWithBottomMargin(relativeLayout, getString(R.string.photo_moved_successfully) + " to " + path, bottomBar.getHeight());
                     }
                 });
                 bottomSheetDialogFragment.show(getSupportFragmentManager(), bottomSheetDialogFragment.getTag());
@@ -858,7 +855,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
             case R.id.action_cover:
                 AlbumSettings albumSettings = AlbumSettings.getSettings(getApplicationContext(), getAlbum());
                 albumSettings.changeCoverPath(getApplicationContext(), getAlbum().getCurrentMedia().getPath());
-                SnackBarHandler.show(parentView, R.string.change_cover);
+                SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.change_cover), bottomBar.getHeight());
                 return true;
 
             case R.id.action_details:
@@ -1021,10 +1018,10 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                         voiceInput = editTextDescription.getText().toString();
                         if (temp == null) {
                             databaseHelper.addImageDesc(new ImageDescModel(pathForDescription, editTextDescription.getText().toString()));
-                            SnackBarHandler.show(parentView,getString(R.string.description_saved).toString());
+                            SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.description_saved), bottomBar.getHeight());
                         } else {
                             databaseHelper.update(new ImageDescModel(pathForDescription, editTextDescription.getText().toString()));
-                            SnackBarHandler.show(parentView,getString(R.string.description_updated).toString());
+                            SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.description_updated), bottomBar.getHeight());
                         }
 
                     }
@@ -1036,7 +1033,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                         descriptionDialog.dismiss();
                         if(temp!= null){
                             databaseHelper.delete(temp);
-                            SnackBarHandler.show(parentView,getString(R.string.description_deleted).toString());
+                            SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.description_deleted), bottomBar.getHeight());
                         }
 
                     }


### PR DESCRIPTION
Fix #1581 

Changes: All snackBar messages are now visible in the singleMedia Activity

Screenshots for the change: 
![screenshot_20180104-171205](https://user-images.githubusercontent.com/20878145/34562307-c447efa6-f173-11e7-9093-7db1d1361729.png)
