### PR TITLE
Fix #1896-Proper images displayed on performing click ope…

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/data/local/UploadHistoryRealmModel.java
+++ b/app/src/main/java/org/fossasia/phimpme/data/local/UploadHistoryRealmModel.java
@@ -1,17 +1,21 @@
 package org.fossasia.phimpme.data.local;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import io.realm.RealmObject;
 
 /**
  * Created by pa1pal on 16/08/17.
  */
 
-public class UploadHistoryRealmModel extends RealmObject{
+public class UploadHistoryRealmModel extends RealmObject implements Parcelable{
 
     String name;
     String pathname;
     String datetime;
     String status;
+
+    public UploadHistoryRealmModel(){}
 
     public String getStatus() {
         return status;
@@ -43,5 +47,33 @@ public class UploadHistoryRealmModel extends RealmObject{
 
     public void setDatetime(String datetime) {
         this.datetime = datetime;
+    }
+
+    @Override public int describeContents() {
+        return 0;
+    }
+
+    @Override public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(name);
+        parcel.writeString(pathname);
+        parcel.writeString(datetime);
+        parcel.writeString(status);
+    }
+
+    public static final Parcelable.Creator<UploadHistoryRealmModel> creator = new Creator<UploadHistoryRealmModel>() {
+        @Override public UploadHistoryRealmModel createFromParcel(Parcel parcel) {
+            return new UploadHistoryRealmModel(parcel);
+        }
+
+        @Override public UploadHistoryRealmModel[] newArray(int i) {
+            return new UploadHistoryRealmModel[i];
+        }
+    };
+
+    private UploadHistoryRealmModel(Parcel in){
+        name = in.readString();
+        pathname = in.readString();
+        datetime = in.readString();
+        status = in.readString();
     }
 }

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -14,7 +14,6 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
-import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
@@ -79,7 +78,6 @@ import org.fossasia.phimpme.gallery.data.AlbumSettings;
 import org.fossasia.phimpme.gallery.data.Media;
 import org.fossasia.phimpme.gallery.data.base.MediaDetailsMap;
 import org.fossasia.phimpme.gallery.util.AlertDialogsHelper;
-import org.fossasia.phimpme.gallery.util.BlurImageUtil;
 import org.fossasia.phimpme.gallery.util.ColorPalette;
 import org.fossasia.phimpme.gallery.util.ContentHelper;
 import org.fossasia.phimpme.gallery.util.Measure;
@@ -135,6 +133,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
     public static String pathForDescription;
     public Boolean allPhotoMode;
     public Boolean favphotomode;
+    public Boolean upoadhis;
     public int all_photo_pos;
     public int size_all;
     public int current_image_pos;
@@ -147,6 +146,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
     boolean slideshow=false;
     private boolean details=false;
     private ArrayList<Media> favouriteslist;
+    private ArrayList<Media> uploadhistory;
 
     ImageDescModel temp;
     private final int REQ_CODE_SPEECH_INPUT = 100;
@@ -250,11 +250,15 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
         SP = PreferenceUtil.getInstance(getApplicationContext());
         securityObj = new SecurityHelper(SingleMediaActivity.this);
         favphotomode = getIntent().getBooleanExtra("fav_photos", false);
+        upoadhis = getIntent().getBooleanExtra("uploadhistory", false);
         allPhotoMode = getIntent().getBooleanExtra(getString(R.string.all_photo_mode), false);
         all_photo_pos = getIntent().getIntExtra(getString(R.string.position), 0);
         size_all = getIntent().getIntExtra(getString(R.string.allMediaSize), getAlbum().getCount());
         if(getIntent().hasExtra("favouriteslist")){
             favouriteslist = getIntent().getParcelableArrayListExtra("favouriteslist");
+        }
+        if(getIntent().hasExtra("datalist")){
+            uploadhistory = getIntent().getParcelableArrayListExtra("datalist");
         }
 
         String path2 = getIntent().getStringExtra("path");
@@ -341,9 +345,10 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
             }
         };
 
