### PR TITLE
Fixed#2268 The set password dialog box now shows alerts 

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -19,7 +19,6 @@ import android.text.InputType;
 import android.text.TextWatcher;
 import android.text.method.HideReturnsTransformationMethod;
 import android.text.method.PasswordTransformationMethod;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;


### PR DESCRIPTION
Fixed #2268 
The set password dialog box now shows alerts if password is too small or does not match ConfirmPassword
Changes: Added the set Error method to the Edit text views so that whenever changes are made these conditions are met.

Screenshots of the change: 
![b43e6e69-f6f7-46ca-ae1f-97f6fb21ef19](https://user-images.githubusercontent.com/37406965/48078266-1173f900-e20f-11e8-8078-98083eb68783.jpg)

![397c4a70-5428-4172-89db-c5e935bde427](https://user-images.githubusercontent.com/37406965/48078272-13d65300-e20f-11e8-9242-4297060d5c8d.jpg)
