### PR TITLE
Fix #1921 - Add a cartoon filter.

### DIFF
--- a/app/src/main/jni/filters.cpp
+++ b/app/src/main/jni/filters.cpp
@@ -551,5 +551,39 @@ void applyFade(cv::Mat &src, cv::Mat &dst, int val){
         }
     }
 }
-    
+
+void applyCartoon(cv::Mat &src, cv::Mat &dst, int val) {
+    double opacity = val / 100.0;
+    Mat srcGray;
+    cvtColor(src, src, CV_BGRA2BGR);
+    cvtColor(src, srcGray, CV_BGR2GRAY);
+
+    medianBlur(srcGray, srcGray, 7);
+    Size size = src.size();
+    Mat mask = Mat(size, CV_8U);
+    Mat edges = Mat(size, CV_8U);
+    Laplacian(srcGray, edges, CV_8U, 5);
+    threshold(edges, mask, 80, (int) 255 * opacity, CV_THRESH_BINARY_INV);
+
+    Size smallSize;
+    smallSize.width = size.width / 4;
+    smallSize.height = size.height / 4;
+    Mat smallImg = Mat(smallSize, CV_8UC3);
+    resize(src, smallImg, smallSize, 0, 0, CV_INTER_LINEAR);
+
+    Mat tmp = Mat(smallSize, CV_8UC3);
+    int repetitions = 7;
+    for (int i = 0; i < repetitions; i++) {
+        int sizeInt = 9;
+        double sigmaColor = 9;
+        double sigmaSpace = 7;
+        bilateralFilter(smallImg, tmp, sizeInt, sigmaColor, sigmaSpace);
+        bilateralFilter(tmp, smallImg, sizeInt, sigmaColor, sigmaSpace);
+    }
+
+    resize(smallImg, src, size, 0, 0, CV_INTER_LINEAR);
+    dst = Mat::zeros(src.size(), src.type());
+    src.copyTo(dst, mask);
+}
+
 }

--- a/app/src/main/jni/filters.h
+++ b/app/src/main/jni/filters.h
@@ -126,5 +126,6 @@ void applyColorBoostEffect(cv::Mat &src, cv::Mat &dst, int val);
 void applyBlueBoostEffect(cv::Mat &src, cv::Mat &dst, int val);
 void applyCyanise(cv::Mat &src, cv::Mat &dst, int val);
 void applyFade(cv::Mat &src, cv::Mat &dst, int val);
+void applyCartoon(cv::Mat &src, cv::Mat &dst, int val);
 
 }

--- a/app/src/main/jni/main_processing.cpp
+++ b/app/src/main/jni/main_processing.cpp
@@ -76,6 +76,9 @@ extern "C" {
             case 18:
                 applyFade(src,dst,val);
                 break;
+            case 19:
+                applyCartoon(src, dst, val);
+                break;
 
             default:
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -683,6 +683,7 @@
         <item>Colour Enhance</item>
         <item>Cyanisation</item>
         <item>Fade</item>
+        <item>Cartoonify</item>
   </string-array>
 
     <integer-array name="enhance_icons">


### PR DESCRIPTION
Fixed #1921 
Changes: Added a cartoonify filter option

Screenshots of the change: 
Original 
![image](https://user-images.githubusercontent.com/22395998/38014229-9ea03a94-3285-11e8-9823-5ed2f3ceffb8.png)

After filter:
![image](https://user-images.githubusercontent.com/22395998/38014236-a66b476e-3285-11e8-97f8-168d9302b089.png)
