### PR TITLE
Fix #2158 Delete albums operation issue

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/data/HandlingAlbums.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/data/HandlingAlbums.java
@@ -332,6 +332,10 @@ public class HandlingAlbums {
     return selectedAlbums.get(index);
   }
 
+  public ArrayList<Album> getSelectedAlbums() {
+      return selectedAlbums;
+  }
+
   public void loadAlbums(Context applicationContext) {
     loadAlbums(applicationContext, hidden);
   }

--- a/app/src/main/java/org/fossasia/phimpme/utilities/SnackBarHandler.java
+++ b/app/src/main/java/org/fossasia/phimpme/utilities/SnackBarHandler.java
@@ -30,7 +30,7 @@ public class SnackBarHandler  {
         return snackbar;
     }
 
-    public static void showWithBottomMargin(View view, String text,int bottomMargin, int duration) {
+    public static Snackbar showWithBottomMargin(View view, String text,int bottomMargin, int duration) {
         ThemeHelper themeHelper=new ThemeHelper(ActivitySwitchHelper.getContext());
         final Snackbar snackbar = Snackbar.make(view, text, duration);
         View sbView = snackbar.getView();
@@ -45,14 +45,9 @@ public class SnackBarHandler  {
                 .snackbar_text);
         textView.setTextColor(Color.WHITE);
         textView.setTextSize(12);
-        snackbar.setAction(R.string.ok_action, new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                snackbar.dismiss();
-            }
-        });
         snackbar.setActionTextColor(themeHelper.getAccentColor());
         snackbar.show();
+        return snackbar;
     }
 
     public static Snackbar showWithBottomMargin2(View view, String text,int bottomMargin, int duration) {
@@ -90,8 +85,8 @@ public class SnackBarHandler  {
         showWithBottomMargin(view, ActivitySwitchHelper.getContext().getResources().getString(res), bottomMargin, duration);
     }
 
-    public static void showWithBottomMargin(View view, String text, int bottomMargin) {
-        showWithBottomMargin(view, text, bottomMargin, Snackbar.LENGTH_LONG);
+    public static Snackbar showWithBottomMargin(View view, String text, int bottomMargin) {
+        return showWithBottomMargin(view, text, bottomMargin, Snackbar.LENGTH_LONG);
     }
 
     public static void showWithBottomMargin(View view, int res, int bottomMargin) {


### PR DESCRIPTION
Fixed #2158

Changes: [(LFMainActivity.java).First get all the images of the selected albums and then add them to database and move all the images to .nonmedia Folder which is selected folder for storing images (trash bin), also add other stuff like restore when click on undo in Snackbar. (HandlingAlbums.java) returning the selected Album arrayList and (SnackBarHandler.java) showing and refreshing the list ]