### PR TITLE
Fix #2071-Fixed delete operation issue in Favourites section.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1795,7 +1795,11 @@ public class LFMainActivity extends SharedMediaActivity {
         menu.findItem(R.id.excludeAlbumButton).setVisible(editMode && !all_photos && albumsMode && !fav_photos);
         menu.findItem(R.id.zipAlbumButton).setVisible(editMode && !all_photos && albumsMode && !fav_photos && !hidden &&
                 getAlbums().getSelectedCount() == 1);
-        menu.findItem(R.id.delete_action).setVisible((!albumsMode || editMode) && (!all_photos || editMode) );
+        menu.findItem(R.id.delete_action).setVisible((!albumsMode || editMode) && (!all_photos || editMode));
+        if(fav_photos && favouriteslist.size() == 0 ){
+            menu.findItem(R.id.delete_action).setVisible(false);
+            menu.findItem(R.id.sort_action).setVisible(false);
+        }
         menu.findItem(R.id.hideAlbumButton).setVisible(!all_photos && !fav_photos && getAlbums().getSelectedCount() >
                 0);
 
@@ -2001,8 +2005,20 @@ public class LFMainActivity extends SharedMediaActivity {
                             }
                             // if not in selection mode, delete current album entirely
                             else if (!editMode) {
-                                succ = getAlbums().deleteAlbum(getAlbum(), getApplicationContext());
-                                getAlbum().getMedia().clear();
+                                if(!fav_photos){
+                                    succ = getAlbums().deleteAlbum(getAlbum(), getApplicationContext());
+                                    getAlbum().getMedia().clear();
+                                }else{
+                                    Realm realm = Realm.getDefaultInstance();
+                                    realm.executeTransaction(new Realm.Transaction() {
+                                        @Override public void execute(Realm realm) {
+                                            RealmQuery<FavouriteImagesModel> favouriteImagesModelRealmQuery = realm
+                                                    .where(FavouriteImagesModel.class);
+                                            succ = favouriteImagesModelRealmQuery.findAll().deleteAllFromRealm();
+                                            favouriteslist.clear();
+                                        }
+                                    });
+                                }
                             }
                         }
                         return succ;


### PR DESCRIPTION
Fixed #2071
Changes: On clicking the delete icon on the app bar in favorites section(non-edit mode), only photos from the fav collection are removed not the corresponding photo albums in the Local albums section.

