### PR TITLE
Fix for issue#2369: Secure local folders dialog does does not close on touching outside.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -192,6 +192,7 @@ public class SecurityActivity extends ThemedActivity {
                         }
                     });
                     ad.show();
+                    ad.setCanceledOnTouchOutside(false);
                     ad.getButton(DialogInterface.BUTTON_NEGATIVE).setTextColor(getAccentColor());
                     ad.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor(getAccentColor());
                 }else{


### PR DESCRIPTION
Fixed #2369 
Changes: Now the secure folders dialog closes only if ok or cancel buttons are pressed. Hence the app also does not crash. 
GIF of the change: 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/41234408/50892983-d0be7900-1425-11e9-8a97-338c7ec8e9eb.gif)
