### PR TITLE
FIXED #2162 All GIF files are saved properly

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -117,8 +117,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.WeakReference;
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Locale;
@@ -3351,10 +3353,13 @@ public class LFMainActivity extends SharedMediaActivity {
             }
             byte[] bytes = createGIFFromImages(bitmaps);
             File file = new File(Environment.getExternalStorageDirectory() + "/" + "Phimpme_gifs");
+            DateFormat dateFormat = new SimpleDateFormat("dMMMyyyy_HHmmss");
+            String date = dateFormat.format(Calendar.getInstance().getTime());
             if(file.exists() && file.isDirectory()){
                 FileOutputStream outStream = null;
+
                 try{
-                    outStream = new FileOutputStream(file.getPath() + "/" + "GIF.gif");
+                    outStream = new FileOutputStream(file.getPath() + "/" + "GIF_"+date+".gif");
                     outStream.write(bytes);
                     outStream.close();
                 }catch(Exception e){
@@ -3364,7 +3369,7 @@ public class LFMainActivity extends SharedMediaActivity {
                 if (file.mkdir()) {
                     FileOutputStream outStream = null;
                     try {
-                        outStream = new FileOutputStream(file.getPath() + "/" + "GIF.gif");
+                        outStream = new FileOutputStream(file.getPath() + "/" + "GIF_"+date+".gif");
                         outStream.write(bytes);
                         outStream.close();
                     } catch (Exception e) {


### PR DESCRIPTION
Fixed #2162 

Changes: The GIF files were created with the same filename (GIF.gif) due to which the newly created gif was overwritten to the old gif and only one file was saved at a time ,so I added date and time to the gif filename so that the new files don't overwrite the previous ones.


