### PR TITLE
Fix #1843-Photos in the favourites collection displayed in the same o…

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1703,6 +1703,8 @@ public class LFMainActivity extends SharedMediaActivity {
                             clearSelectedPhotos();
                             selectAllPhotos();
                         }
+                        Collections.sort(favouriteslist, MediaComparators.getComparator(getAlbum().settings.getSortingMode(),
+                                getAlbum().settings.getSortingOrder()));
                         mediaAdapter.swapDataSet(favouriteslist);
                     }
                 }


### PR DESCRIPTION
…rder after performing select all operation.

Fixed #1843
Changes: Photos in the favourites collection are displayed in the same order as before after performing the select all operation.
