### PR TITLE
Fix #1730-Description dialog issue resolved.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -988,39 +988,42 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 descriptionDialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
                 AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE},
                         getColor(R.color.grey), descriptionDialog);
-
+                descriptionDialog.getButton(AlertDialog.BUTTON_NEUTRAL).setEnabled(false);
                 if(temp == null){
+                    descriptionDialog.getButton(DialogInterface.BUTTON_NEUTRAL).setTextColor(getColor(R.color.grey));
                     descriptionDialog.getButton(DialogInterface.BUTTON_NEUTRAL).setEnabled(false);
                 }
                 else
+                    descriptionDialog.getButton(DialogInterface.BUTTON_NEUTRAL).setTextColor(getAccentColor());
                     descriptionDialog.getButton(DialogInterface.BUTTON_NEUTRAL).setEnabled(true);
-
                 editTextDescription.addTextChangedListener(new TextWatcher() {
                     @Override public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
                         //empty method body
-
                     }
 
                     @Override public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
                         //empty method body
-
                     }
 
                     @Override public void afterTextChanged(Editable editable) {
                         if (TextUtils.isEmpty(editable)) {
+                            descriptionDialog.getButton(DialogInterface.BUTTON_NEUTRAL
+                            ).setEnabled(false);
+                            descriptionDialog.getButton(DialogInterface.BUTTON_NEUTRAL).setTextColor(getColor(R.color
+                                    .grey));
                             // Disable ok button
                             descriptionDialog.getButton(
                                     AlertDialog.BUTTON_POSITIVE).setEnabled(false);
                             AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE},
                                     getColor(R.color.grey), descriptionDialog);
                         } else {
+                            descriptionDialog.getButton(DialogInterface.BUTTON_NEUTRAL).setEnabled(false);
                             // Something into edit text. Enable the button.
                             descriptionDialog.getButton(
                                     AlertDialog.BUTTON_POSITIVE).setEnabled(true);
                             AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE},
                                     getAccentColor(), descriptionDialog);
                         }
-
                     }
                 });
 
@@ -1043,12 +1046,14 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 descriptionDialog.getButton(DialogInterface.BUTTON_NEUTRAL).setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        descriptionDialog.dismiss();
-                        if(temp!= null){
+                        if (temp == null){
+                            descriptionDialog.getButton(DialogInterface.BUTTON_NEUTRAL).setEnabled(false);
+                        }
+                        else{
+                            descriptionDialog.dismiss();
                             databaseHelper.delete(temp);
                             SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.description_deleted), bottomBar.getHeight());
                         }
-
                     }
                 });
                 break;


### PR DESCRIPTION
Fixed #1730

Changes: The text colour of the delete button changes according to the change in accent colour, the delete button is disabled if there is no description saved for the image. The text colour of the update and delete button is changed to the same colour when the buttons are disabled.
