### PR TITLE
Fix #1598 colour of fab is according to the accent colour

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -2,12 +2,12 @@ package org.fossasia.phimpme.gallery.activities;
 
 import android.animation.Animator;
 import android.annotation.TargetApi;
-import android.app.ProgressDialog;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.res.ColorStateList;
 import android.content.res.Configuration;
 import android.database.Cursor;
 import android.graphics.Bitmap;
@@ -26,7 +26,6 @@ import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.BottomNavigationView;
-import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.ActivityOptionsCompat;
 import android.support.design.widget.Snackbar;
@@ -935,7 +934,7 @@ public class LFMainActivity extends SharedMediaActivity {
         drawableScrollBar.setColorFilter(new PorterDuffColorFilter(getPrimaryColor(), PorterDuff.Mode.SRC_ATOP));
 
         /**** FAB ****/
-        fabScrollUp.setBackgroundColor(getAccentColor());
+        fabScrollUp.setBackgroundTintList(ColorStateList.valueOf(getAccentColor()));
         fabScrollUp.setAlpha(0.7f);
     }
 

--- a/app/src/main/res/layout/activity_leafpic.xml
+++ b/app/src/main/res/layout/activity_leafpic.xml
@@ -95,7 +95,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="70dp"
-            android:alpha="0.7"
             app:layout_anchor="@id/bottombar"
             app:layout_anchorGravity="top|center"
             app:srcCompat="@drawable/ic_keyboard_arrow_up_black_24dp" />


### PR DESCRIPTION
Fix #1598 

Changes: Removed redundant `android:alpha="0.7"` as it was being done programmatically in the activity and unused import statements.The colour of fab is now according to the accent colour

Screenshots for the change: 
![screenshot_20180106-002004](https://user-images.githubusercontent.com/20878145/34623453-7280c990-f277-11e7-93a7-af1f82095daa.png)

