### PR TITLE
Fix #2209 ContainerFragment in EditImageActivity changes it's layout on orientation change

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
@@ -87,6 +87,9 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
     public static int mode;
     public static int effectType;
 
+    public static int middleMode = MODE_FILTERS;
+    public static int bottomMode = MODE_MAIN;
+
     /**
      * Number of times image has been edited. Indicates whether image has been edited or not.
      */
@@ -160,6 +163,8 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
         initView();
         if (savedInstanceState != null) {
             mode =  savedInstanceState.getInt("PREVIOUS_FRAGMENT");
+            middleMode = savedInstanceState.getInt("MIDDLE_FRAGMENT", MODE_FILTERS);
+            bottomMode = savedInstanceState.getInt("BOTTOM_FRAGMENT", MODE_MAIN);
         }
         getData();
     }
@@ -169,12 +174,16 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
      * Calleter onCreate() when the activity is first started. Loads the initial default fragments.
      */
     private void setInitialFragments() {
+
         getSupportFragmentManager()
                 .beginTransaction()
-                .add(R.id.controls_container, mainMenuFragment)
+                .replace(R.id.controls_container, getFragment(bottomMode))
                 .commit();
 
-        changeMiddleFragment(mode);
+        getSupportFragmentManager()
+                .beginTransaction()
+                .replace(R.id.preview_container, getFragment(middleMode))
+                .commit();
 
         setButtonsVisibility();
     }
@@ -241,8 +250,19 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
         return mode;
     }
 
+    public static int getMiddleMode() {
+        return middleMode;
+    }
+
+    public void changeBottomMode(int bottomMode) {
+        mode = bottomMode;
+        this.bottomMode = bottomMode;
+    }
+
+
     public void changeMode(int to_mode){
         EditImageActivity.mode = to_mode;
+        bottomMode = to_mode;
         highLightSelectedOption(to_mode);
     }
 
