### PR TITLE
Preview Container resizes according to the size of contents

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
@@ -2,7 +2,6 @@ package org.fossasia.phimpme.editor;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.pm.ActivityInfo;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.PorterDuff;

--- a/app/src/main/res/layout-land/activity_image_edit.xml
+++ b/app/src/main/res/layout-land/activity_image_edit.xml
@@ -7,13 +7,14 @@
 
     <FrameLayout
         android:id="@+id/preview_container"
-        android:layout_width="60dp"
+        android:layout_width="wrap_content"
         android:layout_height="match_parent"
+        android:layout_centerVertical="true"
         android:layout_marginTop="5dp" />
     <LinearLayout
         android:id="@+id/control_area"
         android:layout_width="match_parent"
-        android:layout_marginLeft="60dp"
+        android:layout_toEndOf="@id/preview_container"
         android:layout_marginRight="60dp"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
@@ -118,7 +119,7 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
         android:layout_marginRight="60dp"
-        android:layout_marginLeft="60dp"
+        android:layout_toEndOf="@id/preview_container"
         android:layout_above="@+id/control_area"
         android:layout_alignParentTop="true"
         android:background="#000000">

--- a/app/src/main/res/layout/activity_image_edit.xml
+++ b/app/src/main/res/layout/activity_image_edit.xml
@@ -161,7 +161,6 @@
             android:layout_gravity="center"
             android:visibility="gone" />
 
-
     </FrameLayout>
 
     <ProgressBar


### PR DESCRIPTION
Fixed #2166

Changes: Earlier the boundary of the preview_container in the Editing activity was fixed to 60dp thus leading to the following situation
![git_pr](https://user-images.githubusercontent.com/37406965/46476774-9a5dd600-c806-11e8-87b3-bcefe7d2751c.jpg)

I made changes in the Edit Image layout and made it adjust its width according to the size of the contents. 

Screenshots of the change: 
![20181004_185958](https://user-images.githubusercontent.com/37406965/46477525-769b8f80-c808-11e8-9888-b47bae47251b.gif)
