### PR TITLE
Fix #1820-Error message displayed when entering wrong password.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -463,7 +463,8 @@ public class LFMainActivity extends SharedMediaActivity {
         @Override
         public boolean onLongClick(View v) {
             final Album album = (Album) v.findViewById(R.id.album_name).getTag();
-            if (securityObj.isActiveSecurity() && securityObj.isPasswordOnfolder()) {
+            if(securityObj.isActiveSecurity() && securityObj.isPasswordOnfolder()) {
+                final boolean passco[] = {false};
                 if (check(album.getPath())) {
                     AlertDialog.Builder passwordDialogBuilder =
                             new AlertDialog.Builder(LFMainActivity.this, getDialogStyle());
@@ -479,6 +480,25 @@ public class LFMainActivity extends SharedMediaActivity {
                                     //to avoid dismiss of the dialog on wrong password
                                 }
                             });
+                    editTextPassword.addTextChangedListener(new TextWatcher() {
+                        @Override public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                            //empty method body
+                        }
+
+                        @Override public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                            //empty method body
+                        }
+
+                        @Override public void afterTextChanged(Editable editable) {
+                            if(securityObj.getTextInputLayout().getVisibility() == View.VISIBLE && !passco[0]){
+                                securityObj.getTextInputLayout().setVisibility(View.INVISIBLE);
+                            }
+                            else{
+                                passco[0]=false;
+                            }
+
+                        }
+                    });
 
                     final AlertDialog passwordDialog = passwordDialogBuilder.create();
                     passwordDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
