### PR TITLE
Fix #1661 - SD card icon is selected according to the theme.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
@@ -79,6 +79,7 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
         if(a.getPath().contains(Environment.getExternalStorageDirectory().getPath())){
             holder.storage.setVisibility(View.INVISIBLE);
         } else {
+            holder.storage.setImageResource(theme.getBaseTheme() == ThemeHelper.LIGHT_THEME ? R.drawable.ic_sd_storage_black_24dp : R.drawable.ic_sd_storage_white_24dp);
             holder.storage.setVisibility(View.VISIBLE);
         }
 

--- a/app/src/main/res/drawable/ic_sd_storage_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_sd_storage_white_24dp.xml
@@ -4,6 +4,6 @@
     android:viewportHeight="24.0"
     android:viewportWidth="24.0">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="#FFFFFF"
         android:pathData="M18,2h-8L4.02,8 4,20c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,4c0,-1.1 -0.9,-2 -2,-2zM12,8h-2L10,4h2v4zM15,8h-2L13,4h2v4zM18,8h-2L16,4h2v4z" />
 </vector>

--- a/app/src/main/res/layout/card_album.xml
+++ b/app/src/main/res/layout/card_album.xml
@@ -97,17 +97,16 @@
                     android:textColor="@android:color/white"
                     android:textSize="14sp" />
 
-                <ImageView android:layout_width="wrap_content"
-                           android:layout_height="wrap_content"
-                           android:id="@+id/storage_icon"
-                           android:layout_centerVertical="true"
-                           android:paddingLeft="10dp"
-                           android:paddingStart="10dp"
-                           android:paddingTop="10dp"
-                           android:paddingRight="10dp"
-                           android:visibility="visible"
-                           android:layout_alignParentRight="true"
-                           app2:srcCompat="@drawable/ic_sd_storage_black_24dp"/>
+                <ImageView
+                    android:id="@+id/storage_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentEnd="true"
+                    android:layout_centerVertical="true"
+                    android:paddingLeft="10dp"
+                    android:paddingRight="10dp"
+                    android:paddingStart="10dp"
+                    android:paddingTop="10dp" />
 
             </RelativeLayout>
         </LinearLayout>


### PR DESCRIPTION
Fixed #1661 

Changes: Select appropriate icon to display.

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/22395998/34948284-b3c28b2e-fa32-11e7-8f86-fd5f72557a75.png)
