### PR TITLE
Fix #1859 - App doesn't crash on long pressing toggle filter.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Preview/Preview.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Preview/Preview.java
@@ -1421,8 +1421,10 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
 				public boolean onLongClick(View v) {
 					final List<String> colorEffect = getSupportedColorEffects();
 					colorNum = 0;
-					CameraController.SupportedValues supported_values = camera_controller.setColorEffect(colorEffect.get(0));
-					applicationInterface.setColorEffectPref(supported_values.selected_value);
+					if (colorEffect != null) {
+						CameraController.SupportedValues supported_values = camera_controller.setColorEffect(colorEffect.get(0));
+						applicationInterface.setColorEffectPref(supported_values.selected_value);
+					}
 					return true;
 				}
 			});


### PR DESCRIPTION
Fixed #1859 

Changes: Check for null filter list(devices which don't support filters).