@@ -508,6 +528,8 @@ public class LFMainActivity extends SharedMediaActivity {
                                     }
                                     // if password is incorrect, notify user of incorrect password
                                     else {
+                                        passco[0] = true;
+                                        securityObj.getTextInputLayout().setVisibility(View.VISIBLE);
                                         SnackBarHandler
                                                 .showWithBottomMargin(mDrawerLayout, getString(R.string.wrong_password),
                                                         navigationView.getHeight());
@@ -572,12 +594,31 @@ public class LFMainActivity extends SharedMediaActivity {
                 if (getAlbums().getSelectedCount() == 0)
                     getNavigationBar();
                 invalidateOptionsMenu();
-            } else if (securityObj.isActiveSecurity() && securityObj.isPasswordOnfolder()) {
+            } else if(securityObj.isActiveSecurity() && securityObj.isPasswordOnfolder()){
+                final boolean[] passco = {false};
                 if (check(album.getPath())) {
                     AlertDialog.Builder passwordDialogBuilder =
                             new AlertDialog.Builder(LFMainActivity.this, getDialogStyle());
                     final EditText editTextPassword =
                             securityObj.getInsertPasswordDialog(LFMainActivity.this, passwordDialogBuilder);
+                    editTextPassword.addTextChangedListener(new TextWatcher() {
+                        @Override public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                            //empty method body
+                        }
+
+                        @Override public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                            //empty method body
+                        }
+
+                        @Override public void afterTextChanged(Editable editable) {
+                            if(securityObj.getTextInputLayout().getVisibility() == View.VISIBLE && !passco[0]){
+                                securityObj.getTextInputLayout().setVisibility(View.INVISIBLE);
+                            }
+                            else{
+                                passco[0]=false;
+                            }
+                        }
+                    });
                     passwordDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
 
                     passwordDialogBuilder.setPositiveButton(getString(R.string.ok_action).toUpperCase(),
@@ -606,6 +647,8 @@ public class LFMainActivity extends SharedMediaActivity {
                                     }
                                     // if password is incorrect, notify user of incorrect password
                                     else {
+                                        passco[0] =true;
+                                        securityObj.getTextInputLayout().setVisibility(View.VISIBLE);
                                         SnackBarHandler
                                                 .showWithBottomMargin(mDrawerLayout, getString(R.string.wrong_password),
                                                         navigationView.getHeight());
@@ -1263,6 +1306,7 @@ public class LFMainActivity extends SharedMediaActivity {
                 tint();
                 toolbar.setTitle(getString(R.string.hidden_folder));
                 if (securityObj.isActiveSecurity() && securityObj.isPasswordOnHidden()) {
+                    final boolean[] passco = {false};
                     AlertDialog.Builder passwordDialogBuilder = new AlertDialog.Builder(LFMainActivity.this, getDialogStyle());
                     final EditText editTextPassword = securityObj.getInsertPasswordDialog(LFMainActivity.this, passwordDialogBuilder);
                     passwordDialogBuilder.setPositiveButton(getString(R.string.ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
@@ -1271,6 +1315,25 @@ public class LFMainActivity extends SharedMediaActivity {
                     });
 
                     passwordDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
+                    editTextPassword.addTextChangedListener(new TextWatcher() {
+                        @Override public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                            //empty method body
+                        }
+
+                        @Override public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                            //empty method body
+                        }
+
+                        @Override public void afterTextChanged(Editable editable) {
+                            if(securityObj.getTextInputLayout().getVisibility() == View.VISIBLE && !passco[0]){
+                                securityObj.getTextInputLayout().setVisibility(View.INVISIBLE);
+                            }
+                            else{
+                                passco[0]=false;
+                            }
+
+                        }
+                    });
 
                     final AlertDialog passwordDialog = passwordDialogBuilder.create();
                     passwordDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
@@ -1286,6 +1349,8 @@ public class LFMainActivity extends SharedMediaActivity {
                                 new PrepareAlbumTask().execute();
                                 passwordDialog.dismiss();
                             } else {
+                                passco[0] = true;
+                                securityObj.getTextInputLayout().setVisibility(View.VISIBLE);
                                 SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.wrong_password), 0);
                                 editTextPassword.getText().clear();
                                 editTextPassword.requestFocus();
@@ -1906,6 +1971,7 @@ public class LFMainActivity extends SharedMediaActivity {
                 deleteDialog.setPositiveButton(this.getString(R.string.delete).toUpperCase(), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         if (securityObj.isActiveSecurity() && securityObj.isPasswordOnDelete()) {
+                            final boolean passco[] = {false};
                             AlertDialog.Builder passwordDialogBuilder = new AlertDialog.Builder(LFMainActivity.this, getDialogStyle());
                             final EditText editTextPassword = securityObj.getInsertPasswordDialog(LFMainActivity.this, passwordDialogBuilder);
                             passwordDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
@@ -1915,6 +1981,25 @@ public class LFMainActivity extends SharedMediaActivity {
                                 public void onClick(DialogInterface dialog, int which) {
                                     //This should br empty it will be overwrite later
                                     //to avoid dismiss of the dialog on wrong password
+                                }
+                            });
+                            editTextPassword.addTextChangedListener(new TextWatcher() {
+                                @Override
+                                public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                                    //empty method body
+                                }
+
+                                @Override public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                                    //empty method body
+                                }
+
+                                @Override public void afterTextChanged(Editable editable) {
+                                    if(securityObj.getTextInputLayout().getVisibility() == View.VISIBLE && !passco[0]){
+                                        securityObj.getTextInputLayout().setVisibility(View.INVISIBLE);
+                                    }
+                                    else{
+                                        passco[0]=false;
+                                    }
                                 }
                             });
 
@@ -1932,6 +2017,8 @@ public class LFMainActivity extends SharedMediaActivity {
                                     }
                                     // if password is incorrect, don't delete and notify user of incorrect password
                                     else {
+                                        passco[0] = true;
+                                        securityObj.getTextInputLayout().setVisibility(View.VISIBLE);
                                         SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.wrong_password), navigationView.getHeight());
                                         editTextPassword.getText().clear();
                                         editTextPassword.requestFocus();

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
@@ -404,6 +404,7 @@ public class SettingsActivity extends ThemedActivity {
     }
 
     private void askPasswordDialog() {
+        final boolean[] passco = {false};
         AlertDialog.Builder passwordDialogBuilder = new AlertDialog.Builder(SettingsActivity.this, getDialogStyle());
         final EditText editTextPassword  = securityObj.getInsertPasswordDialog(SettingsActivity.this,passwordDialogBuilder);
         passwordDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
@@ -420,6 +421,12 @@ public class SettingsActivity extends ThemedActivity {
             }
 
             @Override public void afterTextChanged(Editable editable) {
+                if(securityObj.getTextInputLayout().getVisibility() == View.VISIBLE && !passco[0]){
+                    securityObj.getTextInputLayout().setVisibility(View.INVISIBLE);
+                }
+                else{
+                    passco[0]=false;
+                }
                 if(editable.length() == 11) {
                     editTextPassword.setText(editable.toString().substring(0, 10));
                     editTextPassword.setSelection(10);
@@ -449,6 +456,7 @@ public class SettingsActivity extends ThemedActivity {
                     passwordDialog.dismiss();
                     startActivity(new Intent(getApplicationContext(), SecurityActivity.class));
                 } else {
+                    passco[0] = true;
                     securityObj.getTextInputLayout().setVisibility(View.VISIBLE);
                     SnackBarHandler.show(parent,R.string.wrong_password);
                     editTextPassword.getText().clear();

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -788,7 +788,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 deleteDialog.setPositiveButton(this.getString(R.string.delete).toUpperCase(), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         if (securityObj.isActiveSecurity() && securityObj.isPasswordOnDelete()) {
-
+                            final boolean passco[] = {false};
                             final AlertDialog.Builder passwordDialogBuilder = new AlertDialog.Builder(SingleMediaActivity.this, getDialogStyle());
                             final EditText editTextPassword = securityObj.getInsertPasswordDialog
                                     (SingleMediaActivity.this, passwordDialogBuilder);
@@ -799,6 +799,26 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                                         deleteCurrentMedia();
                                     } else
                                         SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.wrong_password), bottomBar.getHeight());
+
+                                }
+                            });
+                            editTextPassword.addTextChangedListener(new TextWatcher() {
+                                @Override
+                                public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                                    //empty method body
+                                }
+
+                                @Override public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                                    //empty method body
+                                }
+
+                                @Override public void afterTextChanged(Editable editable) {
+                                    if(securityObj.getTextInputLayout().getVisibility() == View.VISIBLE && !passco[0]){
+                                        securityObj.getTextInputLayout().setVisibility(View.INVISIBLE);
+                                    }
+                                    else{
+                                        passco[0]=false;
+                                    }
 
                                 }
                             });
@@ -814,6 +834,8 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                                         deleteCurrentMedia();
                                         passwordDialog.dismiss();
                                     } else {
+                                        passco[0] = true;
+                                        securityObj.getTextInputLayout().setVisibility(View.VISIBLE);
                                         SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.wrong_password), bottomBar.getHeight());
                                         editTextPassword.getText().clear();
                                         editTextPassword.requestFocus();


### PR DESCRIPTION
Fixed #1820 
Changes: Error message is displayed as a floating label in the edittexts when entering wrong password, the floating label(error message) dissappears when the user starts typing the password once again after the failed attempt.
