### PR TITLE
Fix #2062 - Details option visible and add to favourites option not v…

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -297,8 +297,10 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
             bottomMenu.findItem(R.id.action_edit).setVisible(false);
         }
 
-        if(!allPhotoMode && favphotomode)
-            bottomBar.getMenu().getItem(4).setVisible(false);
+        if(!allPhotoMode && favphotomode){
+            bottomBar.getMenu().getItem(5).setVisible(false);
+        }
+
         for (int i = 0; i < bottomMenu.size(); i++) {
             bottomMenu.getItem(i).setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
                 @Override


### PR DESCRIPTION
…isible in favorites.

Fixed #2062 

Changes: Changed the visibility of add to favorites option to false when viewing images from the favorites collection.

