### PR TITLE
password edit field hint changed to new password

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -301,10 +301,12 @@ public class SecurityActivity extends ThemedActivity {
 
         editTextPassword.getBackground().mutate().setColorFilter(getTextColor(), PorterDuff.Mode.SRC_ATOP);
         editTextPassword.setTextColor(getTextColor());
+        editTextPassword.setHint(R.string.password);
         editTextPassword.setHintTextColor(getSubTextColor());
         setCursorDrawableColor(editTextPassword, getTextColor());
         editTextConfirmPassword.getBackground().mutate().setColorFilter(getTextColor(), PorterDuff.Mode.SRC_ATOP);
         editTextConfirmPassword.setTextColor(getTextColor());
+        editTextConfirmPassword.setHint(R.string.confirm_password);
         editTextConfirmPassword.setHintTextColor(getSubTextColor());
         setCursorDrawableColor(editTextConfirmPassword, getTextColor());
         securityAnswer1.getBackground().mutate().setColorFilter(getTextColor(), PorterDuff.Mode.SRC_ATOP);
@@ -431,10 +433,12 @@ public class SecurityActivity extends ThemedActivity {
         passwordDialogCard.setBackgroundColor(getCardBackgroundColor());
         editTextPassword.getBackground().mutate().setColorFilter(getTextColor(), PorterDuff.Mode.SRC_ATOP);
         editTextPassword.setTextColor(getTextColor());
+        editTextPassword.setHint(R.string.new_password);
         editTextPassword.setHintTextColor(getSubTextColor());
         setCursorDrawableColor(editTextPassword, getTextColor());
         editTextConfirmPassword.getBackground().mutate().setColorFilter(getTextColor(), PorterDuff.Mode.SRC_ATOP);
         editTextConfirmPassword.setTextColor(getTextColor());
+        editTextConfirmPassword.setHint(R.string.confirm_new_password);
         editTextConfirmPassword.setHintTextColor(getSubTextColor());
         setCursorDrawableColor(editTextConfirmPassword, getTextColor());
         securityAnswer1.getBackground().mutate().setColorFilter(getTextColor(), PorterDuff.Mode.SRC_ATOP);

--- a/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
@@ -263,10 +263,12 @@ public class SecurityHelper {
         passwordDialogCard.setBackgroundColor(activity.getCardBackgroundColor());
         editTextPassword.getBackground().mutate().setColorFilter(activity.getTextColor(), PorterDuff.Mode.SRC_ATOP);
         editTextPassword.setTextColor(activity.getTextColor());
+        editTextPassword.setHint(R.string.new_password);
         editTextPassword.setHintTextColor(activity.getSubTextColor());
         activity.setCursorDrawableColor(editTextPassword, activity.getTextColor());
         editTextConfirmPassword.getBackground().mutate().setColorFilter(activity.getTextColor(), PorterDuff.Mode.SRC_ATOP);
         editTextConfirmPassword.setTextColor(activity.getTextColor());
+        editTextConfirmPassword.setHint(R.string.confirm_new_password);
         editTextConfirmPassword.setHintTextColor(activity.getSubTextColor());
         activity.setCursorDrawableColor(editTextConfirmPassword, activity.getTextColor());
         securityAnswer1.getBackground().mutate().setColorFilter(activity.getTextColor(), PorterDuff.Mode.SRC_ATOP);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -724,11 +724,13 @@
     <string name="security">Security</string>
     <string name="active_security">Access by password</string>
     <string name="password">Password</string>
+    <string name="new_password">New Password</string>
     <string name="forgot_password">Forgot Password</string>
     <string name="security_answer">Security Answer</string>
     <string name="security_question">Security Question</string>
     <string name="enter_password">Enter your password</string>
     <string name="confirm_password">Confirm password</string>
+    <string name="confirm_new_password">Confirm New password</string>
     <string name="wrong_password">Wrong password</string>
     <string name="show_password">Show Password</string>
 


### PR DESCRIPTION
Fixed #2338 

Changes: the edit field hint of password dialog was changed accordingly for initial setup and change password. 


Screenshots of the change: 
![whatsapp image 2018-12-27 at 23 40 16](https://user-images.githubusercontent.com/31561661/50490110-67a43200-0a31-11e9-974b-65ea548a4532.jpeg)

![whatsapp image 2018-12-26 at 15 15 24](https://user-images.githubusercontent.com/31561661/50441529-258bcb00-0921-11e9-9581-6ed48a4f507e.jpeg)
