### PR TITLE
Fixed #2226 Actionbar hidden on second screen when scrolls down in first screen 

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -617,6 +617,7 @@ public class LFMainActivity extends SharedMediaActivity {
         public void onClick(View v) {
             fromOnClick = true;
             final Album album = (Album) v.findViewById(R.id.album_name).getTag();
+            showAppBar();
             //int index = Integer.parseInt(v.findViewById(R.id.album_name).getTag().toString());
             if (editMode) {
                 albumsAdapter.notifyItemChanged(getAlbums().toggleSelectAlbum(album));
@@ -713,6 +714,12 @@ public class LFMainActivity extends SharedMediaActivity {
         AppBarLayout.LayoutParams params = (AppBarLayout.LayoutParams) toolbar.getLayoutParams();
         params.setScrollFlags(AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
                 | AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS);
+    }
+
+    private void showAppBar() {
+        if (toolbar.getParent() instanceof AppBarLayout) {
+            ((AppBarLayout)toolbar.getParent()).setExpanded(true, true);
+        }
     }
 
     public int getImagePosition(String path) {


### PR DESCRIPTION
Fixed #2226 

Changes: [Added a new method for showing the toolbar when it goes from album to photos screen]

GIF of the change: 

<img src = "https://user-images.githubusercontent.com/22986571/48297211-efa59b00-e4c8-11e8-9015-55cc63977afa.gif" width = 250 height = 400>

