### PR TITLE
Fix #1586 clear preview is  visible only when we open an album

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1315,7 +1315,7 @@ public class LFMainActivity extends SharedMediaActivity {
         menu.findItem(R.id.hideAlbumButton).setVisible(!all_photos && !fav_photos && getAlbums().getSelectedCount() >
                 0);
 
-        menu.findItem(R.id.clear_album_preview).setVisible(!albumsMode && getAlbum().hasCustomCover() && !fav_photos);
+        menu.findItem(R.id.clear_album_preview).setVisible(!albumsMode && getAlbum().hasCustomCover() && !fav_photos && !all_photos);
         menu.findItem(R.id.renameAlbum).setVisible(((albumsMode && getAlbums().getSelectedCount() == 1) ||
                 (!albumsMode && !editMode)) && (!all_photos && !fav_photos));
         if (getAlbums().getSelectedCount() == 1)


### PR DESCRIPTION
Fix #1586 

Changes: option to clear album cover is visible only when we open an album whose cover has been changed. It is not visible in the all photos mode

Screenshots for the change: 
![screenshot_20180104-222543](https://user-images.githubusercontent.com/20878145/34574954-fb15a0f2-f19e-11e7-9719-024d4f66e6ad.png)
