### PR TITLE
Fixed  #1720 The toolbar of accounts activity is changing according to the primary color.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
@@ -602,6 +602,7 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
     public void onResume() {
         super.onResume();
         ActivitySwitchHelper.setContext(this);
+        toolbar.setBackgroundColor(getPrimaryColor());
         //dropboxAuthentication();
         boxAuthentication();
         setStatusBarColor();


### PR DESCRIPTION
Fixed #1720

Changes: The reason was that the toolbar color for Account activity was only set in onCreate() method , so when the primary color is changed, the toolbar color remains the same.

