### PR TITLE
Fix #1523-Image details attributes properly visible for all the images.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -12,6 +12,7 @@ import android.content.res.Configuration;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
@@ -59,6 +60,7 @@ import android.widget.ViewSwitcher;
 
 import com.bumptech.glide.Glide;
 import com.mikepenz.community_material_typeface_library.CommunityMaterial;
+import com.mikepenz.iconics.view.IconicsImageView;
 import com.yalantis.ucrop.UCrop;
 
 import org.fossasia.phimpme.R;
@@ -875,23 +877,40 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                     media = new Media(new File(favouriteslist.get(current_image_pos).getPath()));
                 }
                 final MediaDetailsMap<String,String> mediaDetailsMap = media.getMainDetails(this);
-
-                // Set current image as a blurred background
-                Bitmap blurBackground = BlurImageUtil.blur(context, BitmapFactory.decodeFile(media.getPath()));
-                v.setBackground(new BitmapDrawable(getResources(), blurBackground));
+                LinearLayout linearLayout1 = (LinearLayout) findViewById(R.id.image_desc_top);
+                linearLayout1.setBackgroundColor(getPrimaryColor());
+                v.setBackgroundColor(getBackgroundColor());
+                int textColor = getBaseTheme() != ThemeHelper.LIGHT_THEME ? Color.parseColor("#FAFAFA" ): Color
+                        .parseColor("#455A64");
 
                 /* Getting all the viewgroups and views of the image description layout */
 
                 TextView  imgDate = (TextView) linearLayout.findViewById(R.id.image_desc_date);
+                imgDate.setTextColor(textColor);
                 TextView  imgLocation = (TextView) linearLayout.findViewById(R.id.image_desc_loc);
+                imgLocation.setTextColor(textColor);
                 TextView  imgTitle = (TextView) linearLayout.findViewById(R.id.image_desc_title);
+                imgTitle.setTextColor(textColor);
                 TextView  imgType = (TextView) linearLayout.findViewById(R.id.image_desc_type);
+                imgType.setTextColor(textColor);
                 TextView  imgSize = (TextView) linearLayout.findViewById(R.id.image_desc_size);
+                imgSize.setTextColor(textColor);
                 TextView  imgResolution = (TextView) linearLayout.findViewById(R.id.image_desc_res);
+                imgResolution.setTextColor(textColor);
                 TextView  imgPath = (TextView) linearLayout.findViewById(R.id.image_desc_path);
+                imgPath.setTextColor(textColor);
                 TextView  imgOrientation = (TextView) linearLayout.findViewById(R.id.image_desc_orientation);
+                imgOrientation.setTextColor(textColor);
                 TextView  imgExif = (TextView) linearLayout.findViewById(R.id.image_desc_exif);
+                imgExif.setTextColor(textColor);
                 TextView  imgDesc = (TextView) linearLayout.findViewById(R.id.image_desc);
+                imgDesc.setTextColor(textColor);
+                IconicsImageView iconicsImageView = (IconicsImageView) linearLayout.findViewById(R.id.date_icon);
+                iconicsImageView.setColor(textColor);
+                IconicsImageView locationicon = (IconicsImageView) linearLayout.findViewById(R.id.loca_icon);
+                locationicon.setColor(textColor);
+                IconicsImageView detailsicon = (IconicsImageView) linearLayout.findViewById(R.id.detail_icon);
+                detailsicon.setColor(textColor);
                 ImageButton imgBack = (ImageButton) linearLayout.findViewById(R.id.img_desc_back_arrow);
 
                 imgBack.setOnClickListener(new View.OnClickListener() {
@@ -902,6 +921,30 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                         toggleSystemUI();
                     }
                 });
+
+                /*Setting the label text colours*/
+                TextView datelabel = (TextView) linearLayout.findViewById(R.id.date_label);
+                datelabel.setTextColor(textColor);
+                TextView locationlabel = (TextView) linearLayout.findViewById(R.id.location_label);
+                locationlabel.setTextColor(textColor);
+                TextView detaillabel = (TextView) linearLayout.findViewById(R.id.details_label);
+                detaillabel.setTextColor(textColor);
+                TextView titlelabel = (TextView) linearLayout.findViewById(R.id.title_label);
+                titlelabel.setTextColor(textColor);
+                TextView typelabel = (TextView) linearLayout.findViewById(R.id.type_label);
+                typelabel.setTextColor(textColor);
+                TextView sizelabel = (TextView) linearLayout.findViewById(R.id.size_label);
+                sizelabel.setTextColor(textColor);
+                TextView reslabel = (TextView) linearLayout.findViewById(R.id.resolution_label);
+                reslabel.setTextColor(textColor);
+                TextView pathlabel = (TextView) linearLayout.findViewById(R.id.path_label);
+                pathlabel.setTextColor(textColor);
+                TextView orientationlabel = (TextView) linearLayout.findViewById(R.id.orientation_label);
+                orientationlabel.setTextColor(textColor);
+                TextView exiflabel = (TextView) linearLayout.findViewById(R.id.exif_label);
+                exiflabel.setTextColor(textColor);
+                TextView desclabel = (TextView) linearLayout.findViewById(R.id.description_label);
+                desclabel.setTextColor(textColor);
 
                 /*Setting the values to all the textViews*/
 

