### PR TITLE
Fix #1697-Adding text to a photo edittext isuue resloved.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/AddTextFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/AddTextFragment.java
@@ -98,6 +98,10 @@ public class AddTextFragment extends BaseEditFragment implements TextWatcher {
         mColorPicker = new ColorPicker(getActivity(), 255, 0, 0);
         mTextColorSelector.setOnClickListener(new SelectColorBtnClick());
         mInputText.addTextChangedListener(this);
+        boolean focus = mInputText.requestFocus();
+        if(focus){
+            imm.showSoftInput(mInputText, InputMethodManager.SHOW_IMPLICIT);
+        }
         mTextStickerView.setEditText(mInputText);
         onShow();
     }


### PR DESCRIPTION
Fixed #1697 

Changes: Edittext gains focus on the opening up of the AddText fragment, softkeyboard pops up automatically.
