### PR TITLE
Fixes #1779 Removed "As number" option from sorting

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -126,7 +126,6 @@ import io.realm.RealmResults;
 
 import static org.fossasia.phimpme.gallery.data.base.SortingMode.DATE;
 import static org.fossasia.phimpme.gallery.data.base.SortingMode.NAME;
-import static org.fossasia.phimpme.gallery.data.base.SortingMode.NUMERIC;
 import static org.fossasia.phimpme.gallery.data.base.SortingMode.SIZE;
 import static org.fossasia.phimpme.gallery.util.ThemeHelper.LIGHT_THEME;
 
@@ -1500,9 +1499,6 @@ public class LFMainActivity extends SharedMediaActivity {
                 default:
                     menu.findItem(R.id.date_taken_sort_action).setChecked(true);
                     break;
-                case NUMERIC:
-                    menu.findItem(R.id.numeric_sort_action).setChecked(true);
-                    break;
             }
 
         } else {
@@ -1524,9 +1520,6 @@ public class LFMainActivity extends SharedMediaActivity {
                 case DATE:
                 default:
                     menu.findItem(R.id.date_taken_sort_action).setChecked(true);
-                    break;
-                case NUMERIC:
-                    menu.findItem(R.id.numeric_sort_action).setChecked(true);
                     break;
             }
         }
@@ -2093,24 +2086,6 @@ public class LFMainActivity extends SharedMediaActivity {
                     new SortingUtilsAlbums().execute();
                 } else {
                     new SortModeSet().execute(SIZE);
-                    if(!all_photos && !fav_photos){
-                        new SortingUtilsPhtots().execute();
-                    }
-                    else if (all_photos && !fav_photos) {
-                        new SortingUtilsListAll().execute();
-                    }else if(fav_photos && !all_photos){
-                        new SortingUtilsFavouritelist().execute();
-                    }
-                }
-                item.setChecked(true);
-                return true;
-
-            case R.id.numeric_sort_action:
-                if (albumsMode) {
-                    getAlbums().setDefaultSortingMode(NUMERIC);
-                    new SortingUtilsAlbums().execute();
-                } else {
-                    new SortModeSet().execute(NUMERIC);
                     if(!all_photos && !fav_photos){
                         new SortingUtilsPhtots().execute();
                     }

--- a/app/src/main/java/org/fossasia/phimpme/gallery/data/base/AlbumsComparators.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/data/base/AlbumsComparators.java
@@ -18,8 +18,6 @@ public class AlbumsComparators {
                 return getSizeComparator(sortingOrder);
             case DATE: default:
                 return getDateComparator(sortingOrder);
-            case NUMERIC:
-                return getNumericComparator(sortingOrder);
         }
     }
 

--- a/app/src/main/java/org/fossasia/phimpme/gallery/data/base/MediaComparators.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/data/base/MediaComparators.java
@@ -19,8 +19,6 @@ public class MediaComparators {
                 return getDateComparator(sortingOrder);
             case SIZE:
                 return getSizeComparator(sortingOrder);
-            case NUMERIC:
-                return getNumericComparator(sortingOrder);
         }
     }
 

--- a/app/src/main/java/org/fossasia/phimpme/gallery/data/base/SortingMode.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/data/base/SortingMode.java
@@ -5,7 +5,7 @@ package org.fossasia.phimpme.gallery.data.base;
  */
 
 public enum SortingMode {
-  NAME (0), DATE (1), SIZE(2), NUMERIC(3);
+  NAME (0), DATE (1), SIZE(2);
 
   int value;
 
@@ -22,7 +22,6 @@ public enum SortingMode {
       case 0: return NAME;
       case 1: default: return DATE;
       case 2: return SIZE;
-      case 3: return NUMERIC;
     }
   }
 }

--- a/app/src/main/res/menu/menu_albums.xml
+++ b/app/src/main/res/menu/menu_albums.xml
@@ -32,10 +32,6 @@
                         android:id="@+id/size_sort_action"
                         android:title="@string/size"
                         app:showAsAction="never" />
-                    <item
-                        android:id="@+id/numeric_sort_action"
-                        android:title="@string/numeric"
-                        app:showAsAction="never" />
                 </group>
                 <group android:checkableBehavior="all">
                     <item


### PR DESCRIPTION
Fixed #1779

Changes: Since there were two sorting options, "name" and "As number", with same sorting order, so removed "As number" option from the sorting menu.
