### PR TITLE
Fix #2092-App crash fix for twitter option in AccountsActivity.

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -34,6 +34,12 @@
 
 -dontwarn okio.**
 
+#Twitter
+
+-dontwarn twitter4j.**
+-keep  class twitter4j.conf.PropertyConfigurationFactory
+-keep class twitter4j.** { *; }
+
 #Butterknife
 
 # Retain generated class which implement Unbinder.


### PR DESCRIPTION
Fixed #2092 

Changes: Configured proguard file to keep the twitter4j classes when building the apk.
