### PR TITLE
Fixed  #1700 on pressing back gallery is shown

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
@@ -996,6 +996,7 @@ public class SettingsActivity extends ThemedActivity {
             @Override
             public void onClick(View v) {
                 startActivity(new Intent(context, CameraActivity.class));
+                finish();
             }
         });
 


### PR DESCRIPTION
Fixed #1700

Changes: When you install the activity for the first time, open the settings and click on Camera option you will be directed to camera activity. Now if press back you will taken back to the dialog box i.e the settings activity. So added finish() to destroy the settings activity so that Gallery opens on pressing back. Same event happens when you reset your settings and click on the Camera option in settings.


