### PR TITLE
Fix for issue#2349: An error is shown when forgot password answer is wrong.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
@@ -144,8 +144,26 @@ public class SecurityHelper {
         final TextView securityQuestion = (TextView) PasswordDialogLayout.findViewById(R.id.security_question);
         securityQuestion.setTextColor(activity.getTextColor());
         final CardView passwordDialogCard = (CardView) PasswordDialogLayout.findViewById(R.id.forgot_password_dialog_card);
+        final TextInputLayout til = (TextInputLayout) PasswordDialogLayout.findViewById(R.id.text_input_layout);
         final EditText securityAnswer1 = (EditText) PasswordDialogLayout.findViewById(R.id.password_edittxt);
         securityAnswer1.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PERSON_NAME);
+
+        securityAnswer1.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                //empty method body
+            }
+
+            @Override
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                til.setError(null);
+            }
+
+            @Override
+            public void afterTextChanged(Editable editable) {
+                //empty method
+            }
+        });
 
         String question = "";
         question = SP.getString("Security Question", question);
@@ -161,37 +179,38 @@ public class SecurityHelper {
 
         passwordDialog.setView(PasswordDialogLayout);
 
-        passwordDialog.setPositiveButton("Submit", new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-                if (securityAnswer1.getText().length() == 0) {
-                    Toast.makeText(activity.getApplicationContext(), "Enter Answer To the Question", Toast.LENGTH_SHORT)
-                            .show();
-                } else {
-                    String answer1 = "";
-                    answer1 = SP.getString("Security Answer", answer1);
-
-
-                    if (Objects.equals(answer1, securityAnswer1.getText().toString())) {
-                        changePassword(activity, passwordDialog);
-                    } else {
-                        Toast.makeText(activity.getApplicationContext(), "Incorrect Answer", Toast.LENGTH_SHORT)
-                                .show();
-                    }
-                }
-            }
-        });
-
-        passwordDialog.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-                //empty method for cancel button
-                //nothing is done
-            }
-
-        });
-
-        AlertDialog dialog = passwordDialog.create();
+        final AlertDialog dialog = passwordDialog.create();
         dialog.setCancelable(false);
+
+        dialog.setButton(DialogInterface.BUTTON_POSITIVE, activity.getString(R.string.cancel).toUpperCase(), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
+            }
+        });
+
+        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, activity.getString(R.string.ok_action).toUpperCase(), (DialogInterface.OnClickListener) null);
         dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+
+        dialog.setOnShowListener(new DialogInterface.OnShowListener() {
+            @Override
+            public void onShow(DialogInterface dialogInterface) {
+                Button b = dialog.getButton(AlertDialog.BUTTON_NEGATIVE);
+                b.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        String answer1 = "";
+                        answer1 = SP.getString("Security Answer", answer1);
+                        if (Objects.equals(answer1, securityAnswer1.getText().toString())) {
+                            changePassword(activity, passwordDialog);
+                        } else {
+                            securityAnswer1.getText().clear();
+                            til.setError(activity.getString(R.string.wrong_answer));
+                        }
+                    }
+                });
+            }
+        });
         dialog.show();
     }
 
@@ -237,8 +256,8 @@ public class SecurityHelper {
             @Override
             public void afterTextChanged(Editable editable) {
                 if (editable.length() == max_password_length) {
-                    editTextConfirmPassword.setText(editable.toString().substring(0, max_password_length-1));
-                    editTextConfirmPassword.setSelection(max_password_length-1);
+                    editTextConfirmPassword.setText(editable.toString().substring(0, max_password_length - 1));
+                    editTextConfirmPassword.setSelection(max_password_length - 1);
                     Toast.makeText(activity.getApplicationContext(), activity.getResources().getString(R.string.max_password_length), Toast.LENGTH_SHORT).show();
                 }
             }
@@ -257,8 +276,8 @@ public class SecurityHelper {
             @Override
             public void afterTextChanged(Editable editable) {
                 if (editable.length() == max_password_length) {
-                    editTextPassword.setText(editable.toString().substring(0, max_password_length-1));
-                    editTextPassword.setSelection(max_password_length-1);
+                    editTextPassword.setText(editable.toString().substring(0, max_password_length - 1));
+                    editTextPassword.setSelection(max_password_length - 1);
                     Toast.makeText(activity.getApplicationContext(), activity.getResources().getString(R.string.max_password_length), Toast.LENGTH_SHORT)
                             .show();
                 }
@@ -319,21 +338,21 @@ public class SecurityHelper {
                                         dialog.dismiss();
                                         Toast.makeText(activity.getApplicationContext(), "Password Reset", Toast.LENGTH_SHORT)
                                                 .show();
-                                    }else{
+                                    } else {
                                         securityAnswer1.requestFocus();
                                         securityAnswer1.setError(activity.getString(R.string.security_ans_empty));
                                     }
-                                }else{
+                                } else {
                                     securityQuestion.requestFocus();
                                     securityQuestion.setError(activity.getString(R.string.security_ques_empty));
                                 }
-                            } else{
+                            } else {
                                 editTextConfirmPassword.requestFocus();
                                 editTextConfirmPassword.setError(activity.getString(R.string.password_dont_match));
                             }
                         } else {
                             editTextPassword.requestFocus();
-                            editTextPassword.setError(activity.getString( R.string.error_password_length));
+                            editTextPassword.setError(activity.getString(R.string.error_password_length));
                         }
                     }
                 });

--- a/app/src/main/res/layout/dialog_forgot_password.xml
+++ b/app/src/main/res/layout/dialog_forgot_password.xml
@@ -42,6 +42,11 @@
                         android:text=""
                         android:textColor="#000000"
                         android:textSize="20dp"/>
+                    <android.support.design.widget.TextInputLayout
+                        android:id="@+id/text_input_layout"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        app:errorEnabled="true"/>
                     <EditText
                         android:id="@+id/password_edittxt"
                         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -732,6 +732,7 @@
     <string name="enter_password">Enter your password</string>
     <string name="confirm_password">Confirm password</string>
     <string name="confirm_new_password">Confirm New password</string>
+    <string name="wrong_answer">Wrong Answer</string>
     <string name="wrong_password">Wrong password</string>
     <string name="show_password">Show Password</string>
     <string name="security_ans_empty">Security Answer cannot be empty</string>


### PR DESCRIPTION
Fixed #2349 

Changes: Forgot password dialog now shows an error instead of closing when wrong answer is entered.

GIF of the change: 
![error](https://user-images.githubusercontent.com/41234408/51035174-21bda100-15cf-11e9-9318-c29f34b50d1c.gif)

