### PR TITLE
Fix for issue#2433: Fixed position of SnackBar.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
@@ -1,5 +1,6 @@
 package org.fossasia.phimpme.accounts;
 
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -18,6 +19,7 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 
 import com.box.androidsdk.content.BoxConfig;
@@ -219,7 +221,26 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
         ConnectivityManager cm=(ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo ni = cm.getActiveNetworkInfo();
         if (ni == null) {
-           Snackbar.make(findViewById(android.R.id.content),getString(R.string.internet_is_off),Snackbar.LENGTH_SHORT).show();
+            View rootView = AccountActivity.this.getWindow().getDecorView().findViewById(android.R.id.content);
+            Snackbar snackbar = Snackbar
+                    .make(rootView, R.string.internet_is_off, Snackbar.LENGTH_SHORT)
+                    .setAction("Settings", new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            Intent intent = new Intent();
+                            intent.setComponent(new ComponentName("com.android.settings","com.android.settings.Settings$DataUsageSummaryActivity"));
+                            startActivity(intent);
+                        }
+                    })
+                    .setActionTextColor(getAccentColor());
+            View sbView = snackbar.getView();
+            final FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) sbView.getLayoutParams();
+            params.setMargins(params.leftMargin,
+                    params.topMargin,
+                    params.rightMargin,
+                    params.bottomMargin + navigationView.getHeight());
+            sbView.setLayoutParams(params);
+            snackbar.show();
         }
         final SwitchCompat signInSignOut = childView.findViewById(R.id.sign_in_sign_out_switch);
         final String name = AccountDatabase.AccountName.values()[position].toString();


### PR DESCRIPTION
Fixed #2433 

Changes: Corrected position of SnackBar in accounts activity when internet connection is off. I also added a button to the SnackBar to directly let the user pen data usage settings and switch on mobile data.

Screenshots of the change: 

![screencap](https://user-images.githubusercontent.com/41234408/51490317-f1e17b00-1dd0-11e9-92fb-eec433c679cd.png)
