### PR TITLE
Fix #2011 - Upload History image view issue fixed.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -312,6 +312,11 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
             bottomMenu.findItem(R.id.action_favourites).getIcon().setTint(getAccentColor());
         }
 
+        if(upoadhis){
+            bottomMenu.findItem(R.id.action_favourites).setVisible(false);
+            bottomMenu.findItem(R.id.action_edit).setVisible(false);
+        }
+
         if(!allPhotoMode && favphotomode)
             bottomBar.getMenu().getItem(4).setVisible(false);
 


### PR DESCRIPTION
Fixed #2011

Changes: Add to favorites and edit options for images in the upload history are not displayed anymore. 
Screenshots of the change: 
![screenshot_2018-05-31-11-28-39-181_org fossasia phimpme](https://user-images.githubusercontent.com/20841578/40764316-32bd46d2-64c6-11e8-990f-7c7f03ba6edb.png)
