### PR TITLE
Fix for issue#2353 : Forgot password edittext now does not have any limit.

### DIFF
--- a/app/src/main/res/layout/dialog_forgot_password.xml
+++ b/app/src/main/res/layout/dialog_forgot_password.xml
@@ -46,7 +46,6 @@
                         android:id="@+id/password_edittxt"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:maxLength="11"
                         android:layout_marginStart="10dp"
                         android:layout_marginEnd="10dp"
                         android:hint="Enter answer here"


### PR DESCRIPTION
Fixed #2353 

Changes: There is no limit on length of security answer when forgot password button is pressed.
