### PR TITLE
Fix #2055 - Removed compress option from UploadHistory.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -295,6 +295,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
         if(upoadhis){
             bottomMenu.findItem(R.id.action_favourites).setVisible(false);
             bottomMenu.findItem(R.id.action_edit).setVisible(false);
+            bottomMenu.findItem(R.id.action_compress).setVisible(false);
         }
 
         if(!allPhotoMode && favphotomode)


### PR DESCRIPTION
Fixed #2055 

Changes: Compress option not available when viewing upload history images.