-        if (!allPhotoMode && !favphotomode) {
+        if (!allPhotoMode && !favphotomode && !upoadhis) {
             adapter = new ImageAdapter(getAlbum().getMedia(), basicCallBack, this, this);
-            getSupportActionBar().setTitle((getAlbum().getCurrentMediaIndex() + 1) + " " + getString(R.string.of) + " " + getAlbum().getMedia().size());
+            getSupportActionBar().setTitle((getAlbum().getCurrentMediaIndex() + 1) + " " + getString(R.string.of) + " " + getAlbum()
+                    .getMedia().size());
 //            toolbar.setTitle((mViewPager.getCurrentItem() + 1) + " " + getString(R.string.of) + " " + getAlbum().getMedia().size());
             mViewPager.setOnPageChangeListener(new PagerRecyclerView.OnPageChangeListener() {
                 @Override
@@ -355,7 +360,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 }
             });
             mViewPager.scrollToPosition(getAlbum().getCurrentMediaIndex());
-        } else if(allPhotoMode && !favphotomode){
+        } else if(allPhotoMode && !favphotomode && !upoadhis){
             adapter = new ImageAdapter(LFMainActivity.listAll, basicCallBack, this, this);
             getSupportActionBar().setTitle(all_photo_pos + 1 + " " + getString(R.string.of) + " " + size_all);
             current_image_pos = all_photo_pos;
@@ -370,7 +375,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 }
             });
             mViewPager.scrollToPosition(all_photo_pos);
