### PR TITLE
Fixed#2271 Added the button tint list attribute to checkbox

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
@@ -1,6 +1,7 @@
 package org.fossasia.phimpme.gallery.util;
 
 import android.content.Context;
+import android.content.res.ColorStateList;
 import android.graphics.PorterDuff;
 import android.support.design.widget.TextInputLayout;
 import android.support.v7.app.AlertDialog;
@@ -75,6 +76,7 @@ public class SecurityHelper {
         passwordTextInputLayout.setError(context.getString(R.string.wrong_password));
         CheckBox checkBox = (CheckBox) PasswordDialogLayout.findViewById(R.id.show_password_checkbox);
         checkBox.setText(context.getResources().getString(R.string.show_password));
+        checkBox.setButtonTintList(ColorStateList.valueOf(activity.getAccentColor()));
         checkBox.setTextColor(activity.getTextColor());
         editxtPassword.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
         checkBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {


### PR DESCRIPTION
Fixed #2271 
Added the button tint list attribute to checkbox and called the accent color from theme.

**Screenshots of the change:** 
![8f57cdfa-49cd-4eff-9268-f11bf111891c](https://user-images.githubusercontent.com/37406965/48080330-6580dc80-e213-11e8-96b1-91a28bd37b1a.jpg)

