### PR TITLE
Fixes #1849 "Hidden Folders" remains highlighted even when local folders are opened in navigation drawer.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -677,6 +677,9 @@ public class LFMainActivity extends SharedMediaActivity {
                     if(!localFolder){
                         hidden = false;
                         localFolder = true;
+                        findViewById(R.id.ll_drawer_hidden).setBackgroundColor(Color.TRANSPARENT);
+                        findViewById(R.id.ll_drawer_Default).setBackgroundColor(getHighlightedItemColor());
+                        tint();
                     }
                     displayAlbums();
                     return true;


### PR DESCRIPTION

Fixes #1849- "Hidden Folders" remains highlighted even when local folders are opened in navigation drawer.

Changes: 3 lines added in LFMainAcitivity.java to change the highlighted option back to local folders when gallery button in bottom navigation drawer is pressed.

Screenshots for the change: 

Before change(when local folders are opened)
![whatsapp image 2018-02-13 at 12 16 42 pm](https://user-images.githubusercontent.com/24573296/36140318-e3216958-10c6-11e8-8d20-a83a1f1a8a80.jpeg)
After change(when local folders are opened)
![whatsapp image 2018-02-13 at 2 03 58 pm](https://user-images.githubusercontent.com/24573296/36140346-f84b9268-10c6-11e8-9f33-54a645dc397b.jpeg)

