### PR TITLE
Fix for issue#2411: Exit button added to permissions not given dialog.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SplashScreen.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SplashScreen.java
@@ -176,6 +176,12 @@ public class SplashScreen extends SharedMediaActivity {
                 askForPermission();
             }
         });
+        builder.setNegativeButton("EXIT", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                finish();
+            }
+        });
         AlertDialog alertDialog = builder.create();
         alertDialog.show();
     }


### PR DESCRIPTION
Fixed #2411 

Changes: User can exit the app by pressing the eixt button if user does not give permissions to the app and presses "Don't show again"

GIF of the change: 

![ezgif com-video-to-gif 4](https://user-images.githubusercontent.com/41234408/51398859-a3cb3e00-1b6a-11e9-83c8-e063c9da2f64.gif)
