### PR TITLE
Fix #1901-Edit Functionality material design close icon issue fixed.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/SliderFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/SliderFragment.java
@@ -47,7 +47,7 @@ public class SliderFragment extends BaseEditFragment implements View.OnClickList
         apply = (ImageButton) fragmentView.findViewById(R.id.seekbar_apply);
         seekBar = (SeekBar) fragmentView.findViewById(R.id.slider);
 
-        cancel.setImageResource(R.drawable.ic_no);
+        cancel.setImageResource(R.drawable.ic_close_black_24dp);
         apply.setImageResource(R.drawable.ic_done_black_24dp);
 
         cancel.setOnClickListener(this);

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
@@ -76,7 +76,7 @@ public class StickersFragment extends BaseEditFragment implements View.OnClickLi
         cancel = (ImageButton)fragmentView.findViewById(R.id.sticker_cancel);
         apply = (ImageButton)fragmentView.findViewById(R.id.sticker_apply);
 
-        cancel.setImageResource(R.drawable.ic_no);
+        cancel.setImageResource(R.drawable.ic_close_black_24dp);
         apply.setImageResource(R.drawable.ic_done_black_24dp);
 
         cancel.setOnClickListener(this);

--- a/app/src/main/res/drawable/ic_close_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_close_black_24dp.xml
@@ -1,9 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="48dp"
-    android:height="48dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0">
+        android:width="48dp"
+        android:height="48dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
     <path
         android:fillColor="#FF000000"
-        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z" />
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
 </vector>

--- a/app/src/main/res/layout-land/fragment_edit_image_add_text.xml
+++ b/app/src/main/res/layout-land/fragment_edit_image_add_text.xml
@@ -12,7 +12,7 @@
         android:layout_marginLeft="5dp"
         android:layout_marginRight="5dp"
         android:background="?android:attr/selectableItemBackground"
-        app:srcCompat="@drawable/ic_no"/>
+        app:srcCompat="@drawable/ic_close_black_24dp"/>
 
     <EditText
         android:id="@+id/text_input"

--- a/app/src/main/res/layout-land/fragment_edit_image_crop.xml
+++ b/app/src/main/res/layout-land/fragment_edit_image_crop.xml
@@ -15,7 +15,7 @@
         android:layout_alignBottom="@+id/crop_hsv"
         android:layout_alignParentLeft="true"
         android:background="?android:attr/selectableItemBackground"
-        app:srcCompat="@drawable/ic_no" />
+        app:srcCompat="@drawable/ic_close_black_24dp" />
 
     <LinearLayout
         android:layout_width="@dimen/editor_bottom_row_size"

--- a/app/src/main/res/layout-land/fragment_edit_image_rotate.xml
+++ b/app/src/main/res/layout-land/fragment_edit_image_rotate.xml
@@ -18,7 +18,7 @@
         android:layout_weight="1"
         android:background="?android:attr/selectableItemBackground"
         android:scaleType="fitCenter"
-        app:srcCompat="@drawable/ic_no" />
+        app:srcCompat="@drawable/ic_close_black_24dp" />
 
     <LinearLayout
         android:layout_width="60dp"

--- a/app/src/main/res/layout-land/fragment_edit_paint.xml
+++ b/app/src/main/res/layout-land/fragment_edit_paint.xml
@@ -13,7 +13,7 @@
         android:background="?android:attr/selectableItemBackground"
         android:layout_centerVertical="true"
         android:layout_gravity="center"
-        app:srcCompat="@drawable/ic_no"/>
+        app:srcCompat="@drawable/ic_close_black_24dp"/>
 
     <org.fossasia.phimpme.editor.view.PaintModeView
         android:id="@+id/paint_thumb"

--- a/app/src/main/res/layout/fragment_edit_image_add_text.xml
+++ b/app/src/main/res/layout/fragment_edit_image_add_text.xml
@@ -13,7 +13,7 @@
         android:layout_marginRight="5dp"
         android:background="?android:attr/selectableItemBackground"
         android:scaleType="fitCenter"
-        app:srcCompat="@drawable/ic_no" />
+        app:srcCompat="@drawable/ic_close_black_24dp" />
 
     <EditText
         android:id="@+id/text_input"

