### PR TITLE
Fix #2194 app crashes in crop fragment depends on orientation

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/CropFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/CropFragment.java
@@ -77,7 +77,7 @@ public class CropFragment extends BaseEditFragment {
 	}
 
 	private void resetCropView() {
-		if (null != activity && null != mCropPanel){
+		if (null != activity && null != mCropPanel && activity.mainBitmap != null){
 			mCropPanel.setVisibility(View.GONE);
 			RectF r = activity.mainImage.getBitmapRect();
 			activity.mCropPanel.setCropRect(r);
@@ -158,7 +158,10 @@ public class CropFragment extends BaseEditFragment {
 
     @Override
     public void onShow() {
-
+		if (activity.mainBitmap == null) {
+			getActivity().getSupportFragmentManager().beginTransaction().remove(CropFragment.this).commit();
+			return;
+		}
 		activity.changeMode(EditImageActivity.MODE_CROP);
         activity.mCropPanel.setVisibility(View.VISIBLE);
         activity.mainImage.setImageBitmap(activity.mainBitmap);


### PR DESCRIPTION
Fixed #2194 

Changes: [crash due to calling the null bitmap because of changing the orientation so i apply few conditions in order to stop the app crashes.]

GIF  of the change: 

![2018_10_04_16_34_22](https://user-images.githubusercontent.com/22986571/46470386-0edb4980-c7f4-11e8-8ce6-1bed180bf99f.gif)
