### PR TITLE
Fix for issue#2214 : Alerts are shown when password parameters are incorrect.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -24,6 +24,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
+import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.EditText;
@@ -317,7 +318,7 @@ public class SecurityActivity extends ThemedActivity {
         setCursorDrawableColor(securityQuestion, getTextColor());
         passwordDialog.setView(PasswordDialogLayout);
 
-        AlertDialog dialog = passwordDialog.create();
+        final AlertDialog dialog = passwordDialog.create();
         dialog.setCancelable(false);
 
         dialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.cancel).toUpperCase(), new DialogInterface.OnClickListener() {
@@ -325,46 +326,60 @@ public class SecurityActivity extends ThemedActivity {
             public void onClick(DialogInterface dialog, int which) {
                 swActiveSecurity.setChecked(false);
                 SP.putBoolean(getString(R.string.preference_use_password), false);
+                dialog.dismiss();
             }
         });
 
-        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                boolean changed = false;
-
-                if (editTextPassword.length() > 3) {
-                    if (editTextPassword.getText().toString().equals(editTextConfirmPassword.getText().toString())) {
-                        if(securityQuestion.getText().length() == 0){
-                            Toast.makeText(getApplicationContext(), "Please enter security question", Toast.LENGTH_SHORT)
-                                    .show();
-                        }
-                        if (securityAnswer1.getText().length() == 0) {
-                            Toast.makeText(getApplicationContext(), "Security question cannot be empty.", Toast.LENGTH_SHORT)
-                                    .show();
-                        } else {
-                            SP.putString(getString(R.string.preference_password_value), editTextPassword.getText().toString());
-                            SP.putString(getString(R.string.security_question), securityQuestion.getText().toString());
-                            SP.putString(getString(R.string.security_answer), securityAnswer1.getText().toString());
-                            securityObj.updateSecuritySetting();
-                            SnackBarHandler.show(llroot, R.string.remember_password_message);
-                            changed = true;
-                            Toast.makeText(getApplicationContext(), "Password Set", Toast.LENGTH_SHORT)
-                                    .show();
-                        }
-
-                    } else
-                        SnackBarHandler.show(llroot, R.string.password_dont_match);
-                } else
-                    SnackBarHandler.show(llroot, R.string.error_password_length);
-
-                swActiveSecurity.setChecked(changed);
-                SP.putBoolean(getString(R.string.preference_use_password), changed);
-                toggleEnabledChild(changed);
-            }
-        });
-
+        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.ok_action).toUpperCase(), (DialogInterface.OnClickListener) null);
         dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+
+        dialog.setOnShowListener(new DialogInterface.OnShowListener() {
+            @Override
+            public void onShow(DialogInterface dialogInterface) {
+                Button b = dialog.getButton(AlertDialog.BUTTON_NEGATIVE);
+                b.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        boolean changed = false;
+
+                        if (editTextPassword.length() > 3) {
+                            if (editTextPassword.getText().toString().equals(editTextConfirmPassword.getText().toString())) {
+                                if (securityQuestion.getText().length() != 0) {
+                                    if (securityAnswer1.getText().length() != 0) {
+                                        SP.putString(getString(R.string.preference_password_value), editTextPassword.getText().toString());
+                                        SP.putString(getString(R.string.security_question), securityQuestion.getText().toString());
+                                        SP.putString(getString(R.string.security_answer), securityAnswer1.getText().toString());
+                                        securityObj.updateSecuritySetting();
+                                        SnackBarHandler.show(llroot, R.string.remember_password_message);
+                                        changed = true;
+                                        dialog.dismiss();
+                                        Toast.makeText(getApplicationContext(), "Password Set", Toast.LENGTH_SHORT)
+                                                .show();
+                                        swActiveSecurity.setChecked(changed);
+                                        SP.putBoolean(getString(R.string.preference_use_password), changed);
+                                        toggleEnabledChild(changed);
+                                    }else{
+                                        securityAnswer1.requestFocus();
+                                        securityAnswer1.setError(getString(R.string.security_ans_empty));
+                                    }
+                                }else{
+                                    securityQuestion.requestFocus();
+                                    securityQuestion.setError(getString(R.string.security_ques_empty));
+                                }
+                            } else{
+                                editTextConfirmPassword.requestFocus();
+                                editTextConfirmPassword.setError(getString(R.string.password_dont_match));
+                        }
+                    } else {
+                        editTextPassword.requestFocus();
+                        editTextPassword.setError(getString( R.string.error_password_length));
+                    }
+                    }
+                });
+            }
+
+            });
+
         dialog.show();
         AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, getAccentColor(), dialog);
     }
