### PR TITLE
Fixed#2257 App does not crash on clicking DropBox icon

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
@@ -17,6 +17,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.RelativeLayout;
+import android.widget.Toast;
 
 import com.box.androidsdk.content.BoxConfig;
 import com.box.androidsdk.content.auth.BoxAuthentication;
@@ -271,6 +272,11 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
                     break;
 
                 case DROPBOX:
+                    if(CLOUDRAIL_APP_KEY==null || CLOUDRAIL_APP_KEY=="")
+                    {
+                        Toast.makeText(getContext(),R.string.Cloudrail_License_key,Toast.LENGTH_SHORT).show();
+                    }
+                    else
                     signInDropbox();
                     break;
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1027,7 +1027,7 @@
     <string name="first_click">first click</string>
     <string name="account_logged_twitter">Twitter account logged in successfully.</string>
     <string name="twitter_uploading">Image uploading on Twitter</string>
-
+    <string name="Cloudrail_License_key">Cloudrail License key not found</string>
     <!--App shortcuts-->
     <string name="camera_short">Camera</string>
     <string name="camera_long">Opens Phimp.me Camera</string>


### PR DESCRIPTION
Fixed #2257 
Added my personal Cloudrails LICENSE KEY and tested the App. It works pretty good.  
So I just preventing the crash causing call using an if else statement and added a Toast message.

Screenshots of the change: 
![70d29e37-6d65-45d1-b358-3cd138e1fb25 1](https://user-images.githubusercontent.com/37406965/47931564-2db52480-def5-11e8-840a-998a88ab7314.jpg)
