### PR TITLE
Fix #2442 Made navigation drawer visible onResume where ever required.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -833,11 +833,11 @@ public class LFMainActivity extends SharedMediaActivity {
         setupUI();
         if (all_photos && !fav_photos) {
             new PrepareAllPhotos(activityContext).execute();
-        }
-        if (!all_photos && fav_photos) {
+            getNavigationBar();
+        } else if (!all_photos && fav_photos) {
             new FavouritePhotos(activityContext).execute();
-        }
-        if (!all_photos && !fav_photos) {
+        } else {
+            getNavigationBar();
             if (SP.getBoolean("auto_update_media", false)) {
                 if (albumsMode) {
                     if (!firstLaunch) new PrepareAlbumTask(activityContext).execute();


### PR DESCRIPTION
Fixed #2442 Made navigation drawer visible onResume where ever required.

Changes: LFMainActivity.java

Screenshots of the change: 

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/37517284/51525765-049e9300-1e57-11e9-99af-ec37862d2e7e.gif)