--- a/app/src/main/res/layout/fragment_edit_image_crop.xml
+++ b/app/src/main/res/layout/fragment_edit_image_crop.xml
@@ -14,7 +14,7 @@
         android:layout_alignBottom="@+id/crop_hsv"
         android:layout_alignParentLeft="true"
         android:background="?android:attr/selectableItemBackground"
-        app:srcCompat="@drawable/ic_no" />
+        app:srcCompat="@drawable/ic_close_black_24dp" />
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_edit_image_rotate.xml
+++ b/app/src/main/res/layout/fragment_edit_image_rotate.xml
@@ -18,7 +18,7 @@
         android:layout_weight="1"
         android:background="?android:attr/selectableItemBackground"
         android:scaleType="fitCenter"
-        app:srcCompat="@drawable/ic_no" />
+        app:srcCompat="@drawable/ic_close_black_24dp" />
 
     <LinearLayout
         android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_edit_paint.xml
+++ b/app/src/main/res/layout/fragment_edit_paint.xml
@@ -16,7 +16,7 @@
         android:layout_marginRight="5dp"
         android:layout_alignParentStart="true"
         android:layout_alignParentLeft="true"
-        app:srcCompat="@drawable/ic_no"/>
+        app:srcCompat="@drawable/ic_close_black_24dp"/>
 
     <org.fossasia.phimpme.editor.view.PaintModeView
         android:id="@+id/paint_thumb"

--- a/app/src/main/res/layout/fragment_editor_slider.xml
+++ b/app/src/main/res/layout/fragment_editor_slider.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
-              android:layout_height="@dimen/editor_bottom_row_size"
-    >
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/editor_bottom_row_size"
+                xmlns:app="http://schemas.android.com/apk/res-auto"
+>
     <ImageButton
         android:id="@+id/seekbar_cancel"
         android:layout_width="@dimen/icon_item_image_size"
-        android:layout_height="@dimen/icon_item_image_size"
+        android:layout_height="@dimen/editor_bottom_row_size"
         android:scaleType="fitCenter"
         android:background="?android:attr/selectableItemBackground"
         android:layout_centerVertical="true"
         android:layout_alignParentStart="true"
-        android:layout_margin="5dp"
-        android:layout_alignParentLeft="true"
-        />
+        android:layout_marginLeft="5dp"
+        android:layout_marginRight="5dp"
+        android:layout_alignParentLeft="true"/>
 
     <SeekBar
         android:id="@+id/slider"
@@ -28,9 +29,10 @@
     <ImageButton
         android:id="@+id/seekbar_apply"
         android:layout_width="@dimen/icon_item_image_size"
-        android:layout_height="@dimen/icon_item_image_size"
+        android:layout_height="@dimen/editor_bottom_row_size"
         android:scaleType="fitCenter"
-        android:layout_margin="5dp"
+        android:layout_marginLeft="5dp"
+        android:layout_marginRight="5dp"
         android:layout_centerVertical="true"
         android:background="?android:attr/selectableItemBackground"
         android:layout_alignParentEnd="true"

--- a/app/src/main/res/layout/fragment_editor_stickers.xml
+++ b/app/src/main/res/layout/fragment_editor_stickers.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
+                android:layout_width="match_parent" xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:layout_gravity="center_vertical"
                 android:gravity="center_vertical"
-              android:layout_height="@dimen/editor_bottom_row_size">
+                android:layout_height="@dimen/editor_bottom_row_size">
 
     <ImageButton
         android:id="@+id/sticker_cancel"
@@ -15,8 +15,7 @@
         android:background="?android:attr/selectableItemBackground"
         android:layout_centerVertical="true"
         android:layout_alignParentStart="true"
-        android:layout_alignParentLeft="true"
-        />
+        android:layout_alignParentLeft="true"/>
 
     <android.support.v7.widget.RecyclerView
         android:layout_width="wrap_content"


### PR DESCRIPTION
Fixed #1901 

Changes: Material design icons used for both apply and cross, and both icons are set to same width and height.

Screenshot before the change:
![screenshot_20180524-122050](https://user-images.githubusercontent.com/20841578/40469289-a8178222-5f4d-11e8-8dab-67ec4f4660ec.png)
Screenshot after the change:
![screenshot_20180524-121627](https://user-images.githubusercontent.com/20841578/40469307-ba42fc88-5f4d-11e8-98a8-74704cf1e51b.png)
 
