### PR TITLE
Fix #1829-Position of scrollbar remains same on orientation change.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -926,8 +926,18 @@ public class LFMainActivity extends SharedMediaActivity {
 
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
+        int photopos = 0;
+        int albumpos = 0;
         super.onConfigurationChanged(newConfig);
-        updateColumnsRvs();
+        if(albumsMode){
+            albumpos = ((GridLayoutManager) rvAlbums.getLayoutManager()).findFirstVisibleItemPosition();
+            updateColumnsRvs();
+            (rvAlbums.getLayoutManager()).scrollToPosition(albumpos);
+        } else {
+            photopos = ((GridLayoutManager) rvMedia.getLayoutManager()).findFirstVisibleItemPosition();
+            updateColumnsRvs();
+            (rvMedia.getLayoutManager()).scrollToPosition(photopos);
+        }
     }
 
     private boolean displayData(Bundle data) {


### PR DESCRIPTION
Fixed #1829 

Changes: On changing the screen orientation while viewing photos in albums or allphotosmode, the position of the scrollbar remains same i.e the user is not taken to the starting of the album, the photos are displayed from the same position as before the orientation change.