-        } else if(!allPhotoMode && favphotomode){
+        } else if(!allPhotoMode && favphotomode && !upoadhis){
             adapter = new ImageAdapter(favouriteslist, basicCallBack, this, this);
             getSupportActionBar().setTitle(all_photo_pos + 1 + " " + getString(R.string.of) + " " + size_all);
             current_image_pos = all_photo_pos;
@@ -382,6 +387,21 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                     toolbar.setTitle((position + 1) + " " + getString(R.string.of) + " " + size_all);
                     invalidateOptionsMenu();
                     pathForDescription = favouriteslist.get(position).getPath();
+                }
+            });
+            mViewPager.scrollToPosition(all_photo_pos);
+        }else if(!favphotomode && !allPhotoMode && upoadhis){
+            adapter = new ImageAdapter(uploadhistory, basicCallBack, this, this);
+            getSupportActionBar().setTitle(all_photo_pos + 1 + " " + getString(R.string.of) + " " + size_all);
+            current_image_pos = all_photo_pos;
+            mViewPager.setOnPageChangeListener(new PagerRecyclerView.OnPageChangeListener() {
+                @Override
+                public void onPageChanged(int oldPosition, int position) {
+                    current_image_pos = position;
+                    getAlbum().setCurrentPhotoIndex(getAlbum().getCurrentMediaIndex());
+                    toolbar.setTitle((position + 1) + " " + getString(R.string.of) + " " + size_all);
+                    invalidateOptionsMenu();
+                    pathForDescription = uploadhistory.get(position).getPath();
                 }
             });
             mViewPager.scrollToPosition(all_photo_pos);
@@ -515,12 +535,20 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
         if(allPhotoMode || favphotomode){
             menu.findItem(R.id.action_cover).setVisible(false);
         }
-        if (!allPhotoMode && !favphotomode){
+        if (!allPhotoMode && !favphotomode && !upoadhis){
             menu.setGroupVisible(R.id.only_photos_options, true);
         }
-        else if(!allPhotoMode && favphotomode){
+        else if(!allPhotoMode && favphotomode && !upoadhis){
+            menu.findItem(R.id.action_favourites).setVisible(false);
             menu.findItem(R.id.action_copy).setVisible(false);
             menu.findItem(R.id.action_move).setVisible(false);
+        } else if(!allPhotoMode && !favphotomode && upoadhis){
+            menu.findItem(R.id.action_copy).setVisible(false);
+            menu.findItem(R.id.action_move).setVisible(false);
+            menu.findItem(R.id.slide_show).setVisible(false);
+            menu.findItem(R.id.action_use_as).setVisible(false);
+            menu.findItem(R.id.action_cover).setVisible(false);
+            menu.findItem(R.id.action_description).setVisible(false);
         }
 
         if (customUri) {
@@ -837,7 +865,6 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                                     else{
                                         passco[0]=false;
                                     }
-
                                 }
                             });
                             passwordDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
@@ -916,12 +943,14 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 details=true;
                 final View v = findViewById(R.id.layout_image_description);
                 LinearLayout linearLayout = (LinearLayout)v;
-                if(!allPhotoMode && !favphotomode){
+                if(!allPhotoMode && !favphotomode && !upoadhis){
                     media = getAlbum().getCurrentMedia();
-                }else if(allPhotoMode && !favphotomode){
+                }else if(allPhotoMode && !favphotomode && !upoadhis){
                     media = new Media(new File(listAll.get(current_image_pos).getPath()));
-                }else if(!allPhotoMode && favphotomode){
+                }else if(!allPhotoMode && favphotomode && !upoadhis){
                     media = new Media(new File(favouriteslist.get(current_image_pos).getPath()));
+                }else if(!favphotomode && !allPhotoMode && upoadhis){
+                    media = new Media(new File(uploadhistory.get(current_image_pos).getPath()));
                 }
                 final MediaDetailsMap<String,String> mediaDetailsMap = media.getMainDetails(this);
                 LinearLayout linearLayout1 = (LinearLayout) findViewById(R.id.image_desc_top);

--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistoryAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistoryAdapter.java
@@ -42,7 +42,8 @@ public class UploadHistoryAdapter extends RecyclerView.Adapter<UploadHistoryAdap
     private Realm realm = Realm.getDefaultInstance();
     private RealmQuery<UploadHistoryRealmModel> realmResult = realm.where(UploadHistoryRealmModel.class);
     private int color;
-    public static String imagePath;
+    private View.OnClickListener onClickListener;
+    public String imagePath;
 
     public UploadHistoryAdapter(int color) {
         this.color=color;
@@ -54,6 +55,7 @@ public class UploadHistoryAdapter extends RecyclerView.Adapter<UploadHistoryAdap
                 .inflate(R.layout.upload_history_item_view, null, false);
         view.setLayoutParams(new RecyclerView.LayoutParams(RecyclerView.LayoutParams.MATCH_PARENT,
                 RecyclerView.LayoutParams.WRAP_CONTENT));
+        view.setOnClickListener(onClickListener);
         return new ViewHolder(view);
     }
 
@@ -61,11 +63,10 @@ public class UploadHistoryAdapter extends RecyclerView.Adapter<UploadHistoryAdap
     public void onBindViewHolder(ViewHolder holder, int position) {
         Integer id;
         realmResult = realm.where(UploadHistoryRealmModel.class);
-
         if (realmResult.findAll().size() != 0) {
-
-            String date = realmResult.findAll().get(position).getDatetime();
-            String name=realmResult.findAll().get(position).getName();
+            UploadHistoryRealmModel uploadHistoryRealmModel = realmResult.findAll().get(position);
+            String date = uploadHistoryRealmModel.getDatetime();
+            String name=uploadHistoryRealmModel.getName();
             try {
                 DateFormat format = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss");
                 Date parsedDate = format.parse(date);
@@ -77,8 +78,9 @@ public class UploadHistoryAdapter extends RecyclerView.Adapter<UploadHistoryAdap
                 e.printStackTrace();
             }
 
-            Uri uri = Uri.fromFile(new File(realmResult.findAll().get(position).getPathname()));
-            imagePath = uri.getPath();
+            Uri uri = Uri.fromFile(new File(uploadHistoryRealmModel.getPathname()));
+            imagePath = uploadHistoryRealmModel.getPathname();
+            holder.uploadTime.setTag(uploadHistoryRealmModel);
 
             Glide.with(getApplicationContext()).load(uri)
                     .diskCacheStrategy(DiskCacheStrategy.ALL)
@@ -108,7 +110,11 @@ public class UploadHistoryAdapter extends RecyclerView.Adapter<UploadHistoryAdap
         notifyDataSetChanged();
     }
 
-    public static class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
+    public void setOnClickListener(View.OnClickListener lis) {
+        onClickListener = lis;
+    }
+
+    public static class ViewHolder extends RecyclerView.ViewHolder {
 
         @BindView(R.id.upload_time)
         TextView uploadTime;
@@ -125,22 +131,6 @@ public class UploadHistoryAdapter extends RecyclerView.Adapter<UploadHistoryAdap
         public ViewHolder(View itemView) {
             super(itemView);
             ButterKnife.bind(this, itemView);
-            uploadImage.setOnClickListener(this);
-        }
-
-        @Override
-        public void onClick(View v) {
-            if(v.getId() == uploadImage.getId()){
-                if(new File(imagePath).exists()){
-                    Intent intent = new Intent(context, SingleMediaActivity.class);
-                    intent.setAction("com.android.camera.action.REVIEW");
-                    intent.putExtra("path",Uri.fromFile(new File(imagePath)));
-                    context.startActivity(intent);
-                }
-                else{
-                    SnackBarHandler.show(v, "No Media Availaible",SnackBarHandler.SHORT);
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
…ration, Slide to other images enabled.

Fix #1896 

Changes: Proper images are displayed via the SingleMediaActivity on performing click operation on the images present in the upload history section, Slide to other images are enabled i.e users will be able to move to other images in the upload history by sliding.
Gif before change:
![videotogif_2018 05 19_21 57 56](https://user-images.githubusercontent.com/20841578/40270726-f33d1e70-5baf-11e8-8319-50ca4f76f81e.gif)

GIF after change:
![videotogif_2018 05 19_21 42 52](https://user-images.githubusercontent.com/20841578/40270740-2d9d261e-5bb0-11e8-981d-8b298173570f.gif)

