### PR TITLE
fix #2281-SMS permission issue resolved

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -120,7 +120,7 @@ dependencies {
     /*compile('com.crashlytics.sdk.android:crashlytics:2.9.3@aar') {
         transitive = true;
     }*/
-    compile 'com.daksh:loglr:1.2.1'
+
     compile 'com.koushikdutta.ion:ion:2.1.7'
     compile 'org.jetbrains:annotations-java5:15.0'
     compile 'com.android.support:multidex:1.0.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
           package="org.fossasia.phimpme"
           android:versionCode="6"
           android:versionName="1.2.0">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_SMS"
+        tools:node="remove"/>
+    <uses-permission android:name="android.permission.RECEIVE_SMS"
+        tools:node="remove"/>
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
@@ -28,9 +28,9 @@ import com.pinterest.android.pdk.PDKCallback;
 import com.pinterest.android.pdk.PDKClient;
 import com.pinterest.android.pdk.PDKException;
 import com.pinterest.android.pdk.PDKResponse;
-import com.tumblr.loglr.Interfaces.ExceptionHandler;
-import com.tumblr.loglr.Interfaces.LoginListener;
-import com.tumblr.loglr.Loglr;
+//import com.tumblr.loglr.Interfaces.ExceptionHandler;
+//import com.tumblr.loglr.Interfaces.LoginListener;
+//import com.tumblr.loglr.Loglr;
 import com.twitter.sdk.android.core.identity.TwitterAuthClient;
 
 import org.fossasia.phimpme.R;
@@ -288,7 +288,7 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
                     break;
 
                 case TUMBLR:
-                    signInTumblr();
+                    //signInTumblr();
                     break;
 
                 /*case ONEDRIVE:
@@ -340,7 +340,7 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
         startActivity(intent);
     }
 
-    private void signInTumblr() {
+   /* private void signInTumblr() {
         LoginListener loginListener = new LoginListener() {
             @Override
             public void onLoginSuccessful(com.tumblr.loglr.LoginResult loginResult) {
@@ -379,7 +379,7 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
                 .enable2FA(true)
                 .setUrlCallBack(Constants.CALL_BACK_TUMBLR)
                 .initiateInActivity(AccountActivity.this);
-    }
+    }*/
 
     private void signInDropbox() {
         if (accountPresenter.checkAlreadyExist(DROPBOX))


### PR DESCRIPTION
Fixed #2281 

Changes: Removed library Loglr. The library Loglr declared for the purpose of Tumblr authentication was adding SMS permissions at build time. 


