### PR TITLE
onClickListener for images in upload history.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
@@ -9,6 +9,7 @@ import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.mikepenz.community_material_typeface_library.CommunityMaterial;
 import com.mikepenz.iconics.IconicsDrawable;
@@ -71,7 +72,16 @@ public class UploadHistory extends ThemedActivity {
         //uploadHistoryRecyclerView.addOnItemTouchListener(new RecyclerItemClickListner(this, this));
     }
 
+    private View.OnClickListener uploadPhotoClickListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            Toast.makeText(getApplicationContext(),"open photo",Toast.LENGTH_SHORT).show();
+            //open photo in singleMediaActivity
+        }
+    };
+
     private void setUpUI() {
+        uploadHistoryAdapter.setOnClickListener(uploadPhotoClickListener);
         emptyIcon.setColor(getIconColor());
         emptyText.setTextColor(getAccentColor());
         parentView.setBackgroundColor(getBackgroundColor());

--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistoryAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistoryAdapter.java
@@ -40,6 +40,7 @@ public class UploadHistoryAdapter extends RecyclerView.Adapter<UploadHistoryAdap
     private Realm realm = Realm.getDefaultInstance();
     private RealmQuery<UploadHistoryRealmModel> realmResult = realm.where(UploadHistoryRealmModel.class);
     private int color;
+    private View.OnClickListener mOnClickListener;
 
     public UploadHistoryAdapter(int color) {
         this.color=color;
@@ -49,9 +50,14 @@ public class UploadHistoryAdapter extends RecyclerView.Adapter<UploadHistoryAdap
     public UploadHistoryAdapter.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.upload_history_item_view, null, false);
+        view.setOnClickListener(mOnClickListener);
         view.setLayoutParams(new RecyclerView.LayoutParams(RecyclerView.LayoutParams.MATCH_PARENT,
                 RecyclerView.LayoutParams.WRAP_CONTENT));
         return new ViewHolder(view);
+    }
+
+    public void setOnClickListener(View.OnClickListener lis) {
+        mOnClickListener = lis;
     }
 
     @Override


### PR DESCRIPTION
First steps for issue #1531

Changes: Added onCLickListener for uploaded images. On clicking the image thumbnails in upload history, a Toast shows. The click listener is ready and lies in uploadHistory.java . The actual code to open images can now be written in this onClickListener.

Screenshots for the change: 
![screenshot_upload](https://user-images.githubusercontent.com/23417993/34671063-f3d9f218-f49e-11e7-92f5-09a1fd42421e.png)