@@ -383,6 +398,7 @@ public class SecurityActivity extends ThemedActivity {
         final EditText securityAnswer1 = (EditText) PasswordDialogLayout.findViewById(R.id.security_answer_edittext);
         final EditText securityQuestion = (EditText) PasswordDialogLayout.findViewById(R.id.security_question_edittext);
         editTextConfirmPassword.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+        checkBox.setButtonTintList(ColorStateList.valueOf(getAccentColor()));
         checkBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
                 if(!b){
@@ -447,45 +463,60 @@ public class SecurityActivity extends ThemedActivity {
         setCursorDrawableColor(securityQuestion, getTextColor());
         passwordDialog.setView(PasswordDialogLayout);
 
-        AlertDialog dialog = passwordDialog.create();
+        final AlertDialog dialog = passwordDialog.create();
         dialog.setCancelable(false);
         dialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.cancel).toUpperCase(), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-             // nothing is done.
+                dialog.dismiss();
             }
         });
-        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                if (editTextPassword.length() > 3) {
-                   if (editTextPassword.getText().toString().equals(editTextConfirmPassword.getText().toString())) {
-                       if (!editTextPassword.getText().toString().equals(SP.getString(getString(R.string.preference_password_value),"")))   {
-                           if(securityQuestion.getText().length() == 0){
-                               Toast.makeText(getApplicationContext(), "Security question cannot be empty.", Toast.LENGTH_SHORT)
-                                       .show();
-                           }
-                           if (securityAnswer1.getText().length() == 0) {
-                               Toast.makeText(getApplicationContext(), "Security answer cannot be empty.", Toast.LENGTH_SHORT)
-                                       .show();
-                           } else {
-                               SP.putString(getString(R.string.preference_password_value), editTextPassword.getText().toString());
-                               SP.putString(getString(R.string.security_question), securityQuestion.getText().toString());
-                               SP.putString(getString(R.string.security_answer), securityAnswer1.getText().toString());
-                               SnackBarHandler.show(llroot, R.string.remember_password_message);
-                               securityObj.updateSecuritySetting();
-                               Toast.makeText(getApplicationContext(), "Password Changed", Toast.LENGTH_SHORT)
-                                       .show();
+         dialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.ok_action).toUpperCase(), (DialogInterface.OnClickListener) null);
+         dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+
+         dialog.setOnShowListener(new DialogInterface.OnShowListener() {
+             @Override
+             public void onShow(DialogInterface dialogInterface) {
+                 Button b = dialog.getButton(AlertDialog.BUTTON_NEGATIVE);
+                 b.setOnClickListener(new View.OnClickListener() {
+                     @Override
+                     public void onClick(View view) {
+
+                         if (editTextPassword.length() > 3) {
+                             if (editTextPassword.getText().toString().equals(editTextConfirmPassword.getText().toString())) {
+                                 if (securityQuestion.getText().length() != 0) {
+                                     if (securityAnswer1.getText().length() != 0) {
+                                         SP.putString(getString(R.string.preference_password_value), editTextPassword.getText().toString());
+                                         SP.putString(getString(R.string.security_question), securityQuestion.getText().toString());
+                                         SP.putString(getString(R.string.security_answer), securityAnswer1.getText().toString());
+                                         securityObj.updateSecuritySetting();
+                                         SnackBarHandler.show(llroot, R.string.remember_password_message);
+                                         dialog.dismiss();
+                                         Toast.makeText(getApplicationContext(), "Password Changed", Toast.LENGTH_SHORT)
+                                                 .show();
+
+                                         }else{
+                                         securityAnswer1.requestFocus();
+                                         securityAnswer1.setError(getString(R.string.security_ans_empty));
+                                     }
+                                 }else{
+                                     securityQuestion.requestFocus();
+                                     securityQuestion.setError(getString(R.string.security_ques_empty));
                                  }
-                       }else
-                           SnackBarHandler.show(llroot, R.string.error_password_match);
-                    } else
-                       SnackBarHandler.show(llroot, R.string.password_dont_match);
-                } else
-                    SnackBarHandler.show(llroot, R.string.error_password_length);
-            }
-        });
-        dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+                             } else{
+                                 editTextConfirmPassword.requestFocus();
+                                 editTextConfirmPassword.setError(getString(R.string.password_dont_match));
+                             }
+                         } else {
+                             editTextPassword.requestFocus();
+                             editTextPassword.setError(getString( R.string.error_password_length));
+                         }
+                     }
+                 });
+             }
+
+         });
+
         dialog.show();
         AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, getAccentColor(), dialog);
     }

