### PR TITLE
Fix #2144-Fixes upload history crash.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
@@ -122,9 +122,9 @@ public class UploadHistory extends ThemedActivity {
             String choiceofdisply = preferenceUtil.getString(getString(R.string.upload_view_choice), getString(R.string
                     .last_first));
             if(choiceofdisply.equals(getString(R.string.last_first))){
-                uploadHistoryAdapter.updateUploadListItems(loadData(getString(R.string.last_first)));
+                uploadHistoryAdapter.setResults(loadData(getString(R.string.last_first)));
             }else if(choiceofdisply.equals(getString(R.string.latest_first))){
-                uploadHistoryAdapter.updateUploadListItems(loadData(getString(R.string.latest_first)));
+                uploadHistoryAdapter.setResults(loadData(getString(R.string.latest_first)));
             }
             GridLayoutManager layoutManager = new GridLayoutManager(getApplicationContext(), columnsCount());
             layoutManager.setReverseLayout(false);
@@ -212,9 +212,9 @@ public class UploadHistory extends ThemedActivity {
                         .last_first));
                 if(uploadHistoryRealmModelRealmQuery.count() != 0){
                     if(choiceofdisply.equals(getString(R.string.last_first))){
-                        uploadHistoryAdapter.updateUploadListItems(loadData(getString(R.string.last_first)));
+                        uploadHistoryAdapter.setResults(loadData(getString(R.string.last_first)));
                     }else if(choiceofdisply.equals(getString(R.string.latest_first))){
-                        uploadHistoryAdapter.updateUploadListItems(loadData(getString(R.string.latest_first)));
+                        uploadHistoryAdapter.setResults(loadData(getString(R.string.latest_first)));
                     }
                 }else {
                     emptyLayout.setVisibility(View.VISIBLE);
@@ -225,11 +225,6 @@ public class UploadHistory extends ThemedActivity {
                 }
             }
         });
-    }
-
-    public void setUpAdapter(@NotNull ArrayList<UploadHistoryRealmModel> accountDetails) {
-        this.uploadResults = accountDetails;
-        uploadHistoryAdapter.updateUploadListItems(uploadResults);
     }
 
     @Override public boolean onCreateOptionsMenu(Menu menu) {
@@ -389,9 +384,9 @@ public class UploadHistory extends ThemedActivity {
         String choiceofdisply = preferenceUtil.getString(getString(R.string.upload_view_choice), getString(R.string
                 .last_first));
         if(choiceofdisply.equals(getString(R.string.last_first))){
-            uploadHistoryAdapter.updateUploadListItems(loadData(getString(R.string.last_first)));
+            uploadHistoryAdapter.setResults(loadData(getString(R.string.last_first)));
         }else if(choiceofdisply.equals(getString(R.string.latest_first))){
-            uploadHistoryAdapter.updateUploadListItems(loadData(getString(R.string.latest_first)));
+            uploadHistoryAdapter.setResults(loadData(getString(R.string.latest_first)));
         }
         if (uploadHistoryRealmModelRealmQuery.count() == 0) {
             emptyLayout.setVisibility(View.VISIBLE);
@@ -431,7 +426,7 @@ public class UploadHistory extends ThemedActivity {
                 s.commit();
                 runOnUiThread(new Runnable() {
                     @Override public void run() {
-                        uploadHistoryAdapter.updateUploadListItems(loadData(getString(R.string.latest_first)));
+                        uploadHistoryAdapter.setResults(loadData(getString(R.string.latest_first)));
                     }
                 });
             }else if(strings[0].equals(getString(R.string.last_first))){
@@ -440,7 +435,7 @@ public class UploadHistory extends ThemedActivity {
                 s.commit();
                 runOnUiThread(new Runnable() {
                     @Override public void run() {
-                        uploadHistoryAdapter.updateUploadListItems(loadData(getString(R.string.last_first)));
+                        uploadHistoryAdapter.setResults(loadData(getString(R.string.last_first)));
                     }
                 });
             }

--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistoryAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistoryAdapter.java
@@ -112,6 +112,11 @@ public class UploadHistoryAdapter extends RecyclerView.Adapter<UploadHistoryAdap
         diffResult.dispatchUpdatesTo(this);
     }
 
+    public void setResults(ArrayList<UploadHistoryRealmModel> realmResult){
+        this.realmResult = realmResult;
+        notifyDataSetChanged();
+    }
+
     public void setOnClickListener(View.OnClickListener lis) {
         onClickListener = lis;
     }


### PR DESCRIPTION
Fixed #2144 
Changes: There is some error while using the DiffUtil class for populating the recyclerview adapter, therefore have switched to using the notifyDataSetChanged() till the DiffUtil issue is resolved. Will solve the DiffUtil issue via another separate PR.


