### PR TITLE
Fix #1944-Long press operation issue fixed, modified unfavourite func…

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1760,7 +1760,7 @@ public class LFMainActivity extends SharedMediaActivity {
             visible = false;
         menu.findItem(R.id.action_copy).setVisible(visible);
         menu.findItem(R.id.action_move).setVisible((visible || editMode) && !fav_photos);
-        menu.findItem(R.id.unfavourite_image).setVisible((!albumsMode) && (editMode || visible));
+        menu.findItem(R.id.unfavourite_image).setVisible((!albumsMode) && (editMode || visible) && (fav_photos));
         menu.findItem(R.id.action_add_favourites).setVisible((visible || editMode) && (!albumsMode && !fav_photos));
         menu.findItem(R.id.excludeAlbumButton).setVisible(editMode && !all_photos && albumsMode && !fav_photos);
         menu.findItem(R.id.zipAlbumButton).setVisible(editMode && !all_photos && albumsMode && !fav_photos && !hidden &&
@@ -1975,7 +1975,7 @@ public class LFMainActivity extends SharedMediaActivity {
                                 }
                             });
                         }
-                       return true;
+                        return true;
                     }
 
                     @Override
@@ -2004,7 +2004,24 @@ public class LFMainActivity extends SharedMediaActivity {
                         }
                     }
                 }
-                new UnfavouritePhotos().execute();
+
+                final AlertDialog.Builder deletefavDialog = new AlertDialog.Builder(LFMainActivity.this,
+                        getDialogStyle());
+
+                AlertDialogsHelper.getTextDialog(LFMainActivity.this, deletefavDialog,
+                        R.string.remove_from_favourites, R.string.remove_favourites_body, null);
+                deletefavDialog.setNegativeButton(this.getString(R.string.cancel).toUpperCase(), null);
+                deletefavDialog.setPositiveButton(this.getString(R.string.remove).toUpperCase(),
+                        new DialogInterface.OnClickListener() {
+                            @Override public void onClick(DialogInterface dialogInterface, int i) {
+                                dialogInterface.dismiss();
+                                new UnfavouritePhotos().execute();
+                            }
+                        });
+                AlertDialog alertDialog1 = deletefavDialog.create();
+                alertDialog1.show();
+                AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface
+                        .BUTTON_NEGATIVE}, getAccentColor(), alertDialog1);
                 return true;
 
             case R.id.delete_action:

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -790,14 +790,20 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 break;
 
             case R.id.action_delete:
+                String ButtonDelete = "";
                 handler.removeCallbacks(slideShowRunnable);
                 final AlertDialog.Builder deleteDialog = new AlertDialog.Builder(SingleMediaActivity.this, getDialogStyle());
-
-                AlertDialogsHelper.getTextDialog(SingleMediaActivity.this, deleteDialog,
-                        R.string.delete, R.string.delete_photo_message, null);
-
+                if(favphotomode){
+                    AlertDialogsHelper.getTextDialog(SingleMediaActivity.this, deleteDialog,
+                            R.string.remove_from_favourites, R.string.delete_from_favourites_message, null);
+                    ButtonDelete = this.getString(R.string.remove);
+                }else {
+                    AlertDialogsHelper.getTextDialog(SingleMediaActivity.this, deleteDialog,
+                            R.string.delete, R.string.delete_photo_message, null);
+                    ButtonDelete = this.getString(R.string.delete);
+                }
                 deleteDialog.setNegativeButton(this.getString(R.string.cancel).toUpperCase(), null);
-                deleteDialog.setPositiveButton(this.getString(R.string.delete).toUpperCase(), new DialogInterface.OnClickListener() {
+                deleteDialog.setPositiveButton(ButtonDelete.toUpperCase(), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         if (securityObj.isActiveSecurity() && securityObj.isPasswordOnDelete()) {
                             final boolean passco[] = {false};

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -520,6 +520,7 @@
     <string name="delete_album_message">Are you sure you want to delete this album?</string>
     <string name="delete_albums_message">Are you sure you want to delete the selected albums?</string>
     <string name="delete_photo_message">Are you sure you want to delete this media?</string>
+    <string name="delete_from_favourites_message">Are you sure you want to remove this media from Favourites?</string>
     <string name="delete_photos_message">Are you sure you want to delete the selected media?</string>
     <string name="hide_albums_message">Are you sure you want to hide the selected albums?</string>
     <string name="unhide_album_message">Un-hiding this album you will also make the media available for other apps.</string>
@@ -1165,5 +1166,5 @@
 
     <string name="remove">Remove</string>
     <string name="remove_from_favourites">Remove From Favourites</string>
-    <string name="remove_favourites_body">Are you sure you want to remove the selected media from the favourites folder? This will not delete the photos.</string>
+    <string name="remove_favourites_body">Are you sure you want to remove the selected media from the favourites folder? </string>
 </resources>


### PR DESCRIPTION
…tionality.

Fixed #1944 
Changes: Unfavourite option is now only visible in the favourites mode. Previously both add to favourites and Unfavourite option were visible on performing the long press operation, which was somewhat confusing so I guess it's better to limit the Unfavourite option to favourites section only(the user can navigate to the Fav section and perform the remove operation). Added a dialog to confirm the Unfavourite operation in the favourites section(this was there before Unfavourite option was implemented). Also modified the message displayed in the dialog to remove photos from favourites via the SingleMediaActivity.
