### PR TITLE
Fix #1822 Removed settings option from the overflow menu

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1648,6 +1648,7 @@ public class LFMainActivity extends SharedMediaActivity {
             menu.setGroupVisible(R.id.photos_option_men, false);
             menu.findItem(R.id.all_photos).setVisible(!editMode && !hidden);
             menu.findItem(R.id.search_action).setVisible(!editMode);
+            menu.findItem(R.id.settings).setVisible(false);
 
             if (getAlbums().getSelectedCount() >= 1) {
                 if (getAlbums().getSelectedCount() > 1) {


### PR DESCRIPTION
Fixed #1822

Changes: Now there is only one way to open settings, that is, from the navigation drawer. Removed this option from the overflow menu when you are in AlbumsMode.
Screenshots for the change: 

![settings](https://user-images.githubusercontent.com/24502136/36535088-86f9eee6-17ee-11e8-9982-79a83b4784ac.png)