--- a/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
@@ -14,6 +14,7 @@ import android.text.method.HideReturnsTransformationMethod;
 import android.text.method.PasswordTransformationMethod;
 import android.view.View;
 import android.view.WindowManager;
+import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.EditText;
@@ -140,6 +141,7 @@ public class SecurityHelper {
         final View PasswordDialogLayout = activity.getLayoutInflater().inflate(R.layout.dialog_forgot_password, null);
         final TextView passwordDialogTitle = (TextView) PasswordDialogLayout.findViewById(R.id.forgot_password_dialog_title);
         final TextView securityQuestion = (TextView) PasswordDialogLayout.findViewById(R.id.security_question);
+        securityQuestion.setTextColor(activity.getTextColor());
         final CardView passwordDialogCard = (CardView) PasswordDialogLayout.findViewById(R.id.forgot_password_dialog_card);
         final EditText securityAnswer1 = (EditText) PasswordDialogLayout.findViewById(R.id.password_edittxt);
         securityAnswer1.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PERSON_NAME);
@@ -279,47 +281,61 @@ public class SecurityHelper {
         activity.setCursorDrawableColor(securityQuestion, activity.getTextColor());
         passwordDialog.setView(PasswordDialogLayout);
 
-        AlertDialog dialogchange = passwordDialog.create();
-        dialogchange.setCancelable(false);
-        dialogchange.setButton(DialogInterface.BUTTON_POSITIVE, activity.getString(R.string.cancel).toUpperCase(), new DialogInterface.OnClickListener() {
+        final AlertDialog dialog = passwordDialog.create();
+        dialog.setCancelable(false);
+        dialog.setButton(DialogInterface.BUTTON_POSITIVE, activity.getString(R.string.cancel).toUpperCase(), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                // nothing is done.
+                dialog.dismiss();
             }
         });
-        dialogchange.setButton(DialogInterface.BUTTON_NEGATIVE, activity.getString(R.string.ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
+        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, activity.getString(R.string.ok_action).toUpperCase(), (DialogInterface.OnClickListener) null);
+        dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+
+        dialog.setOnShowListener(new DialogInterface.OnShowListener() {
             @Override
-            public void onClick(DialogInterface dialog, int which) {
-                if (editTextPassword.length() > 3) {
-                    if (editTextPassword.getText().toString().equals(editTextConfirmPassword.getText().toString())) {
-                        if (!editTextPassword.getText().toString().equals(SP.getString(activity.getString(R.string.preference_password_value), ""))) {
-                            if(securityQuestion.getText().length() == 0) {
-                                Toast.makeText(activity.getApplicationContext(), "Security question cannot be empty.", Toast.LENGTH_SHORT)
-                                        .show();
+            public void onShow(DialogInterface dialogInterface) {
+                Button b = dialog.getButton(AlertDialog.BUTTON_NEGATIVE);
+                b.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+
+                        if (editTextPassword.length() > 3) {
+                            if (editTextPassword.getText().toString().equals(editTextConfirmPassword.getText().toString())) {
+                                if (securityQuestion.getText().length() != 0) {
+                                    if (securityAnswer1.getText().length() != 0) {
+                                        SP.putString(activity.getString(R.string.preference_password_value), editTextPassword.getText().toString());
+                                        SP.putString(activity.getString(R.string.security_question), securityQuestion.getText().toString());
+                                        SP.putString(activity.getString(R.string.security_answer), securityAnswer1.getText().toString());
+                                        SnackBarHandler.show(activity.findViewById(android.R.id.content), R.string.remember_password_message);
+                                        updateSecuritySetting();
+                                        dialog.dismiss();
+                                        Toast.makeText(activity.getApplicationContext(), "Password Reset", Toast.LENGTH_SHORT)
+                                                .show();
+                                    }else{
+                                        securityAnswer1.requestFocus();
+                                        securityAnswer1.setError(activity.getString(R.string.security_ans_empty));
+                                    }
+                                }else{
+                                    securityQuestion.requestFocus();
+                                    securityQuestion.setError(activity.getString(R.string.security_ques_empty));
+                                }
+                            } else{
+                                editTextConfirmPassword.requestFocus();
+                                editTextConfirmPassword.setError(activity.getString(R.string.password_dont_match));
                             }
-                            if (securityAnswer1.getText().length() == 0) {
-                                Toast.makeText(activity.getApplicationContext(), "Security answer cannot be empty.", Toast.LENGTH_SHORT)
-                                        .show();
-                            } else {
-                                SP.putString(activity.getString(R.string.preference_password_value), editTextPassword.getText().toString());
-                                SP.putString(activity.getString(R.string.security_question), securityQuestion.getText().toString());
-                                SP.putString(activity.getString(R.string.security_answer), securityAnswer1.getText().toString());
-                                SnackBarHandler.show(activity.findViewById(android.R.id.content), R.string.remember_password_message);
-                                updateSecuritySetting();
-                                Toast.makeText(activity.getApplicationContext(), "Password Reset", Toast.LENGTH_SHORT)
-                                        .show();
-                            }
-                        } else
-                            SnackBarHandler.show(activity.findViewById(android.R.id.content), R.string.error_password_match);
-                    } else
-                        SnackBarHandler.show(activity.findViewById(android.R.id.content), R.string.password_dont_match);
-                } else
-                    SnackBarHandler.show(activity.findViewById(android.R.id.content), R.string.error_password_length);
+                        } else {
+                            editTextPassword.requestFocus();
+                            editTextPassword.setError(activity.getString( R.string.error_password_length));
+                        }
+                    }
+                });
             }
+
         });
-        dialogchange.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
-        dialogchange.show();
-        AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, activity.getAccentColor(), dialogchange);
+
+        dialog.show();
+        AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, activity.getAccentColor(), dialog);
     }
 
     public String[] getSecuredfolders() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -731,6 +731,8 @@
     <string name="confirm_password">Confirm password</string>
     <string name="wrong_password">Wrong password</string>
     <string name="show_password">Show Password</string>
+    <string name="security_ans_empty">Security Answer cannot be empty</string>
+    <string name="security_ques_empty">Security Question cannot be empty</string>
 
     <string name="type_password">Insert password</string>
     <string name="change_password">Change password</string>


### PR DESCRIPTION
Fixed #2214 

Changes: Whenever a password is being set or being changed, alerts are shown if fields are not filled appropriately.

Screenshots of the change: 

![screencap](https://user-images.githubusercontent.com/41234408/50450712-9fd64280-0955-11e9-9267-4139495e8da9.png)
![screencap1](https://user-images.githubusercontent.com/41234408/50450719-ac5a9b00-0955-11e9-8c9f-afa39adcac97.png)
![screencap2](https://user-images.githubusercontent.com/41234408/50450723-b1b7e580-0955-11e9-879e-d58d0db3dcde.png)
![screencap34](https://user-images.githubusercontent.com/41234408/50451816-681ec900-095c-11e9-8933-f1f894d0cc7e.png)
