### PR TITLE
Fixed #2160 App does not crash while navigating quickly between editing tabs 

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/FrameFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/FrameFragment.java
@@ -128,7 +128,6 @@ public class FrameFragment extends BaseEditFragment {
         @Override
         public viewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
             View view = View.inflate(getContext(), R.layout.frames, null);
-
             return new viewHolder(view);
         }
         @Override

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/FrameFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/FrameFragment.java
@@ -128,6 +128,7 @@ public class FrameFragment extends BaseEditFragment {
         @Override
         public viewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
             View view = View.inflate(getContext(), R.layout.frames, null);
+
             return new viewHolder(view);
         }
         @Override
@@ -297,6 +298,11 @@ public class FrameFragment extends BaseEditFragment {
     }
     // Asynchronous loading of thumbnails
     private class asyncThumbs extends AsyncTask<Void, Void, Void> {
+
+        @Override
+        protected void onPreExecute() {
+            arrayList=new ArrayList<>();
+        }
 
         @Override
         protected Void doInBackground(Void... params) {

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/FrameFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/FrameFragment.java
@@ -305,7 +305,6 @@ public class FrameFragment extends BaseEditFragment {
 
         @Override
         protected Void doInBackground(Void... params) {
-            arrayList = new ArrayList<>();
             InputStream is = null;
             Bitmap tempBitmap;
             String frameFolder = "frames";


### PR DESCRIPTION
Fixed #2160 

Changes: While navigating through the tabs at the bottom of the editing activity a separate Async task is called for loading the ArrayList attached to the tab. This ArrayList is null in the beginning and is initialized only when the doInBackground() method is called leading to crashes (ArrayList.size() causes null pointer Exception). So i implemented the OnpreExecute() method for Async Tasks and initialized the list in this method.   
