### PR TITLE
Fixed #1651 app doesn't crash on clicking camera button after resetting

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/ImageSaver.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/ImageSaver.java
@@ -1428,7 +1428,7 @@ public class ImageSaver extends Thread {
 		}
 		final SharedPreferences sharedPreferences = getDefaultSharedPreferences(main_activity);
 		String burst_mode = sharedPreferences.getString(PreferenceKeys.getBurstModePreferenceKey(), "");
-		if(burst_mode.equals(""))
+		if(burst_mode.isEmpty())
 		{
 			burst_mode = "1";
 			SharedPreferences.Editor editor = sharedPreferences.edit();

--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/ImageSaver.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/ImageSaver.java
@@ -1428,6 +1428,13 @@ public class ImageSaver extends Thread {
 		}
 		final SharedPreferences sharedPreferences = getDefaultSharedPreferences(main_activity);
 		String burst_mode = sharedPreferences.getString(PreferenceKeys.getBurstModePreferenceKey(), "");
+		if(burst_mode.equals(""))
+		{
+			burst_mode = "1";
+			SharedPreferences.Editor editor = sharedPreferences.edit();
+			editor.putString(PreferenceKeys.getBurstModePreferenceKey(), "1");
+			editor.apply();
+		}
 		burst_mode_value = Integer.parseInt(burst_mode);
 		click_count++;
 		if (basicCallBack != null && burst_mode_value == click_count) {


### PR DESCRIPTION
Fixed #1651

Changes: Actually on resetting, all the saved values in the shared preference(SP) are removed. So saved that value("burst_mode") again in the SP.The value is always 1.


