### PR TITLE
Fix for issue#2339 : Forgot password text color made same as show password.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -234,6 +234,7 @@ public class SecurityActivity extends ThemedActivity {
         final AlertDialog.Builder passwordDialog = new AlertDialog.Builder(SecurityActivity.this, getDialogStyle());
         final View PasswordDialogLayout = getLayoutInflater().inflate(R.layout.dialog_set_password, null);
         final TextView passwordDialogTitle = (TextView) PasswordDialogLayout.findViewById(R.id.password_dialog_title);
+        final TextView security_title = (TextView) PasswordDialogLayout.findViewById(R.id.security_question_title);
         final CheckBox checkBox = (CheckBox) PasswordDialogLayout.findViewById(R.id.set_password_checkbox);
         checkBox.setText(getResources().getString(R.string.show_password));
         checkBox.setTextColor(getTextColor());
@@ -298,7 +299,6 @@ public class SecurityActivity extends ThemedActivity {
         passwordDialogTitle.setText(R.string.type_password);
         passwordDialogTitle.setBackgroundColor(getPrimaryColor());
         passwordDialogCard.setBackgroundColor(getCardBackgroundColor());
-
         editTextPassword.getBackground().mutate().setColorFilter(getTextColor(), PorterDuff.Mode.SRC_ATOP);
         editTextPassword.setTextColor(getTextColor());
         editTextPassword.setHintTextColor(getSubTextColor());
@@ -307,6 +307,7 @@ public class SecurityActivity extends ThemedActivity {
         editTextConfirmPassword.setTextColor(getTextColor());
         editTextConfirmPassword.setHintTextColor(getSubTextColor());
         setCursorDrawableColor(editTextConfirmPassword, getTextColor());
+        security_title.setTextColor(getTextColor());
         securityAnswer1.getBackground().mutate().setColorFilter(getTextColor(), PorterDuff.Mode.SRC_ATOP);
         securityAnswer1.setTextColor(getTextColor());
         securityAnswer1.setHintTextColor(getSubTextColor());
@@ -373,6 +374,7 @@ public class SecurityActivity extends ThemedActivity {
         final AlertDialog.Builder passwordDialog = new AlertDialog.Builder(SecurityActivity.this, getDialogStyle());
         final View PasswordDialogLayout = getLayoutInflater().inflate(R.layout.dialog_set_password, null);
         final TextView passwordDialogTitle = (TextView) PasswordDialogLayout.findViewById(R.id.password_dialog_title);
+        final TextView security_title = (TextView) PasswordDialogLayout.findViewById(R.id.security_question_title);
         CheckBox checkBox = (CheckBox) PasswordDialogLayout.findViewById(R.id.set_password_checkbox);
         checkBox.setText(getResources().getString(R.string.show_password));
         checkBox.setTextColor(getTextColor());
@@ -437,6 +439,7 @@ public class SecurityActivity extends ThemedActivity {
         editTextConfirmPassword.setTextColor(getTextColor());
         editTextConfirmPassword.setHintTextColor(getSubTextColor());
         setCursorDrawableColor(editTextConfirmPassword, getTextColor());
+        security_title.setTextColor(getTextColor());
         securityAnswer1.getBackground().mutate().setColorFilter(getTextColor(), PorterDuff.Mode.SRC_ATOP);
         securityAnswer1.setTextColor(getTextColor());
         securityAnswer1.setHintTextColor(getSubTextColor());

--- a/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
@@ -100,6 +100,7 @@ public class SecurityHelper {
         checkBox.setText(context.getResources().getString(R.string.show_password));
         checkBox.setButtonTintList(ColorStateList.valueOf(activity.getAccentColor()));
         checkBox.setTextColor(activity.getTextColor());
+        forgot_password.setTextColor(activity.getTextColor());
         editxtPassword.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
         checkBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
@@ -150,6 +151,7 @@ public class SecurityHelper {
         passwordDialogTitle.setBackgroundColor(activity.getPrimaryColor());
         passwordDialogCard.setBackgroundColor(activity.getCardBackgroundColor());
         securityQuestion.setText(question);
+        securityQuestion.setTextColor(activity.getTextColor());
         securityAnswer1.getBackground().mutate().setColorFilter(activity.getTextColor(), PorterDuff.Mode.SRC_ATOP);
         securityAnswer1.setTextColor(activity.getTextColor());
         securityAnswer1.setHintTextColor(activity.getSubTextColor());
@@ -195,6 +197,7 @@ public class SecurityHelper {
         final PreferenceUtil SP = PreferenceUtil.getInstance(context);
         final View PasswordDialogLayout = activity.getLayoutInflater().inflate(R.layout.dialog_set_password, null);
         final TextView passwordDialogTitle = (TextView) PasswordDialogLayout.findViewById(R.id.password_dialog_title);
+        final TextView security_title = (TextView) PasswordDialogLayout.findViewById(R.id.security_question_title);
         CheckBox checkBox = (CheckBox) PasswordDialogLayout.findViewById(R.id.set_password_checkbox);
         checkBox.setText(activity.getResources().getString(R.string.show_password));
         checkBox.setTextColor(activity.getTextColor());
@@ -269,6 +272,7 @@ public class SecurityHelper {
         editTextConfirmPassword.setTextColor(activity.getTextColor());
         editTextConfirmPassword.setHintTextColor(activity.getSubTextColor());
         activity.setCursorDrawableColor(editTextConfirmPassword, activity.getTextColor());
+        security_title.setTextColor(activity.getTextColor());
         securityAnswer1.getBackground().mutate().setColorFilter(activity.getTextColor(), PorterDuff.Mode.SRC_ATOP);
         securityAnswer1.setTextColor(activity.getTextColor());
         securityAnswer1.setHintTextColor(activity.getSubTextColor());

--- a/app/src/main/res/layout/dialog_password.xml
+++ b/app/src/main/res/layout/dialog_password.xml
@@ -83,7 +83,6 @@
                         android:layout_marginLeft="15dp"
                         android:layout_toRightOf="@id/show_password_checkbox"
                         android:text="@string/forgot_password"
-                        android:textColor="@color/md_black_1000"
                         android:textSize="14dp" />
                 </RelativeLayout>
             </LinearLayout>

--- a/app/src/main/res/layout/dialog_set_password.xml
+++ b/app/src/main/res/layout/dialog_set_password.xml
@@ -62,6 +62,7 @@
                               android:layout_marginStart="13dp"/>
 
                     <TextView
+                        android:id="@+id/security_question_title"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="10dp"


### PR DESCRIPTION
Fixed #2339 

Changes: Forgot password text color is now the same as show password and the color also changes according to the theme.

Screenshots of the change: 
![screencap](https://user-images.githubusercontent.com/41234408/50441930-ef4f4b00-0922-11e9-9ab8-207326858768.png)
![screencap1](https://user-images.githubusercontent.com/41234408/50441946-f24a3b80-0922-11e9-880a-56990a332774.png)
![screencap2](https://user-images.githubusercontent.com/41234408/50441951-f4ac9580-0922-11e9-9a3a-b8f8b85cccf2.png)
