### PR TITLE
Fix #2189 (Fragment overlapping on orientation change in the edit image section)

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
@@ -174,7 +174,7 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
 
         getSupportFragmentManager()
                 .beginTransaction()
-                .add(R.id.preview_container, filterFragment)
+                .replace(R.id.preview_container, filterFragment)
                 .commit();
 
         setButtonsVisibility();


### PR DESCRIPTION

Fixed #2189 

Changes: [transaction add() in fragment added the fragment on above of another so i used replace() to make only one fragment at time at the preview container]

Screenshots of the change: 

![whatsapp image 2018-10-03 at 3 52 13 am](https://user-images.githubusercontent.com/22986571/46380418-d1759f80-c6bf-11e8-935f-4f017b53be36.jpeg)