--- a/app/src/main/res/layout/image_description.xml
+++ b/app/src/main/res/layout/image_description.xml
@@ -12,8 +12,7 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:id="@+id/image_desc_top"
-        android:paddingLeft="@dimen/sub_small_spacing"
-        android:paddingRight="@dimen/sub_small_spacing">
+        android:padding="13dp">
 
         <ImageButton
             android:layout_width="48dp"
@@ -46,9 +45,9 @@
         <com.mikepenz.iconics.view.IconicsImageView
             android:layout_width="30dp"
             android:layout_height="30dp"
+            android:id="@+id/date_icon"
             app2:iiv_icon="gmd-access-time"
-            android:layout_gravity="center"
-            app2:iiv_color="@color/white"/>
+            android:layout_gravity="center"/>
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -59,6 +58,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/date"
+                android:id="@+id/date_label"
+                android:textStyle="bold"
                 android:textColor="@color/md_grey_200"
                 android:textSize="@dimen/sub_big_text" />
             <View
@@ -71,14 +72,13 @@
                 tools:text="28/September/2018"
                 android:textColor="@color/md_grey_400"
                 android:textSize="@dimen/medium_text"/>
+          <View
+              android:layout_width="match_parent"
+              android:layout_height="20dp"/>
 
         </LinearLayout>
 
     </LinearLayout>
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="20dp"/>
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -88,7 +88,7 @@
         <com.mikepenz.iconics.view.IconicsImageView
             android:layout_width="30dp"
             android:layout_height="30dp"
-            app2:iiv_color="@color/white"
+            android:id="@+id/loca_icon"
             android:layout_gravity="center"
             app2:iiv_icon="gmd-location-on"/>
 
@@ -101,6 +101,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/location"
+                android:id="@+id/location_label"
+                android:textStyle="bold"
                 android:textColor="@color/md_grey_200"
                 android:textSize="@dimen/sub_big_text" />
             <View
@@ -130,7 +132,7 @@
         <com.mikepenz.iconics.view.IconicsImageView
             android:layout_width="30dp"
             android:layout_height="30dp"
-            app2:iiv_color="@color/white"
+            android:id="@+id/detail_icon"
             android:layout_gravity="fill"
             app2:iiv_icon="gmd-camera-roll"/>
 
@@ -144,6 +146,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Details"
+                android:id="@+id/details_label"
+                android:textStyle="bold"
                 android:textColor="@color/md_grey_200"
                 android:textSize="@dimen/sub_big_text" />
             <View
@@ -163,6 +167,8 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
                         android:text="Title"
+                        android:id="@+id/title_label"
+                        android:textStyle="bold"
                         android:textSize="@dimen/sub_big_text"/>
                     <TextView
                         android:layout_width="match_parent"
@@ -184,6 +190,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/type"
+                        android:id="@+id/type_label"
+                        android:textStyle="bold"
                         android:textSize="@dimen/sub_big_text"/>
                     <TextView
                         android:layout_width="match_parent"
@@ -205,6 +213,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/size"
+                        android:id="@+id/size_label"
+                        android:textStyle="bold"
                         android:textSize="@dimen/sub_big_text"/>
                     <TextView
                         android:layout_width="match_parent"
@@ -226,6 +236,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/resolution"
+                        android:id="@+id/resolution_label"
+                        android:textStyle="bold"
                         android:textSize="@dimen/sub_big_text"/>
                     <TextView
                         android:layout_width="match_parent"
@@ -247,6 +259,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/path"
+                        android:id="@+id/path_label"
+                        android:textStyle="bold"
                         android:layout_gravity="center"
                         android:textSize="@dimen/sub_big_text"/>
                     <TextView
@@ -269,6 +283,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/orientation"
+                        android:id="@+id/orientation_label"
+                        android:textStyle="bold"
                         android:textSize="@dimen/sub_big_text"/>
                     <TextView
                         android:layout_width="match_parent"
@@ -290,6 +306,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/exif"
+                        android:id="@+id/exif_label"
+                        android:textStyle="bold"
                         android:textSize="@dimen/sub_big_text"/>
                     <TextView
                         android:layout_width="match_parent"
@@ -313,6 +331,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/type_description"
+                        android:id="@+id/description_label"
+                        android:textStyle="bold"
                         android:textSize="@dimen/sub_big_text"/>
                     <TextView
                         android:layout_width="match_parent"


### PR DESCRIPTION
Fixed #1523 

Changes: Image detail attributes visible properly for all the images, the description view layout is modified from the blur background layout to the theme based background layout.

Screenshots for the change: 
![screenshot_2018-01-25-01-47-20-222_org fossasia phimpme](https://user-images.githubusercontent.com/20841578/35355427-46400052-0173-11e8-9809-b826e78de65f.png)
