### PR TITLE
The image of developer Pawan Pal was out of place

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ The project is maintained by
 </p>
 </td>
 
-<td>
-     <img src="https://avatars1.githubusercontent.com/u/6936968?v=4&s=150" />
-     
+<td >
+     <img src="https://avatars1.githubusercontent.com/u/6936968?v=4&s=150" width="115%" height="100%" />
+  
      Pawan Pal
 
 <p align="center">


### PR DESCRIPTION
The image of developer Pawan Pal was out of place hence the contact icons were either too high up or stacked on top of one another. Issue has been fixed by extending the width.

Fixes Issue #2397

(it is my first edit/commit

Fixed #2397 

Changes: changes in width
<img width="941" alt="screen shot 2019-01-16 at 11 17 16 am" src="https://user-images.githubusercontent.com/38606868/51229629-137ed480-1983-11e9-879a-574d5fe6638b.png">

Screenshots of the change: 
