### PR TITLE
Fix #2131-Checkbox tint issue for delete operation resolved.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/util/AlertDialogsHelper.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/util/AlertDialogsHelper.java
@@ -107,7 +107,6 @@ public class AlertDialogsHelper {
         checkBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
                 if(b){
-                    checkBox.setButtonTintList(ColorStateList.valueOf(colorId));
                     check=true;
 
                 }else{
@@ -124,6 +123,7 @@ public class AlertDialogsHelper {
         else dialogMessage.setText(Message);
         dialogMessage.setTextColor(activity.getTextColor());
         textDialogBuilder.setView(dialogLayout);
+        checkBox.setButtonTintList(ColorStateList.valueOf(colorId));
         return textDialogBuilder.create();
     }
 

--- a/app/src/main/java/org/fossasia/phimpme/trashbin/TrashBinAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/trashbin/TrashBinAdapter.java
@@ -71,7 +71,7 @@ public class TrashBinAdapter extends RecyclerView.Adapter<TrashBinAdapter.ViewHo
             }
             holder.deleteDate.setTag(trashBinRealmModel);
             Uri uri = Uri.fromFile(new File(trashBinRealmModel.getTrashbinpath()));
-            Glide.with(context).load(uri)
+            Glide.with(holder.deletedImage.getContext()).load(uri)
                     .diskCacheStrategy(DiskCacheStrategy.ALL)
                     .into(holder.deletedImage);
             holder.popupMenuButton.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistoryAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistoryAdapter.java
@@ -81,7 +81,7 @@ public class UploadHistoryAdapter extends RecyclerView.Adapter<UploadHistoryAdap
             imagePath = uploadHistoryRealmModel.getPathname();
             holder.uploadTime.setTag(uploadHistoryRealmModel);
 
-            Glide.with(context).load(uri)
+            Glide.with(holder.uploadImage.getContext()).load(uri)
                     .diskCacheStrategy(DiskCacheStrategy.ALL)
                     .into(holder.uploadImage);
 


### PR DESCRIPTION
Fixed #2131 

Changes: The checkbox is now tinted in the accent color irrespective of its state(checked or unchecked).

Screenshots of the change: 
![screenshot_2018-07-31-14-37-53-616_org fossasia phimpme](https://user-images.githubusercontent.com/20841578/43450421-4f9785e4-94d0-11e8-943d-087da9d436e0.png)
