### PR TITLE
Toast displayed on photo deletion

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -63,6 +63,7 @@ import android.widget.ScrollView;
 import android.widget.SeekBar;
 import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
 
 
 import com.mikepenz.google_material_typeface_library.GoogleMaterial;
@@ -1551,6 +1552,11 @@ public class LFMainActivity extends SharedMediaActivity {
                                 albumsAdapter.notifyDataSetChanged();
                             } else {
                                 if (!all_photos && !fav_photos) {
+                                    if(succ)
+                                        Toast.makeText(getApplicationContext(),getString(R.string.photo_deleted_msg),Toast.LENGTH_SHORT).show();
+                                    else
+                                        Toast.makeText(getApplicationContext(),getString(R.string.photo_deletion_failed),Toast.LENGTH_SHORT).show();
+
                                     //if all media in current album have been deleted, delete current album too.
                                     if (getAlbum().getMedia().size() == 0) {
                                         getAlbums().removeCurrentAlbum();
@@ -1560,6 +1566,11 @@ public class LFMainActivity extends SharedMediaActivity {
                                     } else
                                         mediaAdapter.swapDataSet(getAlbum().getMedia());
                                 } else if(all_photos && !fav_photos){
+                                    if(succ)
+                                        Toast.makeText(getApplicationContext(),getString(R.string.photo_deleted_msg),Toast.LENGTH_SHORT).show();
+                                    else
+                                        Toast.makeText(getApplicationContext(),getString(R.string.photo_deletion_failed),Toast.LENGTH_SHORT).show();
+
                                     clearSelectedPhotos();
                                     listAll = StorageProvider.getAllShownImages(LFMainActivity.this);
                                     media = listAll;
@@ -1570,6 +1581,11 @@ public class LFMainActivity extends SharedMediaActivity {
                                     clearSelectedPhotos();
                                     getfavouriteslist();
                                     new FavouritePhotos().execute();
+
+                                    if(succ)
+                                        Toast.makeText(getApplicationContext(),getString(R.string.photo_deleted_from_fav_msg),Toast.LENGTH_SHORT).show();
+                                    else
+                                        Toast.makeText(getApplicationContext(),getString(R.string.photo_deletion_failed),Toast.LENGTH_SHORT).show();
                                 }
                             }
                         } else requestSdCardPermissions();

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -604,7 +604,8 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                     }
                 });
                 dialogBuilder.show();
-            }
+            } else
+                Toast.makeText(getApplicationContext(), getString(R.string.photo_deleted_msg),Toast.LENGTH_SHORT).show();
             if (getAlbum().getMedia().size() == 0) {
                 if (customUri) finish();
                 else {
@@ -619,6 +620,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
             LFMainActivity.listAll.remove(current_image_pos);
             size_all = LFMainActivity.listAll.size();
             adapter.notifyDataSetChanged();
+            Toast.makeText(getApplicationContext(), getString(R.string.photo_deleted_msg),Toast.LENGTH_SHORT).show();
 //            mViewPager.setCurrentItem(current_image_pos);
 //            toolbar.setTitle((mViewPager.getCurrentItem() + 1) + " " + getString(R.string.of) + " " + size_all);
         } else if(favphotomode && !allPhotoMode){
@@ -636,6 +638,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
             size_all = favouriteslist.size();
             adapter.notifyDataSetChanged();
             getSupportActionBar().setTitle((c + 1) + " " + getString(R.string.of) + " " + size_all);
+            Toast.makeText(getApplicationContext(), getString(R.string.photo_deleted_from_fav_msg),Toast.LENGTH_SHORT).show();
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1123,4 +1123,9 @@
     <string name="copyright_2011_2012_chris_banes">Copyright 2011, 2012 Chris Banes</string>
     <string name="copyright_2014_2015_henning_dodenhof">Copyright 2014 - 2015 Henning Dodenhof</string>
     <string name="copyright_2016_mykhailo_schurov">Copyright 2016 Mykhailo Shchurov</string>
+
+    <!-- Photo deletion toast messages -->
+    <string name="photo_deleted_msg">Photo deleted</string>
+    <string name="photo_deleted_from_fav_msg">Photo deleted from favourites</string>
+    <string name="photo_deletion_failed">Photo deletion failed</string>
 </resources>


### PR DESCRIPTION
Fix #1621 

Changes:  A Toast is displayed when a photo is deleted. It indicates whether the deletion was successful or not.

Screenshots for the change: 

![one](https://user-images.githubusercontent.com/23417993/34677135-23efc1f6-f4b5-11e7-879c-3a6c5f3ce72d.png)
![two](https://user-images.githubusercontent.com/23417993/34677136-263fbec0-f4b5-11e7-856b-4298916ac4b4.png)




