### PR TITLE
fix#2333 forgot password alignment issue

### DIFF
--- a/app/src/main/res/layout/dialog_password.xml
+++ b/app/src/main/res/layout/dialog_password.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/vn.mbm.phimp.me"
+    xmlns:app1="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app1="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical">
 
     <android.support.v7.widget.CardView
@@ -37,8 +37,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:paddingTop="15dp"
                     android:paddingLeft="15dp"
+                    android:paddingTop="15dp"
                     android:paddingRight="15dp">
 
                     <android.support.design.widget.TextInputLayout
@@ -63,24 +63,30 @@
 
                 </RelativeLayout>
 
-                <CheckBox android:id="@+id/show_password_checkbox"
+                <RelativeLayout
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="30dp"
-                    android:buttonTint="@color/md_black_1000"
-                    android:text="@string/show_password" />
+                    android:layout_height="wrap_content">
 
-                <TextView
-                    android:id="@+id/forgot_password_button"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/forgot_password"
-                    android:layout_marginLeft="62dp"
-                    android:textColor="@color/md_black_1000"
-                    android:textSize="13.5dp"
-                    />
+                    <CheckBox
+                        android:id="@+id/show_password_checkbox"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="30dp"
+                        android:buttonTint="@color/md_black_1000"
+                        android:text="@string/show_password" />
 
-                </LinearLayout>
+                    <TextView
+                        android:id="@+id/forgot_password_button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_centerVertical="true"
+                        android:layout_marginLeft="15dp"
+                        android:layout_toRightOf="@id/show_password_checkbox"
+                        android:text="@string/forgot_password"
+                        android:textColor="@color/md_black_1000"
+                        android:textSize="14dp" />
+                </RelativeLayout>
+            </LinearLayout>
 
         </ScrollView>
     </android.support.v7.widget.CardView>


### PR DESCRIPTION
Fixed #2333 

Changes: 
forgot password is now aligned on the side of show password checkbox.

Screenshots of the change: 
![whatsapp image 2018-12-25 at 19 14 57](https://user-images.githubusercontent.com/31561661/50423307-ac856880-0879-11e9-8987-adbc344f6df6.jpeg)
