### PR TITLE
Fixed #1728 password protection doesn't get removed from resetting

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -143,7 +143,7 @@ public class SecurityActivity extends ThemedActivity {
                                 SharedPreferences.Editor editor = SP.getEditor();
                                 Gson gson = new Gson();
                                 String securedfolders = gson.toJson(securedfol);
-                                editor.putString("SecuredLocalFolders", securedfolders);
+                                editor.putString(getString(R.string.preference_use_password_secured_local_folders), securedfolders);
                                 editor.commit();
                             }else{
                                 SP.putBoolean(getString(R.string.preference_use_password_on_folder), false);

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
@@ -966,8 +966,29 @@ public class SettingsActivity extends ThemedActivity {
         resetDialog.setNegativeButton(this.getString(R.string.no_action).toUpperCase(), null);
         resetDialog.setPositiveButton(this.getString(R.string.yes_action).toUpperCase(), new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {
-                SP.clearPreferences();
-                recreate();
+                if(!securityObj.isActiveSecurity()) {
+                    SP.clearPreferences();
+                    recreate();
+                } else {
+                    String password =  SP.getString(getString(R.string.preference_password_value),"");
+                    String securedLocalFolders = SP.getString(getString(R.string.preference_use_password_secured_local_folders),"");
+                    boolean activeSecurity = SP.getBoolean(getString(R.string.preference_use_password), false);
+                    boolean hiddenFolders =  SP.getBoolean(getString(R.string.preference_use_password_on_hidden), false);
+                    boolean localFolders =  SP.getBoolean(getString(R.string.preference_use_password_on_folder), false);
+                    boolean deleteAction = SP.getBoolean(getString(R.string.preference_use_password_on_delete), false);
+
+                    SP.clearPreferences();
+                    recreate();
+
+                    SP.putString(getString(R.string.preference_password_value),password);
+                    SP.putString(getString(R.string.preference_use_password_secured_local_folders),securedLocalFolders);
+                    SP.putBoolean(getString(R.string.preference_use_password), activeSecurity);
+                    SP.putBoolean(getString(R.string.preference_use_password_on_hidden), hiddenFolders);
+                    SP.putBoolean(getString(R.string.preference_use_password_on_folder), localFolders);
+                    SP.putBoolean(getString(R.string.preference_use_password_on_delete), deleteAction);
+                    securityObj.updateSecuritySetting();
+
+                }
             }
         });
         AlertDialog alertDialog = resetDialog.create();

--- a/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
@@ -48,7 +48,7 @@ public class SecurityHelper {
 
     public void updateSecuritySetting(){
         PreferenceUtil SP = PreferenceUtil.getInstance(context);
-        String secur = SP.getString("SecuredLocalFolders", "");
+        String secur = SP.getString(context.getString(R.string.preference_use_password_secured_local_folders), "");
         Gson gson = new Gson();
         String[] secfo = gson.fromJson(secur, String[].class);
         if(secfo!=null){

--- a/app/src/main/res/values/preferences-key.xml
+++ b/app/src/main/res/values/preferences-key.xml
@@ -22,6 +22,7 @@
     <string name="preference_use_password_on_hidden">password_on_hidden</string>
     <string name="preference_use_password_on_delete">password_on_delete</string>
     <string name="preference_use_password_on_folder">password on folder</string>
+    <string name="preference_use_password_secured_local_folders">SecuredLocalFolders</string>
     <string name="preference_internal_uri_extsdcard_photos">uri_extsdcard_photos</string>
     <string name="preference_show_fab">show_fab</string>
     <string name="preference_sub_scaling">use_sub_scaling</string>


### PR DESCRIPTION
Fixed #1728

Changes: Before password protection gets removed on pressing the reset button due to which having password protection seemed to be of no use if anyone can just remove the protection from just resetting all the settings. Now the password protection remains intact even after resetting.
