### PR TITLE
Fix #1659-Appropriate message is displayed if search results are null.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -216,6 +216,8 @@ public class LFMainActivity extends SharedMediaActivity {
     protected View toolbari;
     @BindView(R.id.nothing_to_show)
     protected TextView nothingToShow;
+    @BindView(R.id.no_search_results)
+    protected TextView textView;
     @BindView(R.id.Drawer_Default_Icon)
     protected IconicsImageView defaultIcon;
     @BindView(R.id.Drawer_hidden_Icon)
@@ -741,6 +743,9 @@ public class LFMainActivity extends SharedMediaActivity {
             public boolean onNavigationItemSelected(@NonNull MenuItem item) {
                 int itemID = item.getItemId();
                 if (itemID == R.id.navigation_home) {
+                    if(textView.getVisibility() == View.VISIBLE){
+                        textView.setVisibility(View.GONE);
+                    }
                     if (!localFolder) {
                         hidden = false;
                         localFolder = true;
@@ -1577,6 +1582,12 @@ public class LFMainActivity extends SharedMediaActivity {
             starImageView.setColorFilter(ContextCompat.getColor(this, R.color.black), PorterDuff.Mode.SRC_ATOP);
     }
 
+    private void checkNoSearchResults(String result){
+        textView.setText(getString(R.string.null_search_result) + " " + '"' + result + '"' );
+        textView.setTextColor(getTextColor());
+        textView.setVisibility(View.VISIBLE);
+    }
+
     //region MENU
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
@@ -1676,6 +1687,14 @@ public class LFMainActivity extends SharedMediaActivity {
                 String name = album.getName().toLowerCase();
                 if (name.contains(queryText)) {
                     newList.add(album);
+                }
+            }
+            if(newList.isEmpty()){
+                checkNoSearchResults(newText);
+            }
+            else{
+                if(textView.getVisibility() == View.VISIBLE){
+                    textView.setVisibility(View.INVISIBLE);
                 }
             }
             albumsAdapter.swapDataSet(newList);

--- a/app/src/main/res/layout/activity_leafpic.xml
+++ b/app/src/main/res/layout/activity_leafpic.xml
@@ -64,6 +64,14 @@
                             android:scrollbarThumbVertical="@drawable/ic_scrollbar"
                             android:scrollbars="vertical" />
 
+                        <TextView android:layout_width="match_parent"
+                                  android:layout_height="wrap_content"
+                                  android:id="@+id/no_search_results"
+                                  android:gravity="center_horizontal"
+                                  android:textSize="18sp"
+                                  android:layout_marginTop="150dp"
+                                  android:visibility="invisible"/>
+
                         <TextView
                             android:id="@+id/nothing_to_show"
                             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -577,6 +577,7 @@
     <!-- RANDOM -->
     <string name="done">Done!</string>
     <string name="there_is_nothing_to_show">There\'s nothing to show!</string>
+    <string name="null_search_result">No search result found for</string>
     <string name="insert_a_name">Insert something</string>
     <string name="nothing_changed">Nothing changed!</string>
     <string name="install_shortcut">Install shortcut</string>


### PR DESCRIPTION
Fixed #1659 
Changes: Appropriate message is displayed if the results are null on performing the search folder operation.
