### PR TITLE
After resetting password forgot password dialog is dismissed.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/util/SecurityHelper.java
@@ -203,6 +203,7 @@ public class SecurityHelper {
                         answer1 = SP.getString("Security Answer", answer1);
                         if (Objects.equals(answer1, securityAnswer1.getText().toString())) {
                             changePassword(activity, passwordDialog);
+                            dialog.dismiss();
                         } else {
                             securityAnswer1.getText().clear();
                             til.setError(activity.getString(R.string.wrong_answer));


### PR DESCRIPTION
Fixed #2392 

Changes: After resetting the password, the user is directly shown the insert password screen instead of the forgot password dialog screen.

GIF of the change: 
![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/41234408/51163697-883d0a80-18c0-11e9-898f-00c47de153cd.gif)
