### PR TITLE
Fixed #1728 password protection doesn't get removed from resetting

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
@@ -966,8 +966,27 @@ public class SettingsActivity extends ThemedActivity {
         resetDialog.setNegativeButton(this.getString(R.string.no_action).toUpperCase(), null);
         resetDialog.setPositiveButton(this.getString(R.string.yes_action).toUpperCase(), new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {
-                SP.clearPreferences();
-                recreate();
+                if(!securityObj.isActiveSecurity()) {
+                    SP.clearPreferences();
+                    recreate();
+                } else {
+                    String password =  SP.getString(getString(R.string.preference_password_value),"");
+                    boolean activeSecurity = SP.getBoolean(getString(R.string.preference_use_password), false);
+                    boolean hiddenFolders =  SP.getBoolean(getString(R.string.preference_use_password_on_hidden), false);
+                    boolean localFolders =  SP.getBoolean(getString(R.string.preference_use_password_on_folder), false);
+                    boolean deleteAction = SP.getBoolean(getString(R.string.preference_use_password_on_delete), false);
+
+                    SP.clearPreferences();
+                    recreate();
+
+                    SP.putString(getString(R.string.preference_password_value),password);
+                    SP.putBoolean(getString(R.string.preference_use_password), activeSecurity);
+                    SP.putBoolean(getString(R.string.preference_use_password_on_hidden), hiddenFolders);
+                    SP.putBoolean(getString(R.string.preference_use_password_on_folder), localFolders);
+                    SP.putBoolean(getString(R.string.preference_use_password_on_delete), deleteAction);
+                    securityObj.updateSecuritySetting();
+
+                }
             }
         });
         AlertDialog alertDialog = resetDialog.create();


### PR DESCRIPTION
Fixed #1728

Changes: Before password protection gets removed on pressing the reset button due to which having password protection seemed to be of no use if anyone can just remove the protection from just resetting all the settings. Now the password protection remains intact even after resetting.

