### PR TITLE
Fix #1877 - Add pencil sketch filter in edit mode.

### DIFF
--- a/app/src/main/jni/filters.cpp
+++ b/app/src/main/jni/filters.cpp
@@ -586,4 +586,10 @@ void applyCartoon(cv::Mat &src, cv::Mat &dst, int val) {
     src.copyTo(dst, mask);
 }
 
+void applyPencilSketch(cv::Mat &src, cv::Mat &dst, int val) {
+    cvtColor(src, src, COLOR_BGRA2GRAY);
+    dst = Mat::zeros(src.size(), src.type());
+    adaptiveThreshold(src, dst, 255, CV_ADAPTIVE_THRESH_MEAN_C, CV_THRESH_BINARY, 9, 2);
+}
+
 }

--- a/app/src/main/jni/filters.h
+++ b/app/src/main/jni/filters.h
@@ -127,5 +127,6 @@ void applyBlueBoostEffect(cv::Mat &src, cv::Mat &dst, int val);
 void applyCyanise(cv::Mat &src, cv::Mat &dst, int val);
 void applyFade(cv::Mat &src, cv::Mat &dst, int val);
 void applyCartoon(cv::Mat &src, cv::Mat &dst, int val);
+void applyPencilSketch(cv::Mat &src, cv::Mat &dst, int val);
 
 }

--- a/app/src/main/jni/main_processing.cpp
+++ b/app/src/main/jni/main_processing.cpp
@@ -79,7 +79,9 @@ extern "C" {
             case 19:
                 applyCartoon(src, dst, val);
                 break;
-
+            case 20:
+                applyPencilSketch(src, dst, val);
+                break;
             default:
 
                 int lowThreshold = val;

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -684,7 +684,8 @@
         <item>Cyanisation</item>
         <item>Fade</item>
         <item>Cartoonify</item>
-  </string-array>
+        <item>Pencil Sketch</item>
+    </string-array>
 
     <integer-array name="enhance_icons">
         <item>@drawable/ic_bright</item>


### PR DESCRIPTION
Fixed #1877 

Changes: Added a pencil sketch filter in edit mode. Made required changes in cpp files.
Screenshots of the change: 
![image](https://user-images.githubusercontent.com/22395998/36744802-bf751d9e-1c13-11e8-8cef-9679892921e6.png)

After filter :
![image](https://user-images.githubusercontent.com/22395998/36744825-ce1351f4-1c13-11e8-843f-47d85b75dd74.png)