@@ -312,6 +332,8 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
      * @param index integer corresponding to the current editing mode.
      */
     public void changeBottomFragment(int index){
+        bottomMode = index;
+        mode = index;
         getSupportFragmentManager()
                 .beginTransaction()
                 .replace(R.id.controls_container, getFragment(index))
@@ -367,6 +389,8 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
      * @param index integer representing selected editing mode
      */
     public void changeMiddleFragment(int index){
+            EditImageActivity.middleMode = index;
+            EditImageActivity.mode = index;
             getSupportFragmentManager()
                     .beginTransaction()
                     .replace(R.id.preview_container, getFragment(index))
@@ -659,6 +683,8 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putInt("PREVIOUS_FRAGMENT", mode);
+        outState.putInt("MIDDLE_FRAGMENT", middleMode);
+        outState.putInt("BOTTOM_FRAGMENT", bottomMode);
     }
 
     @Override
@@ -684,7 +710,11 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
                 showDiscardChangesDialog(MODE_PAINT,R.string.discard_paint_message);
             case MODE_FRAME:
                 if(canAutoExit())
-                {finish();}
+                {
+                    bottomMode = MODE_MAIN;
+                    middleMode = MODE_FILTERS;
+                    finish();
+                }
                 else{
                 showDiscardChangesDialog(MODE_FRAME,R.string.discard_frame_mode_message);}
                 return;
@@ -692,6 +722,8 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
         }
         //if the image has not been edited or has been edited and saved.
         if (canAutoExit()) {
+            bottomMode = MODE_MAIN;
+            middleMode = MODE_FILTERS;
             finish();
         } else {
             final AlertDialog.Builder discardChangesDialogBuilder = new AlertDialog.Builder(EditImageActivity.this, getDialogStyle());
@@ -699,6 +731,8 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
             discardChangesDialogBuilder.setPositiveButton(getString(R.string.confirm).toUpperCase(), new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
+                    bottomMode = MODE_MAIN;
+                    middleMode = MODE_FILTERS;
                     finish();
                 }
             });

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/AddTextFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/AddTextFragment.java
@@ -204,7 +204,6 @@ public class AddTextFragment extends BaseEditFragment implements TextWatcher, Fo
 
     public void backToMain() {
         hideInput();
-        activity.changeMode(EditImageActivity.MODE_WRITE);
         activity.writeFragment.clearSelection();
         activity.changeBottomFragment(EditImageActivity.MODE_MAIN);
         activity.mainImage.setVisibility(View.VISIBLE);
@@ -214,6 +213,8 @@ public class AddTextFragment extends BaseEditFragment implements TextWatcher, Fo
 
     @Override
     public void onShow() {
+        if (activity.mainBitmap == null)
+            return;
         activity.changeMode(EditImageActivity.MODE_TEXT);
         activity.mainImage.setImageBitmap(activity.mainBitmap);
         activity.addTextFragment.getmTextStickerView().mainImage = activity.mainImage;

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/CropFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/CropFragment.java
@@ -158,7 +158,9 @@ public class CropFragment extends BaseEditFragment {
 
     @Override
     public void onShow() {
-
+		if (activity.mainBitmap == null) {
+			return;
+		}
 		activity.changeMode(EditImageActivity.MODE_CROP);
         activity.mCropPanel.setVisibility(View.VISIBLE);
         activity.mainImage.setImageBitmap(activity.mainBitmap);
@@ -176,7 +178,6 @@ public class CropFragment extends BaseEditFragment {
 	}
 
 	public void backToMain() {
-		activity.changeMode(EditImageActivity.MODE_ADJUST);
 		activity.changeBottomFragment(EditImageActivity.MODE_MAIN);
 		activity.adjustFragment.clearSelection();
 		mCropPanel.setVisibility(View.GONE);

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/MainMenuFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/MainMenuFragment.java
@@ -41,7 +41,7 @@ public class MainMenuFragment extends BaseEditFragment implements View.OnClickLi
         menu_stickers.setOnClickListener(this);
         menu_write.setOnClickListener(this);
         menu_frame.setOnClickListener(this);
-        highLightSelectedOption(EditImageActivity.getMode());
+        highLightSelectedOption(EditImageActivity.middleMode);
         return view;
     }
     @Override
@@ -64,30 +64,30 @@ public class MainMenuFragment extends BaseEditFragment implements View.OnClickLi
     public void onClick(View v) {
         switch (v.getId()) {
             case R.id.menu_filter:
-                activity.changeMode(EditImageActivity.MODE_FILTERS);
                 activity.sliderFragment.resetBitmaps();
                 activity.changeMiddleFragment(EditImageActivity.MODE_FILTERS);
+                highLightSelectedOption(EditImageActivity.middleMode);
                 break;
             case R.id.menu_enhance:
-                activity.changeMode(EditImageActivity.MODE_ENHANCE);
                 activity.sliderFragment.resetBitmaps();
                 activity.changeMiddleFragment(EditImageActivity.MODE_ENHANCE);
+                highLightSelectedOption(EditImageActivity.middleMode);
                 break;
             case R.id.menu_adjust:
-                activity.changeMode(EditImageActivity.MODE_ADJUST);
                 activity.changeMiddleFragment(EditImageActivity.MODE_ADJUST);
+                highLightSelectedOption(EditImageActivity.middleMode);
                 break;
             case R.id.menu_sticker:
-                activity.changeMode(EditImageActivity.MODE_STICKER_TYPES);
                 activity.changeMiddleFragment(EditImageActivity.MODE_STICKER_TYPES);
+                highLightSelectedOption(EditImageActivity.middleMode);
                 break;
             case R.id.menu_write:
-                activity.changeMode(EditImageActivity.MODE_WRITE);
                 activity.changeMiddleFragment(EditImageActivity.MODE_WRITE);
+                highLightSelectedOption(EditImageActivity.middleMode);
                 break;
             case R.id.menu_frame:
-                activity.changeMode(EditImageActivity.MODE_FRAME);
                 activity.changeMiddleFragment(EditImageActivity.MODE_FRAME);
+                highLightSelectedOption(EditImageActivity.middleMode);
                 break;
 
         }

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/PaintFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/PaintFragment.java
@@ -138,7 +138,6 @@ public class PaintFragment extends BaseEditFragment implements View.OnClickListe
     }
 
     public void backToMain() {
-        activity.changeMode(EditImageActivity.MODE_WRITE);
         activity.changeBottomFragment(EditImageActivity.MODE_MAIN);
         activity.writeFragment.clearSelection();
         activity.mainImage.setVisibility(View.VISIBLE);

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/RecyclerMenuFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/RecyclerMenuFragment.java
@@ -78,8 +78,6 @@ public class RecyclerMenuFragment extends BaseEditFragment {
         } else if(orientation == Configuration.ORIENTATION_LANDSCAPE) {
             layoutManager = new LinearLayoutManager(getActivity());
         }
-        recyclerView = (RecyclerView) fragmentView.findViewById(R.id.editor_recyclerview);
-
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.setAdapter(new mRecyclerAdapter());
         this.mStickerView = activity.mStickerView;
@@ -90,6 +88,7 @@ public class RecyclerMenuFragment extends BaseEditFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         fragmentView = inflater.inflate(R.layout.fragment_editor_recycler, container, false);
+        recyclerView = (RecyclerView) fragmentView.findViewById(R.id.editor_recyclerview);
         return fragmentView;
     }
 
@@ -283,20 +282,17 @@ public class RecyclerMenuFragment extends BaseEditFragment {
             switch (MODE){
                 case EditImageActivity.MODE_FILTERS:
                     activity.setEffectType(pos,MODE);
-                    activity.changeMode(EditImageActivity.MODE_SLIDER);
                     activity.changeBottomFragment(EditImageActivity.MODE_SLIDER);
                     break;
 
                 case EditImageActivity.MODE_ENHANCE:
                     activity.setEffectType(pos,MODE);
-                    activity.changeMode(EditImageActivity.MODE_SLIDER);
                     activity.changeBottomFragment(EditImageActivity.MODE_SLIDER);
                     break;
 
                 case EditImageActivity.MODE_STICKER_TYPES:
                     String data = (String) view.getTag();
                     activity.setStickerType(data);
-                    activity.changeMode(EditImageActivity.MODE_STICKERS);
                     activity.changeBottomFragment(EditImageActivity.MODE_STICKERS);
                     break;
             }

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/RotateFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/RotateFragment.java
@@ -148,7 +148,6 @@ public class RotateFragment extends BaseEditFragment {
     }
 
     public void backToMain() {
-        activity.changeMode(EditImageActivity.MODE_ADJUST);
         activity.changeBottomFragment(EditImageActivity.MODE_MAIN);
         activity.adjustFragment.clearSelection();
         activity.mainImage.setVisibility(View.VISIBLE);

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/SliderFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/SliderFragment.java
@@ -174,11 +174,10 @@ public class SliderFragment extends BaseEditFragment implements View.OnClickList
         if (null != activity) {
             currentBitmap = null;
             activity.mainImage.setImageBitmap(activity.mainBitmap);
-            activity.changeMode(EditImageActivity.effectType / 100);
             activity.changeBottomFragment(EditImageActivity.MODE_MAIN);
             activity.mainImage.setScaleEnabled(true);
 
-            switch (activity.mode)
+            switch (activity.middleMode)
             {
                 case EditImageActivity.MODE_FILTERS:
                     activity.filterFragment.clearCurrentSelection();

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
@@ -151,7 +151,6 @@ public class StickersFragment extends BaseEditFragment implements View.OnClickLi
 
     public void backToMain(){
         activity.mainImage.setImageBitmap(activity.mainBitmap);
-        activity.changeMode(EditImageActivity.MODE_STICKER_TYPES);
         activity.stickerTypesFragment.clearCurrentSelection();
         activity.stickersFragment.getmStickerView().clear();
         activity.stickersFragment.getmStickerView().setVisibility(View.GONE);

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/TwoItemFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/TwoItemFragment.java
@@ -18,6 +18,7 @@ public class TwoItemFragment extends BaseEditFragment implements View.OnClickLis
     LinearLayout ll_item1, ll_item2;
     ImageView icon1,icon2;
     TextView text1,text2;
+    private boolean item1Clicked, item2Clicked;
     int mode;
     public TwoItemFragment() {
 
@@ -32,6 +33,11 @@ public class TwoItemFragment extends BaseEditFragment implements View.OnClickLis
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        if (savedInstanceState != null) {
+            item1Clicked = savedInstanceState.getBoolean("ITEM1", false);
+            item2Clicked = savedInstanceState.getBoolean("ITEM2", false);
+        }
+
     }
 
     @Override
@@ -66,6 +72,12 @@ public class TwoItemFragment extends BaseEditFragment implements View.OnClickLis
             text2.setText(getString(R.string.rotate));
         }
 
+        if (item1Clicked && !item2Clicked) {
+            ll_item1.setBackgroundColor(ContextCompat.getColor(view.getContext(), R.color.md_grey_200));
+        }else if (item2Clicked && !item1Clicked){
+            ll_item2.setBackgroundColor(ContextCompat.getColor(view.getContext(), R.color.md_grey_200));
+        }
+
         return view;
     }
 
@@ -85,11 +97,15 @@ public class TwoItemFragment extends BaseEditFragment implements View.OnClickLis
         switch (v.getId()){
             case R.id.menu_item1:
                 clearSelection();
+                item1Clicked = true;
+                item2Clicked = false;
                 ll_item1.setBackgroundColor(ContextCompat.getColor(v.getContext(), R.color.md_grey_200));
                 firstItemClicked();
                 break;
             case R.id.menu_item2:
                 clearSelection();
+                item1Clicked = false;
+                item2Clicked = true;
                 ll_item2.setBackgroundColor(ContextCompat.getColor(v.getContext(), R.color.md_grey_200));
                 secondItemClicked();
                 break;
@@ -122,4 +138,10 @@ public class TwoItemFragment extends BaseEditFragment implements View.OnClickLis
         }
     }
 
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putBoolean("ITEM1", item1Clicked);
+        outState.putBoolean("ITEM2", item2Clicked);
+    }
 }


### PR DESCRIPTION
Fixed #2209 

Changes: [There are different issues in the EditImageActivity due to the orientation either it is app crash or it may differ the layout changes so what i added to prevent it from app crash as well as layout changes , i added two variable to handle two different fragment.
1. middleMode 
2. bottomMode 
These two will  handle all the fragment in the EditImageActivity, previously EditImageActivity  has only one variable name mode which handles both work so many times changes in mode affect both fragments in the EditImageActivity. ]

Screenshots of the change: 

![whatsapp image 2018-10-12 at 1 40 14 am](https://user-images.githubusercontent.com/22986571/46831071-f81e8f00-cdbf-11e8-97e6-762a5683a8e5.jpeg)

