### PR TITLE
Fix #1850 - information is now properly with their tags.

### DIFF
--- a/app/src/main/res/layout/image_description.xml
+++ b/app/src/main/res/layout/image_description.xml
@@ -124,235 +124,242 @@
         android:layout_width="match_parent"
         android:layout_height="20dp"/>
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="horizontal">
-
-        <com.mikepenz.iconics.view.IconicsImageView
-            android:layout_width="30dp"
-            android:layout_height="30dp"
-            android:id="@+id/detail_icon"
-            android:layout_gravity="fill"
-            app2:iiv_icon="gmd-camera-roll"/>
-
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:layout_marginLeft="10dp">
+            android:orientation="horizontal">
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Details"
-                android:id="@+id/details_label"
-                android:textStyle="bold"
-                android:textColor="@color/md_grey_200"
-                android:textSize="@dimen/sub_big_text" />
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/fab_margin"/>
+            <com.mikepenz.iconics.view.IconicsImageView
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:id="@+id/detail_icon"
+                android:layout_gravity="fill"
+                app2:iiv_icon="gmd-camera-roll"/>
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:layout_marginLeft="10dp">
 
-                <LinearLayout
-                    android:layout_width="wrap_content"
+                <TextView
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:text="Title"
-                        android:id="@+id/title_label"
-                        android:textStyle="bold"
-                        android:textSize="@dimen/sub_big_text"/>
-                    <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="5dp"
-                        android:id="@+id/image_desc_title"/>
-
-                </LinearLayout>
-
+                    android:text="Details"
+                    android:id="@+id/details_label"
+                    android:textStyle="bold"
+                    android:textColor="@color/md_grey_200"
+                    android:textSize="@dimen/sub_big_text" />
                 <View
                     android:layout_width="match_parent"
-                    android:layout_height="10dp"/>
-
+                    android:layout_height="@dimen/fab_margin"/>
                 <LinearLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/type"
-                        android:id="@+id/type_label"
-                        android:textStyle="bold"
-                        android:textSize="@dimen/sub_big_text"/>
-                    <TextView
+                    android:layout_height="match_parent"
+                    android:orientation="vertical">
+
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:id="@+id/image_desc_type"
-                        android:layout_marginLeft="5dp"/>
+                        android:orientation="horizontal"
+                        android:layout_marginBottom="2dp">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/details_title"
+                            android:id="@+id/title_label"
+                            android:textStyle="bold"
+                            android:textSize="@dimen/sub_big_text"/>
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginLeft="5dp"
+                            android:id="@+id/image_desc_title"
+                            android:textSize="@dimen/medium_text"
+                            android:layout_marginBottom="2dp"/>
 
-                </LinearLayout>
+                    </LinearLayout>
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp"/>
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="8dp"
+                        />
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/size"
-                        android:id="@+id/size_label"
-                        android:textStyle="bold"
-                        android:textSize="@dimen/sub_big_text"/>
-                    <TextView
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:id="@+id/image_desc_size"
-                        android:layout_marginLeft="5dp"/>
+                        android:orientation="horizontal">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/type"
+                            android:id="@+id/type_label"
+                            android:textStyle="bold"
+                            android:textSize="@dimen/sub_big_text"/>
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:id="@+id/image_desc_type"
+                            android:layout_marginLeft="5dp"
+                            android:textSize="@dimen/medium_text"
+                            android:layout_marginBottom="2dp"/>
 
-                </LinearLayout>
+                    </LinearLayout>
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp"/>
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="8dp"/>
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/resolution"
-                        android:id="@+id/resolution_label"
-                        android:textStyle="bold"
-                        android:textSize="@dimen/sub_big_text"/>
-                    <TextView
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:id="@+id/image_desc_res"
-                        android:layout_marginLeft="5dp"/>
+                        android:orientation="horizontal">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/size"
+                            android:id="@+id/size_label"
+                            android:textStyle="bold"
+                            android:textSize="@dimen/sub_big_text"/>
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:id="@+id/image_desc_size"
+                            android:layout_marginLeft="5dp"
+                            android:textSize="@dimen/medium_text"
+                            android:layout_marginBottom="2dp"/>
 
