### PR TITLE
Fix #1777-Choose folders to secure dialog issue resolved.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -42,6 +42,7 @@ import org.fossasia.phimpme.gallery.data.providers.MediaStoreProvider;
 import org.fossasia.phimpme.gallery.util.AlertDialogsHelper;
 import org.fossasia.phimpme.gallery.util.PreferenceUtil;
 import org.fossasia.phimpme.gallery.util.SecurityHelper;
+import org.fossasia.phimpme.gallery.util.ThemeHelper;
 import org.fossasia.phimpme.utilities.ActivitySwitchHelper;
 import org.fossasia.phimpme.utilities.SnackBarHandler;
 
@@ -127,6 +128,7 @@ public class SecurityActivity extends ThemedActivity {
                 if(isChecked) {
                     AlertDialog.Builder builder = new AlertDialog.Builder(SecurityActivity.this, getDialogStyle());
                     View view = getLayoutInflater().inflate(R.layout.dialog_security_folder, null);
+                    view.setBackgroundColor(getBackgroundColor());
                     TextView title = (TextView) view.findViewById(R.id.titlesecure);
                     LinearLayout linearLayout = (LinearLayout)view.findViewById(R.id.titlelayout);
                     linearLayout.setBackgroundColor(getAccentColor());
@@ -500,6 +502,7 @@ public class SecurityActivity extends ThemedActivity {
             holder.foldername.setTextColor(getTextColor());
             holder.foldercheckbox.setOnCheckedChangeListener(null);
             holder.foldercheckbox.setChecked(a.getsecured());
+            //holder.foldercheckbox.setButtonTintList();
             holder.foldercheckbox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                 @Override public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
                     if(b){
@@ -525,7 +528,15 @@ public class SecurityActivity extends ThemedActivity {
             public ViewHolder(View itemView) {
                 super(itemView);
                 foldername = (TextView) itemView.findViewById(R.id.foldername);
-                foldercheckbox = (CheckBox) itemView.findViewById(R.id.secure_folder_checkbox);
+                if (getBaseTheme() == ThemeHelper.LIGHT_THEME) {
+                    CheckBox checkBox = (CheckBox) itemView.findViewById(R.id.secure_folder_checkbox_black);
+                    checkBox.setVisibility(View.VISIBLE);
+                    foldercheckbox = (CheckBox) itemView.findViewById(R.id.secure_folder_checkbox_black);
+                } else if (getBaseTheme() == ThemeHelper.DARK_THEME || getBaseTheme() == ThemeHelper.AMOLED_THEME) {
+                    CheckBox checkBox = (CheckBox) itemView.findViewById(R.id.secure_folder_checkbox_white);
+                    checkBox.setVisibility(View.VISIBLE);
+                    foldercheckbox = (CheckBox) itemView.findViewById(R.id.secure_folder_checkbox_white);
+                }
             }
         }
     }

--- a/app/src/main/res/layout/dialog_security_folder.xml
+++ b/app/src/main/res/layout/dialog_security_folder.xml
@@ -5,43 +5,36 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent">
 
-  <android.support.v7.widget.CardView
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      app:cardCornerRadius="2dp"
-      android:id="@+id/folder_security_dialog_card">
+  <LinearLayout android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
 
     <LinearLayout android:layout_width="match_parent"
-                  android:layout_height="wrap_content"
-                  android:orientation="vertical">
+                  android:orientation="vertical"
+                  android:id="@+id/titlelayout"
+                  android:layout_height="wrap_content">
 
-      <LinearLayout android:layout_width="match_parent"
-                    android:orientation="vertical"
-                    android:id="@+id/titlelayout"
-                    android:layout_height="wrap_content">
-
-        <TextView android:layout_width="match_parent"
-                  android:layout_height="wrap_content"
-                  android:textSize="18dp"
-                  android:id="@+id/titlesecure"
-                  android:textStyle="bold"
-                  android:textColor="@color/accent_white"
-                  android:background="@color/accent_blue"
-                  android:text="Select folders to secure"
-                  android:layout_margin="20dp"/>
-
-      </LinearLayout>
-
-      <android.support.v7.widget.RecyclerView
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:scrollbars="vertical"
-          android:id="@+id/secure_folder_recyclerview">
-
-      </android.support.v7.widget.RecyclerView>
+      <TextView android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="18dp"
+                android:id="@+id/titlesecure"
+                android:textStyle="bold"
+                android:textColor="@color/accent_white"
+                android:background="@color/accent_blue"
+                android:text="Select folders to secure"
+                android:layout_margin="20dp"/>
 
     </LinearLayout>
 
-  </android.support.v7.widget.CardView>
+    <android.support.v7.widget.RecyclerView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:scrollbars="vertical"
+        android:id="@+id/secure_folder_recyclerview">
+
+    </android.support.v7.widget.RecyclerView>
+
+  </LinearLayout>
+
 
 </LinearLayout>

--- a/app/src/main/res/layout/secure_folder_dialog_item_view.xml
+++ b/app/src/main/res/layout/secure_folder_dialog_item_view.xml
@@ -2,44 +2,42 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
-    android:background="@color/accent_white"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <android.support.v7.widget.CardView
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/accent_white"
-        app:cardCornerRadius="2dp"
-        android:layout_marginLeft="3dp"
-        android:layout_marginTop="2dp"
-        android:layout_marginRight="3dp"
-        android:id="@+id/folder_security_dialog_card">
+        android:weightSum="1"
+        android:orientation="horizontal">
 
-        <LinearLayout
-            android:layout_width="match_parent"
+        <TextView
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:background="@color/accent_white"
-            android:weightSum="1"
-            android:orientation="horizontal">
+            android:layout_margin="5dp"
+            android:textSize="18dp"
+            android:text="lalalalala"
+            android:layout_weight="0.9"
+            android:textColor="@color/md_blue_grey_500"
+            android:id="@+id/foldername" />
 
-            <TextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_margin="5dp"
-                android:textSize="18dp"
-                android:layout_weight="0.9"
-                android:textColor="@color/md_blue_grey_500"
-                android:id="@+id/foldername" />
+        <CheckBox
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            android:layout_marginEnd="2dp"
+            android:layout_weight="0.1"
+            android:buttonTint="@color/accent_black"
+            android:id="@+id/secure_folder_checkbox_black"/>
 
-            <CheckBox
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="2dp"
-                android:layout_weight="0.1"
-                android:buttonTint="@color/accent_black"
-                android:id="@+id/secure_folder_checkbox"/>
+        <CheckBox
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="2dp"
+            android:visibility="gone"
+            android:layout_weight="0.1"
+            android:buttonTint="@color/accent_white"
+            android:id="@+id/secure_folder_checkbox_white"/>
 
-        </LinearLayout>
-    </android.support.v7.widget.CardView>
+    </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
Fixed #1777

Changes: Choose folders to secure dialog view items visible properly for darker themes.

Screenshots of the change: 
![screenshot_20180722-003833](https://user-images.githubusercontent.com/20841578/43039310-2cec241c-8d48-11e8-9be7-fb94b0845b78.jpeg)

