### PR TITLE
Added the feature to blur images

### DIFF
--- a/app/src/main/jni/enhance.cpp
+++ b/app/src/main/jni/enhance.cpp
@@ -169,4 +169,11 @@ extern "C" {
         medianBlur( src, dst, i);
         addWeighted(src, 1.5, dst, -0.5, 0, dst);
     }
+
+    void adjustBlur(Mat &src, Mat &dst, int val) {
+        cvtColor(src,src,CV_BGRA2BGR);
+        int i = 2*(val/5)+1;
+        dst = Mat::zeros(src.size(), src.type());
+        medianBlur( src, dst, i);
+    }
 }

--- a/app/src/main/jni/enhance.h
+++ b/app/src/main/jni/enhance.h
@@ -13,4 +13,5 @@ extern "C" {
     void adjustTint(cv::Mat &inp, cv::Mat &out, int val);
     void adjustVignette(cv::Mat &inp, cv::Mat &out, int val);
     void adjustSharpness(cv::Mat &inp, cv::Mat &out, int val);
+    void adjustBlur(cv::Mat &inp, cv::Mat &out, int val);
 }

--- a/app/src/main/jni/main_processing.cpp
+++ b/app/src/main/jni/main_processing.cpp
@@ -115,6 +115,9 @@ extern "C" {
             case 7:
                 adjustSharpness(src, dst, val);
                 break;
+            case 8:
+                adjustBlur(src, dst, val);
+                break;
             default:
                 break;
         }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -689,8 +689,8 @@
         <item>@drawable/ic_temp</item>
         <item>@drawable/ic_tint</item>
         <item>@drawable/ic_vignette</item>
-        <item>@drawable/ic_sharp</item><!--
-        <item>@drawable/ic_blur</item>-->
+        <item>@drawable/ic_sharp</item>
+        <item>@drawable/ic_blur</item>
     </integer-array>
 
     <string-array name="enhance_titles">
@@ -702,6 +702,7 @@
         <item>tint</item>
         <item>vignette</item>
         <item>sharp</item>
+        <item>blur</item>
     </string-array>
 
 


### PR DESCRIPTION
Fixed #1644  

The C++ native filter files had to be changed and some additions had to be made in them so that the blur feature was incorporated properly. 
Earlier there was no feature to blur the images.

Screenshots for the change: 
 Before : 

![screenshot_20180115-222041](https://user-images.githubusercontent.com/16780496/34953467-e32f68f4-fa42-11e7-847c-e44cd9d98386.png)

 After : 

![screenshot_20180115-222057](https://user-images.githubusercontent.com/16780496/34953488-f1f32efc-fa42-11e7-99c9-040526d5b710.png)

