### PR TITLE
Fix #1926 - Toolbar doesn't overlap with the image

### DIFF
--- a/app/src/main/res/layout/activity_share.xml
+++ b/app/src/main/res/layout/activity_share.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -20,6 +19,10 @@
         android:id="@+id/share_image"
         android:layout_below="@+id/toolbar"
         android:layout_weight="10"
+        android:layout_marginBottom="10dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginLeft="10dp"
+        android:layout_marginRight="10dp"
         android:layout_alignParentStart="true"
         android:scaleType="centerCrop"/>
 


### PR DESCRIPTION
Fixed #1926

Changes: Added margin on top,bottom,right and left of the image to make the UI look better.

Screenshots of the change: 

![change](https://user-images.githubusercontent.com/24502136/37456606-c93a21f4-2865-11e8-9632-fae6b2721ebd.png)

