### PR TITLE
Fix #1834-Back press issue for search operation fixed.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1446,16 +1446,29 @@ public class LFMainActivity extends SharedMediaActivity {
             starImageView.setColorFilter(ContextCompat.getColor(this, R.color.black), PorterDuff.Mode.SRC_ATOP);
     }
 
+    private void setItemsVisibility(Menu menu, MenuItem exception, boolean visible) {
+        for (int i=0; i<menu.size(); ++i) {
+            MenuItem item = menu.getItem(i);
+            if (!item.equals(exception)) item.setVisible(visible);
+        }
+    }
+
     //region MENU
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(final Menu menu) {
 
         // Inflate the menu; this adds items to the action bar if it is present.
         getMenuInflater().inflate(R.menu.menu_albums, menu);
 
         if (albumsMode) {
-            MenuItem menuitem = menu.findItem(R.id.search_action);
+            final MenuItem menuitem = menu.findItem(R.id.search_action);
             final SearchView searchView = (SearchView) MenuItemCompat.getActionView(menuitem);
+            searchView.setOnSearchClickListener(new View.OnClickListener() {
+                @Override public void onClick(View view) {
+                    setItemsVisibility(menu, menuitem,false);
+
+                }
+            });
             searchView.setOnQueryTextFocusChangeListener(new View.OnFocusChangeListener() {
                 @Override public void onFocusChange(final View view, boolean b) {
                     if (b) {
@@ -1467,8 +1480,17 @@ public class LFMainActivity extends SharedMediaActivity {
                                 imm.showSoftInput(view.findFocus(), 0);
                             }
                         }, 200);
-
                     }
+                }
+            });
+            MenuItemCompat.setOnActionExpandListener(menuitem, new MenuItemCompat.OnActionExpandListener() {
+                @Override public boolean onMenuItemActionExpand(MenuItem item) {
+                    return true;
+                }
+
+                @Override public boolean onMenuItemActionCollapse(MenuItem item) {
+                    invalidateOptionsMenu();
+                    return true;
                 }
             });
             searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
@@ -1501,7 +1523,6 @@ public class LFMainActivity extends SharedMediaActivity {
                     menu.findItem(R.id.numeric_sort_action).setChecked(true);
                     break;
             }
-
         } else {
             getfavouriteslist();
             menu.findItem(R.id.select_all).setTitle(getString(getAlbum().getSelectedCount() == mediaAdapter

--- a/app/src/main/res/drawable/ic_search_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_search_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+</vector>

--- a/app/src/main/res/menu/menu_albums.xml
+++ b/app/src/main/res/menu/menu_albums.xml
@@ -129,10 +129,9 @@
         android:id="@+id/search_action"
         android:title="@string/search_menu"
         android:visible="true"
-        android:icon="@drawable/ic_search_black_24dp"
-        android:tint="@color/white"
+        android:icon="@drawable/ic_search_white_24dp"
         app:actionViewClass="android.support.v7.widget.SearchView"
-        app:showAsAction="always" />
+        app:showAsAction="always|collapseActionView" />
     <item
         android:id="@+id/all_photos"
         android:title="@string/all_photos"


### PR DESCRIPTION
Fixed #1834 
Changes: On performing back press after the search operation is performed, local folders/hidden folders are displayed accordingly, search view fills up the entire action bar area hiding the other items. A back navigation button is displayed in place of the navigation drawer icon.
