### PR TITLE
Fix #2113-Rename image feature dialog issue resolved.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -1080,7 +1080,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 editTextNewName.selectAll();
                 editTextNewName.setSingleLine(false);
                 AlertDialogsHelper.getInsertTextDialog(SingleMediaActivity.this, renameDialogBuilder,
-                        editTextNewName, R.string.rename_album, null);
+                        editTextNewName, R.string.rename_image, null);
                 renameDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
                 renameDialogBuilder.setPositiveButton(getString(R.string.ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
                     @Override
@@ -1152,11 +1152,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                             renameDialog.dismiss();
                             SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.rename_succes), navigationView
                                     .getHeight());
-                        } else {
-                            SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.insert_something),
-                                    navigationView.getHeight());
-                            editTextNewName.requestFocus();
-                        }
+                        } 
                     }
                 });
                 return true;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -602,6 +602,7 @@
     <string name="fix_date">Fix date</string>
     <string name="rename">Rename</string>
     <string name="rename_album">Rename album</string>
+    <string name="rename_image">Rename Image</string>
     <string name="album_not_found">Album not found</string>
     <string name="details">Details</string>
     <string name="more">More</string>


### PR DESCRIPTION
Fixed #2113

Changes: "Rename Image" is displayed as the dialog title instead of "Rename album".

Screenshot for the change:

![screenshot_2018-07-23-23-59-45-313_org fossasia phimpme](https://user-images.githubusercontent.com/20841578/43095825-aaf6582c-8ed4-11e8-9f85-5f1b9b068cf4.png)
