### PR TITLE
fixes the crashing of app due to orientation change.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -284,7 +284,9 @@
         <activity
             android:name=".editor.EditImageActivity"
             android:theme="@style/AppTheme.NoActionBar"
-            android:windowSoftInputMode="adjustPan" />
+            android:windowSoftInputMode="adjustPan"
+            android:configChanges="orientation|screenSize"
+            />
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"
             android:screenOrientation="portrait"


### PR DESCRIPTION
This makes the Activity(EditImageActivity) to retain it's state even after rotation and hence prevents the app from crashing while inserting text to the image.
In the AddTextFragment.java file the mTextSticketView was getting null
due to restarting of the activity due to which the app crashed. This fix
allows the activiy to retain its state after rotation and hence the
mTextStickeerView is no longer null.

Fixed #2192 