### PR TITLE
Fix #2141-Fixed app crash for Upload History section.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistoryAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistoryAdapter.java
@@ -39,7 +39,7 @@ import static org.fossasia.phimpme.utilities.ActivitySwitchHelper.getContext;
 public class UploadHistoryAdapter extends RecyclerView.Adapter<UploadHistoryAdapter.ViewHolder> {
 
     private Realm realm = Realm.getDefaultInstance();
-    private ArrayList<UploadHistoryRealmModel> realmResult = null;
+    private ArrayList<UploadHistoryRealmModel> realmResult = new ArrayList<>();
     private int color;
     private View.OnClickListener onClickListener;
     public String imagePath;


### PR DESCRIPTION
Fixed #2141 
Changes: App crash fixed for navigating to Upload History with no item shared.
