### PR TITLE
Fix #2061-Shared images delete issue resolved.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -791,6 +791,12 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
         } else if (!favphotomode && !allPhotoMode && upoadhis) {
             int c = current_image_pos;
             //deleteMedia(favouriteslist.get(current_image_pos).getPath());
+            if(uploadhistory.get(current_image_pos).getPath().contains(".nomedia")){
+                File file = new File(uploadhistory.get(current_image_pos).getPath());
+                if(file.exists()){
+                    file.delete();
+                }
+            }
             realm = Realm.getDefaultInstance();
             realm.executeTransaction(new Realm.Transaction() {
                 @Override public void execute(Realm realm) {
@@ -1751,7 +1757,11 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
             imgType.setText(mediaDetailsMap.get("Type").toUpperCase());
             imgSize.setText(StringUtils.humanReadableByteCount(media.getSize(), true));
             imgResolution.setText(mediaDetailsMap.get("Resolution"));
-            imgPath.setText(mediaDetailsMap.get("Path").toString());
+            if(mediaDetailsMap.get("Path").toString().contains(".nomedia")){
+                imgPath.setText(R.string.deleted_share_image);
+            } else {
+                imgPath.setText(mediaDetailsMap.get("Path").toString());
+            }
             imgOrientation.setText(mediaDetailsMap.get("Orientation"));
             if(mediaDetailsMap.get("Description") == null) {
                 imgDesc.setText(R.string.no_description);

--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
@@ -116,16 +116,20 @@ public class UploadHistory extends ThemedActivity {
         securityObj = new SecurityHelper(UploadHistory.this);
         removedeletedphotos();
         uploadHistoryRealmModelRealmQuery = realm.where(UploadHistoryRealmModel.class);
-        GridLayoutManager layoutManager = new GridLayoutManager(getApplicationContext(), columnsCount());
-        layoutManager.setReverseLayout(false);
-        uploadHistoryRecyclerView.setLayoutManager(layoutManager);
-        uploadHistoryRecyclerView.setAdapter(uploadHistoryAdapter);
-        String choiceofdisply = preferenceUtil.getString(getString(R.string.upload_view_choice), getString(R.string
-                .last_first));
-        if(choiceofdisply.equals(getString(R.string.last_first))){
-            uploadHistoryAdapter.updateUploadListItems(loadData(getString(R.string.last_first)));
-        }else if(choiceofdisply.equals(getString(R.string.latest_first))){
-            uploadHistoryAdapter.updateUploadListItems(loadData(getString(R.string.latest_first)));
+        if(uploadHistoryRealmModelRealmQuery.count() == 0){
+            emptyLayout.setVisibility(View.VISIBLE);
+        } else {
+            String choiceofdisply = preferenceUtil.getString(getString(R.string.upload_view_choice), getString(R.string
+                    .last_first));
+            if(choiceofdisply.equals(getString(R.string.last_first))){
+                uploadHistoryAdapter.updateUploadListItems(loadData(getString(R.string.last_first)));
+            }else if(choiceofdisply.equals(getString(R.string.latest_first))){
+                uploadHistoryAdapter.updateUploadListItems(loadData(getString(R.string.latest_first)));
+            }
+            GridLayoutManager layoutManager = new GridLayoutManager(getApplicationContext(), columnsCount());
+            layoutManager.setReverseLayout(false);
+            uploadHistoryRecyclerView.setLayoutManager(layoutManager);
+            uploadHistoryRecyclerView.setAdapter(uploadHistoryAdapter);
         }
         setUpUI();
         //uploadHistoryRecyclerView.addOnItemTouchListener(new RecyclerItemClickListner(this, this));
@@ -165,11 +169,11 @@ public class UploadHistory extends ThemedActivity {
        // ArrayList<UploadHistoryRealmModel> ki = new ArrayList<>();
        // String s = preferenceUtil.getString("upload_view_choice", "Last first");
         uploadResults = new ArrayList<>();
-        if(displaychoice.equals(getString(R.string.last_first))){
+        if(displaychoice.equals(getString(R.string.last_first)) && uploadHistoryRealmModelRealmQuery.count() != 0){
             for(int i = 0; i < uploadHistoryRealmModelRealmQuery.findAll().size(); i++){
                 uploadResults.add(uploadHistoryRealmModelRealmQuery.findAll().get(i));
             }
-        }else if(displaychoice.equals(getString(R.string.latest_first))){
+        }else if(displaychoice.equals(getString(R.string.latest_first)) && uploadHistoryRealmModelRealmQuery.count() != 0){
             for(int i = 0; i < uploadHistoryRealmModelRealmQuery.findAll().size(); i++){
                 uploadResults.add(uploadHistoryRealmModelRealmQuery.findAll().get(uploadHistoryRealmModelRealmQuery
                         .findAll().size() - i - 1));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -873,6 +873,7 @@
     <string name="orientation">Orientation</string>
     <string name="location">Location</string>
     <string name="no_description">No description added.</string>
+    <string name="deleted_share_image">Media deleted from local folders.</string>
     <string name="no_location">No location</string>
     <string name="no_exif_data">No data found.</string>
 


### PR DESCRIPTION
Fixed #2061 
Changes: Now on deleting images that have been shared and have a record in the Upload History, the upload history record persists. An option is provided to the user to delete the upload history record of the image by navigating to the Upload History section.
