### PR TITLE
Fixed #1781 - Unlimited Burst Mode now working in Camera.

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -100,21 +100,19 @@
     </string-array>
     <string-array name="preference_burst_mode_entries">
         <item>Off</item>
-        <item>2x</item>
-        <item>3x</item>
-        <item>4x</item>
         <item>5x</item>
         <item>10x</item>
+        <item>25x</item>
+        <item>40x</item>
         <item>Unlimited</item>
     </string-array>
     <string-array name="preference_burst_mode_values">
         <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
         <item>5</item>
         <item>10</item>
-        <item>unlimited</item>
+        <item>25</item>
+        <item>40</item>
+        <item>99</item>
     </string-array>
     <string-array name="preference_burst_interval_entries">
         <item>No delay</item>


### PR DESCRIPTION
Fixed #1781 

Changes: 
Changed burst mode options from off,2x,3x,4x,5x,10x,unlimited  to  off,5x,10x,25x,40x,unlimited-->99x.
