### PR TITLE
Fix#1601: Pinned icon in dark mode

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
@@ -75,8 +75,14 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
         Album a = SharedMediaActivity.getAlbums().dispAlbums.get(position);
         Media f = a.getCoverAlbum();
 
-        if (a.isPinned())
+        if (a.isPinned() && (theme.getBaseTheme() == ThemeHelper.LIGHT_THEME)){
             holder.pin.setVisibility(View.VISIBLE);
+            holder.pin.setImageDrawable(ContextCompat.getDrawable(context,R.drawable.pin_black));
+        }
+        else if( a.isPinned() && (theme.getBaseTheme() == ThemeHelper.AMOLED_THEME || theme.getBaseTheme() == ThemeHelper.DARK_THEME)) {
+            holder.pin.setVisibility(View.VISIBLE);
+            holder.pin.setImageDrawable(ContextCompat.getDrawable(context,R.drawable.pin_white));
+        }
         else
             holder.pin.setVisibility(View.INVISIBLE);
 

--- a/app/src/main/res/drawable/pin_black.xml
+++ b/app/src/main/res/drawable/pin_black.xml
@@ -1,4 +1,4 @@
-<!-- drawable/pin.xml -->
+<!-- drawable/pin_black.xml -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:height="24dp"
     android:width="24dp"

--- a/app/src/main/res/drawable/pin_white.xml
+++ b/app/src/main/res/drawable/pin_white.xml
@@ -1,0 +1,8 @@
+<!-- drawable/pin_white.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#fff" android:pathData="M16,12V4H17V2H7V4H8V12L6,14V16H11.2V22H12.8V16H18V14L16,12Z" />
+</vector>

--- a/app/src/main/res/layout/card_album.xml
+++ b/app/src/main/res/layout/card_album.xml
@@ -78,7 +78,7 @@
                     android:paddingStart="10dp"
                     android:paddingTop="10dp"
                     android:visibility="invisible"
-                    app2:srcCompat="@drawable/pin" />
+                    app2:srcCompat="@drawable/pin_black" />
 
             </RelativeLayout>
 


### PR DESCRIPTION
Fix #1601 
Changes:The pinned to top icon is now visible in the dark mode as well.

Screenshots for the change: 
![device 2018 01 07 130659](https://user-images.githubusercontent.com/20684618/34647580-ce015caa-f3ab-11e7-94bb-b0a597309cfb.jpg)

