### PR TITLE
Fix #2173 (App crashed when changing the orientation)

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/PaintFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/PaintFragment.java
@@ -78,7 +78,7 @@ public class PaintFragment extends BaseEditFragment implements View.OnClickListe
     }
 
     private void resetPaintView() {
-        if (null != mPaintView){
+        if (null != mPaintView && activity.mainBitmap != null){
             mPaintView.reset();
             mPaintView.setVisibility(View.GONE);
         }
@@ -147,6 +147,10 @@ public class PaintFragment extends BaseEditFragment implements View.OnClickListe
     }
 
     public void onShow() {
+        if (activity.mainBitmap == null) {
+            getActivity().getSupportFragmentManager().beginTransaction().remove(PaintFragment.this).commit();
+            return;
+        }
         activity.changeMode(EditImageActivity.MODE_PAINT);
         activity.mainImage.setImageBitmap(activity.mainBitmap);
         activity.mPaintView.mainBitmap=activity.mainBitmap;

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/RotateFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/RotateFragment.java
@@ -126,6 +126,10 @@ public class RotateFragment extends BaseEditFragment {
 
     @Override
     public void onShow() {
+        if (activity.mainBitmap == null) {
+            getActivity().getSupportFragmentManager().beginTransaction().remove(RotateFragment.this).commit();
+            return;
+        }
         activity.changeMode(EditImageActivity.MODE_ROTATE);
         activity.mainImage.setImageBitmap(activity.mainBitmap);
         activity.mainImage.setDisplayType(ImageViewTouchBase.DisplayType.FIT_TO_SCREEN);

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/SliderFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/SliderFragment.java
@@ -123,6 +123,7 @@ public class SliderFragment extends BaseEditFragment implements View.OnClickList
 
     @Override
     public void onShow() {
+
         if (activity!=null) {
             setDefaultSeekBarProgress();
             activity.changeMode(EditImageActivity.MODE_SLIDER);
@@ -137,6 +138,7 @@ public class SliderFragment extends BaseEditFragment implements View.OnClickList
     private void defaultApply() {
         ProcessImageTask processImageTask = new ProcessImageTask();
         processImageTask.execute(seekBar.getProgress());
+
     }
 
     public void doPendingApply() {
@@ -224,18 +226,22 @@ public class SliderFragment extends BaseEditFragment implements View.OnClickList
             if (srcBitmap != null && !srcBitmap.isRecycled()) {
                 srcBitmap.recycle();
             }
-
-            srcBitmap = Bitmap.createBitmap(currentBitmap.copy(
-                    Bitmap.Config.RGB_565, true));
-            return PhotoProcessing.processImage(srcBitmap, EditImageActivity.effectType, val);
+            if (currentBitmap != null) {
+                srcBitmap = Bitmap.createBitmap(currentBitmap.copy(
+                        Bitmap.Config.RGB_565, true));
+                return PhotoProcessing.processImage(srcBitmap, EditImageActivity.effectType, val);
+            }
+            return null;
         }
 
         @Override
         protected void onPostExecute(Bitmap result) {
             super.onPostExecute(result);
             activity.hideProgressBar();
-            if (result == null)
+            if (result == null) {
+                getActivity().getSupportFragmentManager().beginTransaction().remove(SliderFragment.this).commit();
                 return;
+            }
             filterBit = result;
             activity.mainImage.setImageBitmap(filterBit);
         }

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
@@ -104,6 +104,10 @@ public class StickersFragment extends BaseEditFragment implements View.OnClickLi
 
     @Override
     public void onShow() {
+        if (activity.mainBitmap == null) {
+            getActivity().getSupportFragmentManager().beginTransaction().remove(StickersFragment.this).commit();
+            return;
+        }
         activity.changeMode(EditImageActivity.MODE_STICKERS);
         activity.stickersFragment.getmStickerView().mainImage = activity.mainImage;
         activity.stickersFragment.getmStickerView().mainBitmap = activity.mainBitmap;

--- a/app/src/main/java/org/fossasia/phimpme/editor/view/CustomPaintView.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/view/CustomPaintView.java
@@ -12,6 +12,7 @@ import android.support.annotation.RequiresApi;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
 import org.fossasia.phimpme.editor.view.imagezoom.ImageViewTouch;
 
 /**
@@ -58,6 +59,12 @@ public class CustomPaintView extends View {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+        if (mainBitmap == null) {
+            if (this.getParent() != null) {
+                ((ViewGroup) this.getParent()).removeView(this);
+            }
+            return;
+        }
         int displayW=mainBitmap.getWidth()*getMeasuredHeight()/mainBitmap.getHeight();
         int displayH=mainBitmap.getHeight()*getMeasuredWidth()/mainBitmap.getWidth();
         leftX=(mainImage.getMeasuredWidth()-displayW)>>1;


### PR DESCRIPTION
Fixed #2173 

Changes: [All files which i changed they call different image processing method on a null object of bitmap so i changed all the methods will invoke only if bitmap is not null and if it's null it will also remove that fragment if i didn't do that then it make more and more stack of fragment on activity.]

Gif of the change: 
![fix 2171](https://user-images.githubusercontent.com/22986571/46042378-d9b76300-c132-11e8-8001-f3f20519959c.gif)
