### PR TITLE
Fix for issue#2369 : Secure folders is not cancelled by outside touches.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -192,6 +192,7 @@ public class SecurityActivity extends ThemedActivity {
                         }
                     });
                     ad.show();
+                    ad.setCanceledOnTouchOutside(false);
                     ad.getButton(DialogInterface.BUTTON_NEGATIVE).setTextColor(getAccentColor());
                     ad.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor(getAccentColor());
                 }else{


### PR DESCRIPTION
Fixed #2369 

Changes: Now the secure local folders dialog can only be closed by pressing cancel or ok. Hence the app does not crash anymore if the dialog is closed without choosing any folders to secure.

Screenshots of the change: 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/41234408/50887206-91d5f680-1418-11e9-9117-f5cda7f68285.gif)
