### PR TITLE
Added feature to remove multiple photos from favourites from album itself.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1878,7 +1878,7 @@ public class LFMainActivity extends SharedMediaActivity {
         getfavouriteslist();
         menu.findItem(R.id.action_copy).setVisible(visible);
         menu.findItem(R.id.action_move).setVisible((visible || editMode) && !fav_photos);
-        menu.findItem(R.id.action_add_favourites).setVisible((visible || editMode) && (!albumsMode && !fav_photos));
+        menu.findItem(R.id.action_add_favourites).setVisible((visible || editMode) && (!albumsMode && !fav_photos && !checkfav(favouriteslist,getAlbum().getSelectedMedia())));
         menu.findItem(R.id.action_remove_favourites).setVisible((visible || editMode) && (!albumsMode && !fav_photos && favouriteslist.size()>0));
         menu.findItem(R.id.excludeAlbumButton).setVisible(editMode && !all_photos && albumsMode && !fav_photos);
         menu.findItem(R.id.zipAlbumButton).setVisible(editMode && !all_photos && albumsMode && !fav_photos && !hidden &&
@@ -1899,8 +1899,7 @@ public class LFMainActivity extends SharedMediaActivity {
         menu.findItem(R.id.set_pin_album).setVisible(albumsMode && getAlbums().getSelectedCount() == 1);
         menu.findItem(R.id.setAsAlbumPreview).setVisible(!albumsMode && !all_photos && getAlbum()
                 .getSelectedCount() == 1);
-        menu.findItem(R.id.affixPhoto).setVisible((!albumsMode && (getAlbum().getSelectedCount() > 1) ||
-                selectedMedias.size() > 1) && !fav_photos);
+        menu.findItem(R.id.affixPhoto).setVisible((!albumsMode && (getAlbum().getSelectedCount() > 1)) && !fav_photos);
         if (albumsMode)
             menu.findItem(R.id.action_move).setVisible(getAlbums().getSelectedCount() == 1);
         return super.onPrepareOptionsMenu(menu);
@@ -1908,7 +1907,23 @@ public class LFMainActivity extends SharedMediaActivity {
 
     private void togglePrimaryToolbarOptions(final Menu menu) {
         menu.setGroupVisible(R.id.general_action, !editMode);
+    }
 
+    private boolean checkfav(ArrayList<Media> favlist,ArrayList<Media> selected) {
+        int check=0;
+        for(Media sm:selected) {
+            check=0;
+            for(Media fm:favlist){
+                if(sm.getPath().equals(fm.getPath())){
+                    check=1;
+                }
+            }if(check==0){
+                return false;
+            }
+        }
+        if(selected.size()==0){
+            return false;
+        } else return true;
     }
 
     //endregion

--- a/app/src/main/res/menu/menu_albums.xml
+++ b/app/src/main/res/menu/menu_albums.xml
@@ -71,6 +71,11 @@
             app:showAsAction="never"/>
 
         <item
+            android:id="@+id/action_remove_favourites"
+            android:title="@string/remove_favourite_menu"
+            app:showAsAction="never"/>
+
+        <item
             android:id="@+id/create_gif"
             android:title="Create GIF"
             app:showAsAction="never"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -562,12 +562,15 @@
     <string name="trashbin_move_error">Error! Images cannot be moved to the TrashBin</string>
     <string name="change_cover">Album cover changed..</string>
     <string name="add_favourite">Image is successfully added to the favourites collection.</string>
+    <string name="remove_favourite">Image has been successfully removed from the favourites collection.</string>
     <string name="add_favourite_multiple">Images are successfully added to the favourites collection.</string>
+    <string name="remove_favourite_multiple">Images have been successfully removed from the favourites collection.</string>
     <string name="remove_from_favourite">images removed from favourites section</string>
     <string name="invalid_selection">Invalid Selection</string>
     <string name="single_image_removed">Image removed from favourites section</string>
     <string name="check_favourite">Image is already present in the favourites collection.</string>
     <string name="check_favourite_multipleitems">All the images are already present in the favourite collection.</string>
+    <string name="none_item_favourites">None of the items selected were present in favourites collection.</string>
     <string name="rename_photo_action">Rename photo</string>
     <string name="drawer_open">Open navigation drawer</string>
     <string name="drawer_close">Close navigation drawer</string>
@@ -600,6 +603,7 @@
     <string name="move_to">Move to</string>
     <string name="use_as">Use as</string>
     <string name="favourite">Add to favourites</string>
+    <string name="remove_favourite_menu">Remove from favourites</string>
     <string name="favourite_title">Favourite Photos</string>
     <string name="unfavourite">Unfavourite</string>
     <string name="edit">Edit</string>


### PR DESCRIPTION
Fixed #2210 Added feature to remove multiple photos from favourites from album itself.

Changes: LFMainActivity.java, menu_albums.xml, strings.xml

Screenshots of the change: 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/37517284/51489028-1e939380-1dcd-11e9-9cc7-888d9d39bde5.gif)


