### PR TITLE
Fix for #2289 :A message is shown when password is removed

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -100,6 +100,8 @@ public class SecurityActivity extends ThemedActivity {
                     editor.putBoolean(getString(R.string.preference_use_password), false);
                     editor.commit();
                     toggleEnabledChild(false);
+                    Toast.makeText(getApplicationContext(), "No Password Set", Toast.LENGTH_SHORT)
+                            .show();
                 }
             }
         });


### PR DESCRIPTION
Fixed #2289 

Changes: When a set password is removed, a message is shown to the user indicating that the password has been removed.

Gif of the change: 
![password](https://user-images.githubusercontent.com/41234408/48969807-e6204500-f029-11e8-811b-da29d0aa7984.gif)
