### PR TITLE
Fix for issue#2369: Prevented dialog from closing on outside touch.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -192,6 +192,7 @@ public class SecurityActivity extends ThemedActivity {
                         }
                     });
                     ad.show();
+                    ad.setCanceledOnTouchOutside(false);
                     ad.getButton(DialogInterface.BUTTON_NEGATIVE).setTextColor(getAccentColor());
                     ad.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor(getAccentColor());
                 }else{


### PR DESCRIPTION
Fixed #2369 

Changes:Secure local folder dialog cannot be closed if the user taps the screen anywhere outside the dialog. Hence the app also doesn't crash anymore. 

GIF of the change: 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/41234408/50970249-e061be80-1506-11e9-8efe-cdd83ea02f54.gif)
