### PR TITLE
Fix #1938 - sticker size not accurate

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
@@ -219,7 +219,7 @@ public class StickersFragment extends BaseEditFragment implements View.OnClickLi
                 holder.itemView.setTag(path);
                 holder.title.setText("");
 
-            int size = (int) getActivity().getResources().getDimension(R.dimen.icon_item_image_size_filter_preview);
+            int size = (int) getActivity().getResources().getDimension(R.dimen.icon_item_image_size_sticker);
             LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(size,size);
             holder.icon.setLayoutParams(layoutParams);
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -71,6 +71,7 @@
     <dimen name="icon_item_image_size_main">30dp</dimen>
     <dimen name="icon_item_image_size_recycler">30dp</dimen>
     <dimen name="icon_item_image_size_filter_preview">130dp</dimen>
+    <dimen name="icon_item_image_size_sticker">50dp</dimen>
     <dimen name="icon_item_image_size_top">30dp</dimen>
     <dimen name="icon_item_image_size">30dp</dimen>
     <dimen name="icon_item_title_size">12sp</dimen>


### PR DESCRIPTION
Fixed #1938 

Screenshots for the change: 
![screenshot_20180307-151448](https://user-images.githubusercontent.com/16614355/37085815-0a0223ee-221c-11e8-8efa-e0be8aa40e49.png)
![screenshot_20180307-151452](https://user-images.githubusercontent.com/16614355/37085818-0bf81870-221c-11e8-90ed-9bdb1caa8c56.png)
