### PR TITLE
Fix for issue #2213 : No message is shown while setting password

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -327,6 +327,12 @@ public class SecurityActivity extends ThemedActivity {
                         securityObj.updateSecuritySetting();
                         SnackBarHandler.show(llroot, R.string.remember_password_message);
                         changed = true;
+                        Toast toast=Toast.makeText(getApplicationContext(), "Password Set", Toast.LENGTH_SHORT);
+                        View view = toast.getView();
+                        view.setBackgroundResource(R.drawable.custom_background);
+                        TextView text = (TextView) view.findViewById(android.R.id.message);
+                        text.setTextColor(Color.parseColor("#ffffff"));
+                        toast.show();
                     } else
                         SnackBarHandler.show(llroot, R.string.password_dont_match);
                 } else
@@ -427,6 +433,12 @@ public class SecurityActivity extends ThemedActivity {
                             SP.putString(getString(R.string.preference_password_value), editTextPassword.getText().toString());
                             securityObj.updateSecuritySetting();
                             SnackBarHandler.show(llroot, R.string.remember_password_message);
+                            Toast toast=Toast.makeText(getApplicationContext(), "Password Changed", Toast.LENGTH_SHORT);
+                            View view = toast.getView();
+                            view.setBackgroundResource(R.drawable.custom_background);
+                            TextView text = (TextView) view.findViewById(android.R.id.message);
+                            text.setTextColor(Color.parseColor("#ffffff"));
+                            toast.show();
                         } else
                            SnackBarHandler.show(llroot, R.string.error_password_match);
                     } else

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -327,12 +327,8 @@ public class SecurityActivity extends ThemedActivity {
                         securityObj.updateSecuritySetting();
                         SnackBarHandler.show(llroot, R.string.remember_password_message);
                         changed = true;
-                        Toast toast=Toast.makeText(getApplicationContext(), "Password Set", Toast.LENGTH_SHORT);
-                        View view = toast.getView();
-                        view.setBackgroundResource(R.drawable.custom_background);
-                        TextView text = (TextView) view.findViewById(android.R.id.message);
-                        text.setTextColor(Color.parseColor("#ffffff"));
-                        toast.show();
+                        Toast.makeText(getApplicationContext(), "Password Set", Toast.LENGTH_SHORT)
+                                .show();
                     } else
                         SnackBarHandler.show(llroot, R.string.password_dont_match);
                 } else
@@ -433,12 +429,8 @@ public class SecurityActivity extends ThemedActivity {
                             SP.putString(getString(R.string.preference_password_value), editTextPassword.getText().toString());
                             securityObj.updateSecuritySetting();
                             SnackBarHandler.show(llroot, R.string.remember_password_message);
-                            Toast toast=Toast.makeText(getApplicationContext(), "Password Changed", Toast.LENGTH_SHORT);
-                            View view = toast.getView();
-                            view.setBackgroundResource(R.drawable.custom_background);
-                            TextView text = (TextView) view.findViewById(android.R.id.message);
-                            text.setTextColor(Color.parseColor("#ffffff"));
-                            toast.show();
+                           Toast.makeText(getApplicationContext(), "Password Changed", Toast.LENGTH_SHORT)
+                                   .show();
                         } else
                            SnackBarHandler.show(llroot, R.string.error_password_match);
                     } else

--- a/app/src/main/res/drawable/custom_background.xml
+++ b/app/src/main/res/drawable/custom_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <solid android:color="#000000" />
+
+</shape>

--- a/app/src/main/res/drawable/custom_background.xml
+++ b/app/src/main/res/drawable/custom_background.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" >
-
-    <solid android:color="#000000" />
-
-</shape>


### PR DESCRIPTION
Fixed #2213 

Changes:Now a message is shown when password is set or changed.

Screenshots of the change: 

![screen6cap](https://user-images.githubusercontent.com/41234408/48909671-e5ee4100-ee93-11e8-90c8-da8b9adb9db3.png)
