### PR TITLE
Fix #1669-Pin to top icon displayed according to the theme.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
@@ -82,8 +82,11 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
             holder.storage.setVisibility(View.VISIBLE);
         }
 
-        if (a.isPinned())
+        if (a.isPinned()){
+            holder.pin.setImageResource(theme.getBaseTheme() == ThemeHelper.LIGHT_THEME ? R.drawable.pin : R.drawable
+                    .pin_white);
             holder.pin.setVisibility(View.VISIBLE);
+        }
         else
             holder.pin.setVisibility(View.INVISIBLE);
 

--- a/app/src/main/res/drawable/pin_white.xml
+++ b/app/src/main/res/drawable/pin_white.xml
@@ -1,0 +1,8 @@
+<!-- drawable/pin_white.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:height="24dp"
+        android:width="24dp"
+        android:viewportWidth="24"
+        android:viewportHeight="24">
+  <path android:fillColor="#FAFAFA" android:pathData="M16,12V4H17V2H7V4H8V12L6,14V16H11.2V22H12.8V16H18V14L16,12Z" />
+</vector>

--- a/app/src/main/res/layout/card_album.xml
+++ b/app/src/main/res/layout/card_album.xml
@@ -77,8 +77,7 @@
                     android:paddingLeft="10dp"
                     android:paddingStart="10dp"
                     android:paddingTop="10dp"
-                    android:visibility="invisible"
-                    app2:srcCompat="@drawable/pin" />
+                    android:visibility="invisible"/>
 
             </RelativeLayout>
 


### PR DESCRIPTION
Fixed #1669 

Changes: Pin to top icon displayed according to the theme.

Screenshots for the change: 
![screenshot_2018-01-16-01-30-07-426_org fossasia phimpme](https://user-images.githubusercontent.com/20841578/34959526-e7d4e5cc-fa5c-11e7-87e2-b2422e2313cd.png)
