### PR TITLE
Fixed#2206: Created layout-land resource file for frames

### DIFF
--- a/app/src/main/res/layout-land/fragment_editor_frames.xml
+++ b/app/src/main/res/layout-land/fragment_editor_frames.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="70dp"
+    android:layout_gravity="center_vertical"
+    android:background="@color/white"
+    android:gravity="center_vertical">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:orientation="horizontal"
+        >
+        <ImageButton
+            android:id="@+id/cancel"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:layout_gravity="center_vertical"
+            android:layout_marginLeft="5dp"
+            android:layout_marginRight="5dp"
+            android:background="@color/white"
+            android:scaleType="fitCenter"
+            android:visibility="gone" />
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/frameRecyler"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
+            android:layout_toRightOf="@+id/cancel"
+            android:layout_weight="0.5"
+            android:gravity="center">
+
+        </android.support.v7.widget.RecyclerView>
+
+        <ImageButton
+            android:id="@+id/done"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:layout_gravity="center_vertical"
+            android:layout_marginLeft="5dp"
+            android:layout_marginRight="5dp"
+            android:background="@color/white"
+            android:scaleType="fitCenter"
+            android:visibility="gone" />
+    </LinearLayout>
+
+</RelativeLayout>


### PR DESCRIPTION
Fixed #2206

Changes: The preview container resizes itself as per the size of the contents(landscape-mode) to enhance user experience. But the layout file for frames had some constraints leading to the issue #2206. These constraints were appropriate for portrait mode but not for landscape mode. So i created a layout-land file for frames fragment with appropriate constraints. 

Screenshots of the change: 
![f8f6500b-3a7a-423f-aa75-53617f0ea8f4 1](https://user-images.githubusercontent.com/37406965/46569204-2ab72a80-c96f-11e8-92cc-49b13bd44296.jpg)
