### PR TITLE
solved the issue of "No toolchains found in the NDK toolchains folder for ABI with prefix: mips64el-linux-android" which occurs while running it in android studio

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
         classpath "io.realm:realm-gradle-plugin:$realm_version"
 


### PR DESCRIPTION
Fixed #[Add issue number here. If you do not solve the issue entirely, please change the message e.g. "First steps for issues #IssueNumber]

Changes: [Mention the files changed in the PR. Add here what changes were made in this issue and if possible provide links(Deploy/Preview Link).]

Screenshots of the change: 
