### PR TITLE
Fix #2201 (Fragment should remain same after orientation changed)

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
@@ -158,6 +158,9 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
         setContentView(R.layout.activity_image_edit);
         ButterKnife.bind(this);
         initView();
+        if (savedInstanceState != null) {
+            mode =  savedInstanceState.getInt("PREVIOUS_FRAGMENT");
+        }
         getData();
     }
 
@@ -171,10 +174,7 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
                 .add(R.id.controls_container, mainMenuFragment)
                 .commit();
 
-        getSupportFragmentManager()
-                .beginTransaction()
-                .replace(R.id.preview_container, filterFragment)
-                .commit();
+        changeMiddleFragment(mode);
 
         setButtonsVisibility();
     }
@@ -653,6 +653,12 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
                 SnackBarHandler.show(parentLayout,R.string.save_error);
             }
         }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putInt("PREVIOUS_FRAGMENT", mode);
     }
 
     @Override


### PR DESCRIPTION
Fixed #2201 

Changes: [Traditionally savedInstanceState() used to restore the state of activity so implement it in EditImageActivity to restore selected fragments.]

GIF of the change: 

<img src="https://user-images.githubusercontent.com/22986571/46514183-0b8aa100-c87a-11e8-9832-07a7a145cb5f.gif" width="350" height="600">