-                </LinearLayout>
+                    </LinearLayout>
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp"/>
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="8dp"/>
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/path"
-                        android:id="@+id/path_label"
-                        android:textStyle="bold"
-                        android:layout_gravity="center"
-                        android:textSize="@dimen/sub_big_text"/>
-                    <TextView
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:id="@+id/image_desc_path"
-                        android:layout_marginLeft="5dp"/>
+                        android:orientation="horizontal">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/resolution"
+                            android:id="@+id/resolution_label"
+                            android:textStyle="bold"
+                            android:textSize="@dimen/sub_big_text"/>
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:id="@+id/image_desc_res"
+                            android:layout_marginLeft="5dp"
+                            android:textSize="@dimen/medium_text"
+                            android:layout_marginBottom="2dp"/>
 
-                </LinearLayout>
+                    </LinearLayout>
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp"/>
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="8dp"/>
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/orientation"
-                        android:id="@+id/orientation_label"
-                        android:textStyle="bold"
-                        android:textSize="@dimen/sub_big_text"/>
-                    <TextView
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:id="@+id/image_desc_orientation"
-                        android:layout_marginLeft="5dp"/>
+                        android:orientation="horizontal">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/path"
+                            android:id="@+id/path_label"
+                            android:textStyle="bold"
+                            android:textSize="@dimen/sub_big_text"/>
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:id="@+id/image_desc_path"
+                            android:layout_marginLeft="5dp"
+                            android:layout_marginBottom="2dp"
+                            android:textSize="@dimen/medium_text"/>
 
-                </LinearLayout>
+                    </LinearLayout>
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp"/>
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="8dp"/>
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/exif"
-                        android:id="@+id/exif_label"
-                        android:textStyle="bold"
-                        android:textSize="@dimen/sub_big_text"/>
-                    <TextView
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:textSize="@dimen/medium_text"
-                        android:textColor="@color/md_grey_400"
-                        android:id="@+id/image_desc_exif"
-                        android:layout_marginLeft="5dp"/>
+                        android:orientation="horizontal">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/orientation"
+                            android:id="@+id/orientation_label"
+                            android:textStyle="bold"
+                            android:textSize="@dimen/sub_big_text"/>
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:id="@+id/image_desc_orientation"
+                            android:layout_marginLeft="5dp"
+                            android:textSize="@dimen/medium_text"
+                            android:layout_marginBottom="2dp"/>
 
-                </LinearLayout>
+                    </LinearLayout>
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp"/>
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="8dp"/>
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/type_description"
-                        android:id="@+id/description_label"
-                        android:textStyle="bold"
-                        android:textSize="@dimen/sub_big_text"/>
-                    <TextView
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:id="@+id/image_desc"
-                        android:textSize="@dimen/medium_text"
-                        android:textColor="@color/md_grey_400"
-                        android:layout_marginLeft="5dp"/>
+                        android:orientation="horizontal">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/exif"
+                            android:id="@+id/exif_label"
+                            android:textStyle="bold"
+                            android:textSize="@dimen/sub_big_text"/>
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textSize="@dimen/medium_text"
+                            android:textColor="@color/md_grey_400"
+                            android:id="@+id/image_desc_exif"
+                            android:layout_marginLeft="5dp"
+                            android:layout_marginBottom="2dp"/>
 
+                    </LinearLayout>
+
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="8dp"/>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/type_description"
+                            android:id="@+id/description_label"
+                            android:textStyle="bold"
+                            android:textSize="@dimen/sub_big_text"/>
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:id="@+id/image_desc"
+                            android:textSize="@dimen/medium_text"
+                            android:textColor="@color/md_grey_400"
+                            android:layout_marginLeft="5dp"
+                            android:layout_marginBottom="2dp"/>
+
+                    </LinearLayout>
                 </LinearLayout>
-
-
-
             </LinearLayout>
-
         </LinearLayout>
-
     </LinearLayout>
-    </LinearLayout>
-
-
 </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -719,6 +719,7 @@
 
     <!--PHOTO DETAILS-->
     <string name="path">Path</string>
+    <string name="details_title">Title</string>
     <string name="type">Type</string>
     <string name="resolution">Resolution</string>
     <string name="exif">EXIF</string>


### PR DESCRIPTION
Fixed #1850

Changes: The information is now properly assigned with their respective tags. Also added a "2dp" bottom margin to avoid the problems faced in the issue #1634. Since I added a "2dp" bottom margin so reduce the height of the view (from 10dp to 8dp) that provides space between tags in details view. Also assigned a common textSize to the information in details view.

Screenshots for the change: 
![detailschanges](https://user-images.githubusercontent.com/24502136/36533963-2b8c53bc-17eb-11e8-8024-e529fa96b20e.png)

