### PR TITLE
onClickListener for images in upload history. 

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -61,6 +61,7 @@ import android.widget.ScrollView;
 import android.widget.SeekBar;
 import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
 
 
 import com.mikepenz.google_material_typeface_library.GoogleMaterial;
@@ -1549,6 +1550,11 @@ public class LFMainActivity extends SharedMediaActivity {
                                 albumsAdapter.notifyDataSetChanged();
                             } else {
                                 if (!all_photos && !fav_photos) {
+                                    if(succ)
+                                        Toast.makeText(getApplicationContext(),"Photo deleted",Toast.LENGTH_SHORT).show();
+                                    else
+                                        Toast.makeText(getApplicationContext(),"Photo deletion unsuccessful",Toast.LENGTH_SHORT).show();
+
                                     //if all media in current album have been deleted, delete current album too.
                                     if (getAlbum().getMedia().size() == 0) {
                                         getAlbums().removeCurrentAlbum();
@@ -1558,6 +1564,11 @@ public class LFMainActivity extends SharedMediaActivity {
                                     } else
                                         mediaAdapter.swapDataSet(getAlbum().getMedia());
                                 } else if(all_photos && !fav_photos){
+                                    if(succ)
+                                        Toast.makeText(getApplicationContext(),"Photo deleted",Toast.LENGTH_SHORT).show();
+                                    else
+                                        Toast.makeText(getApplicationContext(),"Photo deletion unsuccessful",Toast.LENGTH_SHORT).show();
+
                                     clearSelectedPhotos();
                                     listAll = StorageProvider.getAllShownImages(LFMainActivity.this);
                                     media = listAll;
@@ -1568,6 +1579,11 @@ public class LFMainActivity extends SharedMediaActivity {
                                     clearSelectedPhotos();
                                     getfavouriteslist();
                                     new FavouritePhotos().execute();
+
+                                    if(succ)
+                                        Toast.makeText(getApplicationContext(),"Photo deleted from favourites",Toast.LENGTH_SHORT).show();
+                                    else
+                                        Toast.makeText(getApplicationContext(),"Photo deletion unsuccessful",Toast.LENGTH_SHORT).show();
                                 }
                             }
                         } else requestSdCardPermissions();

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -597,7 +597,8 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                     }
                 });
                 dialogBuilder.show();
-            }
+            } else
+                Toast.makeText(getApplicationContext(),"Photo deleted",Toast.LENGTH_SHORT).show();
             if (getAlbum().getMedia().size() == 0) {
                 if (customUri) finish();
                 else {
@@ -612,6 +613,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
             LFMainActivity.listAll.remove(current_image_pos);
             size_all = LFMainActivity.listAll.size();
             adapter.notifyDataSetChanged();
+            Toast.makeText(getApplicationContext(),"Photo deleted",Toast.LENGTH_SHORT).show();
 //            mViewPager.setCurrentItem(current_image_pos);
 //            toolbar.setTitle((mViewPager.getCurrentItem() + 1) + " " + getString(R.string.of) + " " + size_all);
         } else if(favphotomode && !allPhotoMode){
@@ -629,6 +631,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
             size_all = favouriteslist.size();
             adapter.notifyDataSetChanged();
             getSupportActionBar().setTitle((c + 1) + " " + getString(R.string.of) + " " + size_all);
+            Toast.makeText(getApplicationContext(),"Photo deleted from favourites",Toast.LENGTH_SHORT).show();
         }
     }
 

--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
@@ -9,6 +9,7 @@ import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.mikepenz.community_material_typeface_library.CommunityMaterial;
 import com.mikepenz.iconics.IconicsDrawable;
@@ -71,7 +72,16 @@ public class UploadHistory extends ThemedActivity {
         //uploadHistoryRecyclerView.addOnItemTouchListener(new RecyclerItemClickListner(this, this));
     }
 
+    private View.OnClickListener uploadPhotoClickListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            Toast.makeText(getApplicationContext(),"open photo",Toast.LENGTH_SHORT).show();
+            //open photo in singleMediaActivity
+        }
+    };
+
     private void setUpUI() {
+        uploadHistoryAdapter.setOnClickListener(uploadPhotoClickListener);
         emptyIcon.setColor(getIconColor());
         emptyText.setTextColor(getAccentColor());
         parentView.setBackgroundColor(getBackgroundColor());

--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistoryAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistoryAdapter.java
@@ -40,6 +40,7 @@ public class UploadHistoryAdapter extends RecyclerView.Adapter<UploadHistoryAdap
     private Realm realm = Realm.getDefaultInstance();
     private RealmQuery<UploadHistoryRealmModel> realmResult = realm.where(UploadHistoryRealmModel.class);
     private int color;
+    private View.OnClickListener mOnClickListener;
 
     public UploadHistoryAdapter(int color) {
         this.color=color;
@@ -49,9 +50,14 @@ public class UploadHistoryAdapter extends RecyclerView.Adapter<UploadHistoryAdap
     public UploadHistoryAdapter.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.upload_history_item_view, null, false);
+        view.setOnClickListener(mOnClickListener);
         view.setLayoutParams(new RecyclerView.LayoutParams(RecyclerView.LayoutParams.MATCH_PARENT,
                 RecyclerView.LayoutParams.WRAP_CONTENT));
         return new ViewHolder(view);
+    }
+
+    public void setOnClickListener(View.OnClickListener lis) {
+        mOnClickListener = lis;
     }
 
     @Override


### PR DESCRIPTION
First steps for issues #1531 

Changes: Added onCLickListener for uploaded images. On clicking the image thumbnails in upload history, a Toast shows. The click listener is ready and lies in uploadHistory.java . The actual code to open images can now be written in this onClickListener.

Screenshots for the change:

![screenshot_upload](https://user-images.githubusercontent.com/23417993/34671063-f3d9f218-f49e-11e7-92f5-09a1fd42421e.png)


