### PR TITLE
fix: Phimpme logo in navigation drawer overlaps status bar

### DIFF
--- a/app/src/main/res/layout/activity_drawer.xml
+++ b/app/src/main/res/layout/activity_drawer.xml
@@ -24,7 +24,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="160dp"
                 android:elevation="@dimen/card_elevation"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:paddingTop="@dimen/medium_spacing">
 
                 <ImageView
                     android:layout_width="match_parent"


### PR DESCRIPTION
Fixed #2321 

Changes:  paddingTop was added to the layout enclosing the concerned ImageView.

Screenshots of the change: 

<table>
  <tr>
    <th>Before Change</th>
    <th>After Change</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/25201519/50416046-7a0d4880-0844-11e9-9f66-1ae5d0bd7083.jpeg" width="300"></td>
    <td><img src="https://user-images.githubusercontent.com/25201519/50416045-7a0d4880-0844-11e9-9c00-e2140477b458.jpeg" width="300"></td>
  </tr>
</table>



