### PR TITLE
Fix #1894-App crash fixed for deleting favourite marked images from a…

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/AboutActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/AboutActivity.java
@@ -42,11 +42,9 @@ public class AboutActivity extends ThemedActivity {
         super.onPostCreate(savedInstanceState);
         setContentView(R.layout.activity_about);
         toolbar = (Toolbar) findViewById(R.id.toolbar);
-
         setNavBarColor();
         cts = new CustomTabService(AboutActivity.this,getPrimaryColor());
         scr = (ScrollView)findViewById(R.id.aboutAct_scrollView);
-
     }
 
     @Override

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -827,6 +827,7 @@ public class LFMainActivity extends SharedMediaActivity {
 
     private void getfavouriteslist() {
         favouriteslist = new ArrayList<Media>();
+        ArrayList<String> todelete = new ArrayList<>();
         realm = Realm.getDefaultInstance();
         RealmQuery<FavouriteImagesModel> favouriteImagesModelRealmQuery = realm.where(FavouriteImagesModel.class);
         int count = Integer.parseInt(String.valueOf(favouriteImagesModelRealmQuery.count()));
@@ -835,15 +836,19 @@ public class LFMainActivity extends SharedMediaActivity {
             if (new File(favouriteImagesModelRealmQuery.findAll().get(i).getPath()).exists()) {
                 favouriteslist.add(new Media(new File(favouriteImagesModelRealmQuery.findAll().get(i).getPath())));
             } else {
-                realm.executeTransaction(new Realm.Transaction() {
-                    @Override
-                    public void execute(Realm realm) {
-                        RealmResults<FavouriteImagesModel> result = realm.where(FavouriteImagesModel.class).equalTo
-                                ("path", path).findAll();
-                        result.deleteAllFromRealm();
-                    }
-                });
+                todelete.add(path);
             }
+        }
+        for(int i = 0; i < todelete.size(); i++){
+            final String path = todelete.get(i);
+            realm.executeTransaction(new Realm.Transaction() {
+                @Override
+                public void execute(Realm realm) {
+                    RealmResults<FavouriteImagesModel> result = realm.where(FavouriteImagesModel.class).equalTo
+                            ("path", path).findAll();
+                    result.deleteAllFromRealm();
+                }
+            });
         }
     }
 
@@ -2603,7 +2608,6 @@ public class LFMainActivity extends SharedMediaActivity {
                 bottomSheetDialogFragment.setSelectAlbumInterface(new SelectAlbumBottomSheet.SelectAlbumInterface() {
                     @Override
                     public void folderSelected(String path) {
-
                         new CopyPhotos(path, false, true).execute();
                         bottomSheetDialogFragment.dismiss();
                     }


### PR DESCRIPTION
…lbums or all photos mode.

Fixed #1894 
Changes: The issue was in removing the path of the deleted image from the favorites table in the realm database, so added a new ArrayList to keep track of the images deleted from the phone storage while traversing through the image paths present in the favorites table and then removing the paths from the favorites table by traversing through the ArrayList(keeping track of all the fav marked photos that have been deleted permanently from the storage).

