### PR TITLE
Fix for issue#2363: Option added for user to give permissions from app settings.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SplashScreen.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SplashScreen.java
@@ -4,9 +4,11 @@ import android.Manifest;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
@@ -176,6 +178,18 @@ public class SplashScreen extends SharedMediaActivity {
                 askForPermission();
             }
         });
+
+        builder.setNeutralButton("GRANT PERMISSIONS", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                Intent intent = new Intent();
+                intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                Uri uri = Uri.fromParts("package", getPackageName(), null);
+                intent.setData(uri);
+                startActivity(intent);
+            }
+        });
+
         AlertDialog alertDialog = builder.create();
         alertDialog.show();
     }

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SplashScreen.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SplashScreen.java
@@ -16,6 +16,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
+import android.widget.Toast;
 
 import org.fossasia.phimpme.R;
 import org.fossasia.phimpme.base.SharedMediaActivity;
@@ -172,16 +173,18 @@ public class SplashScreen extends SharedMediaActivity {
         builder.setTitle(R.string.permission_rationale_title);
         builder.setMessage(R.string.permission_storage_alert);
         builder.setCancelable(false);
-        builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+        builder.setPositiveButton(R.string.exit, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                askForPermission();
+                finish();
             }
         });
 
-        builder.setNeutralButton("GRANT PERMISSIONS", new DialogInterface.OnClickListener() {
+        builder.setNegativeButton(R.string.grant_permission, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
+                Toast.makeText(getApplicationContext(), R.string.permissions_restart, Toast.LENGTH_LONG)
+                        .show();
                 Intent intent = new Intent();
                 intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
                 Uri uri = Uri.fromParts("package", getPackageName(), null);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,8 @@
     <string name="answer_yes">Yes</string>
     <string name="answer_no">No</string>
 
+    <string name="permissions_restart">Please restart app after giving permissions</string>
+    <string name="grant_permission">Grant Permissions</string>
     <string name="on">On</string> <!-- whether a setting is turned on, e.g., "Auto-level: On" -->
     <string name="off">Off</string> <!-- whether a setting is turned off, e.g., "Auto-level: Off" -->
 


### PR DESCRIPTION
Fixed #2363, #2411 

Changes: When the dialog is shown to the user to give permissions, the user has the option to go to app settings and grant permissions from there.

GIF of the change: 

![ezgif com-video-to-gif 6](https://user-images.githubusercontent.com/41234408/51438027-95953300-1ccc-11e9-86bc-78a8fc5c9840.gif)
