### PR TITLE
Fix #2404 LongPress works correctly for selecting multiple photos.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -284,9 +284,7 @@ public class LFMainActivity extends SharedMediaActivity {
                     mediaAdapter.notifyItemChanged(toggleSelectPhoto(m));
                     editMode = true;
                 }
-                else {
-                    selectAllPhotosUpTo(getImagePosition(m.getPath()),mediaAdapter);
-                }
+                else selectAllPhotosUpTo(getImagePosition(m.getPath()),mediaAdapter);
             } else if (fav_photos && !all_photos) {
                 if (!editMode) {
                     mediaAdapter.notifyItemChanged(toggleSelectPhoto(m));

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -283,8 +283,7 @@ public class LFMainActivity extends SharedMediaActivity {
                 if (!editMode) {
                     mediaAdapter.notifyItemChanged(toggleSelectPhoto(m));
                     editMode = true;
-                }
-                else selectAllPhotosUpTo(getImagePosition(m.getPath()),mediaAdapter);
+                } else selectAllPhotosUpTo(getImagePosition(m.getPath()),mediaAdapter);
             } else if (fav_photos && !all_photos) {
                 if (!editMode) {
                     mediaAdapter.notifyItemChanged(toggleSelectPhoto(m));

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -284,6 +284,9 @@ public class LFMainActivity extends SharedMediaActivity {
                     mediaAdapter.notifyItemChanged(toggleSelectPhoto(m));
                     editMode = true;
                 }
+                else {
+                    selectAllPhotosUpTo(getImagePosition(m.getPath()),mediaAdapter);
+                }
             } else if (fav_photos && !all_photos) {
                 if (!editMode) {
                     mediaAdapter.notifyItemChanged(toggleSelectPhoto(m));


### PR DESCRIPTION
Fixed #2404 

Changes: Files changes: LFMainActivity.java. Fixed bug where LongPressing one photo after selecting one photo in AllPhotos Activity didn't automatically select all photos in between.

