### PR TITLE
Fix #2029-Made changes to provide box sharing feature only in devices…

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountAdapter.java
@@ -1,5 +1,6 @@
 package org.fossasia.phimpme.accounts;
 
+import android.os.Build;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.RecyclerView;
@@ -23,6 +24,8 @@ import static org.fossasia.phimpme.data.local.AccountDatabase.HIDEINACCOUNTS;
 import static org.fossasia.phimpme.utilities.ActivitySwitchHelper.context;
 import static org.fossasia.phimpme.utilities.ActivitySwitchHelper.getContext;
 
+import java.util.ArrayList;
+
 /**
  * Created by pa1pal on 7/7/17.
  */
@@ -33,10 +36,12 @@ public class AccountAdapter extends RecyclerView.Adapter<AccountAdapter.ViewHold
     public int switchAccentColor;
     public int switchBackgroundColor;
     private ThemeHelper themeHelper;
+    private ArrayList<String> databaseoptions = new ArrayList<>();
 
     public AccountAdapter() {
         themeHelper = new ThemeHelper(getContext());
         updateTheme();
+        getdatabaseAccounts();
         this.switchAccentColor = themeHelper.getAccentColor();
         this.switchBackgroundColor = themeHelper.getPrimaryColor();
     }
@@ -58,7 +63,7 @@ public class AccountAdapter extends RecyclerView.Adapter<AccountAdapter.ViewHold
     public void onBindViewHolder(ViewHolder holder, int position) {
         realmResult = realm.where(AccountDatabase.class);
        // themeHelper.updateSwitchColor(holder.signInSignOutSwitch, switchBackgroundColor);
-        String name = AccountDatabase.AccountName.values()[position].toString();
+        String name = databaseoptions.get(position);
         if (realmResult.equalTo("name", name).count() > 0){
             holder.accountName.setText(realmResult
                     .equalTo("name", name).findAll()
@@ -105,7 +110,20 @@ public class AccountAdapter extends RecyclerView.Adapter<AccountAdapter.ViewHold
          * whatsapp, Instagram , googleplus and others option is only required in the Sharing activity.
          */
         //return AccountDatabase.AccountName.values().length - HIDEINACCOUNTS;
-        return AccountDatabase.AccountName.values().length - HIDEINACCOUNTS;
+        return databaseoptions.size() - HIDEINACCOUNTS;
+    }
+
+    public void getdatabaseAccounts(){
+        for(int i = 0; i < AccountDatabase.AccountName.values().length; i++){
+            if(AccountDatabase.AccountName.values()[i].toString().equals("BOX")){
+                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
+                    databaseoptions.add(AccountDatabase.AccountName.values()[i].toString());
+                }
+            }
+            else{
+                databaseoptions.add(AccountDatabase.AccountName.values()[i].toString());
+            }
+        }
     }
 
     public void setResults(RealmQuery<AccountDatabase> results) {


### PR DESCRIPTION
… running version 5.0 and above.

Fixed #2029 

Changes: With Box removing support for TLS 1.0, TLS 1.1 will only be supported by Android versions 5.0 and above. Therefore I have made changes to enable the Box upload/share feature in the Accounts Sections only for devices running 5.0 and higher(so the app would still run on a device running on KitKat version but without the Box share feature).

