### PR TITLE
Sliding Feature Added to the Editing Activity

### DIFF
--- a/app/src/main/res/drawable/ic_fiber_manual_record_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_fiber_manual_record_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="30dp" android:tint="#E3EFE1"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="30dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#010101" android:pathData="M12,12m-8,0a8,8 0,1 1,16 0a8,8 0,1 1,-16 0"/>
+</vector>

--- a/app/src/main/res/layout-land/activity_image_edit.xml
+++ b/app/src/main/res/layout-land/activity_image_edit.xml
@@ -7,13 +7,14 @@
 
     <FrameLayout
         android:id="@+id/preview_container"
-        android:layout_width="60dp"
+        android:layout_width="100dp"
         android:layout_height="match_parent"
+        android:layout_centerVertical="true"
         android:layout_marginTop="5dp" />
     <LinearLayout
         android:id="@+id/control_area"
         android:layout_width="match_parent"
-        android:layout_marginLeft="60dp"
+        android:layout_toEndOf="@id/preview_container"
         android:layout_marginRight="60dp"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
@@ -118,7 +119,7 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
         android:layout_marginRight="60dp"
-        android:layout_marginLeft="60dp"
+        android:layout_toEndOf="@id/preview_container"
         android:layout_above="@+id/control_area"
         android:layout_alignParentTop="true"
         android:background="#000000">
@@ -163,6 +164,15 @@
             android:layout_height="fill_parent"
             android:layout_gravity="center"
             android:visibility="gone" />
+
+        <ImageButton
+            android:id="@+id/sliding_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_toEndOf="@id/preview_container"
+            android:layout_gravity="center_vertical"
+            android:background="@null"
+            app:srcCompat="@drawable/ic_fiber_manual_record_black_24dp" />
     </FrameLayout>
 
     <ProgressBar

--- a/app/src/main/res/layout-land/fragment_edit_image_crop.xml
+++ b/app/src/main/res/layout-land/fragment_edit_image_crop.xml
@@ -10,8 +10,7 @@
         android:layout_width="@dimen/icon_item_image_size_main"
         android:layout_height="@dimen/editor_bottom_row_size"
         android:scaleType="fitCenter"
-        android:layout_marginRight="5dp"
-        android:layout_marginLeft="5dp"
+        android:layout_gravity="center_horizontal"
         android:layout_alignBottom="@+id/crop_hsv"
         android:layout_alignParentLeft="true"
         android:background="?android:attr/selectableItemBackground"
@@ -48,8 +47,7 @@
         android:layout_height="@dimen/editor_bottom_row_size"
         android:foregroundGravity="center_vertical"
         android:scaleType="fitCenter"
-        android:layout_marginRight="5dp"
-        android:layout_marginLeft="5dp"
+        android:layout_gravity="center_horizontal"
         android:background="?android:attr/selectableItemBackground"
         app:srcCompat="@drawable/ic_done_black_24dp" />
 </LinearLayout>

--- a/app/src/main/res/layout/activity_image_edit.xml
+++ b/app/src/main/res/layout/activity_image_edit.xml
@@ -164,6 +164,15 @@
 
     </FrameLayout>
 
+    <ImageButton
+        android:id="@+id/sliding_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:background="@null"
+        app:srcCompat="@drawable/ic_fiber_manual_record_black_24dp"
+        android:visibility="gone"/>
+
     <ProgressBar
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
Fixed #2166 

Changes:
Earlier the boundary of the preview_container in the Editing activity was fixed to 60dp thus leading to the following situation
![git_pr](https://user-images.githubusercontent.com/37406965/46429412-fd4a6100-c763-11e8-840d-3566a388c1c8.jpg)

I made changes in the Edit Image Activity and made its width dynamic and under the control of the user. The user can control the width of the layout using the white button attached to the boundary of the Preview container.
 
Screenshots of the change: 

![20181003_234716](https://user-images.githubusercontent.com/37406965/46430557-ef4a0f80-c766-11e8-9db0-90cb2282af7b.gif)

**Now the user can adjust the size of the preview container as per his own convenience**