### PR TITLE
Swipe-able Tabs

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/OnSwipeTouchListener.java
+++ b/app/src/main/java/org/fossasia/phimpme/OnSwipeTouchListener.java
@@ -1,0 +1,87 @@
+package org.fossasia.phimpme;
+
+/**
+ * Created by anirudh on 1/22/2019.
+ */
+
+import android.content.Context;
+import android.view.GestureDetector;
+import android.view.GestureDetector.SimpleOnGestureListener;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.View.OnTouchListener;
+
+public class OnSwipeTouchListener implements OnTouchListener {
+
+    private final GestureDetector gestureDetector;
+
+
+    public OnSwipeTouchListener (Context ctx){
+        gestureDetector = new GestureDetector(ctx, new GestureListener());
+    }
+
+    @Override
+    public boolean onTouch(View v, MotionEvent event) {
+        return gestureDetector.onTouchEvent(event);
+    }
+
+    private final class GestureListener extends SimpleOnGestureListener {
+
+        private static final int SWIPE_THRESHOLD = 100;
+        private static final int SWIPE_VELOCITY_THRESHOLD = 100;
+
+        @Override
+        public boolean onDown(MotionEvent e) {
+            return true;
+        }
+
+        @Override
+        public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+            boolean result = false;
+            try {
+                float diffY = e2.getY() - e1.getY();
+                float diffX = e2.getX() - e1.getX();
+                if (Math.abs(diffX) > Math.abs(diffY)) {
+                    if (Math.abs(diffX) > SWIPE_THRESHOLD && Math.abs(velocityX) > SWIPE_VELOCITY_THRESHOLD) {
+                        if (diffX > 0) {
+                            onSwipeRight();
+                        } else {
+                            onSwipeLeft();
+                        }
+                        result = true;
+                    }
+                }
+                else if (Math.abs(diffY) > SWIPE_THRESHOLD && Math.abs(velocityY) > SWIPE_VELOCITY_THRESHOLD) {
+                    if (diffY > 0) {
+                        onSwipeBottom();
+                    } else {
+                        onSwipeTop();
+                    }
+                    result = true;
+                }
+            } catch (Exception exception) {
+                exception.printStackTrace();
+            }
+            return result;
+        }
+    }
+
+    public void onSwipeRight() {
+        //to Override
+    }
+
+    public void onSwipeLeft() {
+        //to Override
+    }
+
+    public void onSwipeTop() {
+        //to Override
+    }
+
+    public void onSwipeBottom() {
+        //to Override
+    }
+
+}
+
+

--- a/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/accounts/AccountActivity.java
@@ -32,6 +32,7 @@ import com.pinterest.android.pdk.PDKException;
 import com.pinterest.android.pdk.PDKResponse;
 import com.twitter.sdk.android.core.identity.TwitterAuthClient;
 
+import org.fossasia.phimpme.OnSwipeTouchListener;
 import org.fossasia.phimpme.R;
 import org.fossasia.phimpme.base.PhimpmeProgressBarHandler;
 import org.fossasia.phimpme.base.RecyclerItemClickListner;
@@ -142,6 +143,15 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
         setDebugMode(true);
         //  googleApiClient();
         configureBoxClient();
+
+        accountsRecyclerView.setOnTouchListener(new OnSwipeTouchListener(this){
+            @Override
+            public void onSwipeRight() {
+                Log.i("tag","Opening Main");
+                startActivity(new Intent(AccountActivity.this,LFMainActivity.class));
+                finish();
+            }
+        });
     }
 
 
@@ -587,7 +597,7 @@ public class AccountActivity extends ThemedActivity implements AccountContract.V
         startActivity(intent);
         finish();
         overridePendingTransition(R.anim.left_to_right,
-                R.anim.right_to_left);
+                R.anim.left_to_right);
     }
 
     private void boxAuthentication() {

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -28,6 +28,7 @@ import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.BottomNavigationView;
+import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.ActivityOptionsCompat;
@@ -57,6 +58,7 @@ import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.View;
 import android.view.ViewAnimationUtils;
+import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.webkit.MimeTypeMap;
@@ -66,17 +68,21 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
+import android.widget.RelativeLayout;
 import android.widget.ScrollView;
 import android.widget.SeekBar;
 import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
 
 
 import com.bumptech.glide.gifencoder.AnimatedGifEncoder;
 import com.mikepenz.google_material_typeface_library.GoogleMaterial;
 import com.mikepenz.iconics.view.IconicsImageView;
 
+import org.fossasia.phimpme.OnSwipeTouchListener;
 import org.fossasia.phimpme.R;
+import org.fossasia.phimpme.accounts.AccountActivity;
 import org.fossasia.phimpme.base.SharedMediaActivity;
 import org.fossasia.phimpme.data.local.FavouriteImagesModel;
 import org.fossasia.phimpme.data.local.ImageDescModel;
@@ -104,6 +110,7 @@ import org.fossasia.phimpme.gallery.util.SecurityHelper;
 import org.fossasia.phimpme.gallery.util.StringUtils;
 import org.fossasia.phimpme.gallery.views.CustomScrollBarRecyclerView;
 import org.fossasia.phimpme.gallery.views.GridSpacingItemDecoration;
+import org.fossasia.phimpme.opencamera.Camera.CameraActivity;
 import org.fossasia.phimpme.trashbin.TrashBinActivity;
 import org.fossasia.phimpme.uploadhistory.UploadHistory;
 import org.fossasia.phimpme.utilities.ActivitySwitchHelper;
@@ -251,7 +258,8 @@ public class LFMainActivity extends SharedMediaActivity {
     protected TextView hiddenText;
     @BindView(R.id.star_image_view)
     protected ImageView starImageView;
-
+    @BindView(R.id.rlayout)
+    protected RelativeLayout rlayout;
     /*
     editMode-  When true, user can select items by clicking on them one by one
      */
@@ -751,12 +759,13 @@ public class LFMainActivity extends SharedMediaActivity {
         super.onCreate(savedInstanceState);
         Log.e("TAG", "lfmain");
         ButterKnife.bind(this);
-
         navigationView = (BottomNavigationView) findViewById(R.id.bottombar);
         favicon = (IconicsImageView) findViewById(R.id.Drawer_favourite_Icon);
 
         rvAlbums = (CustomScrollBarRecyclerView) findViewById(R.id.grid_albums);
         rvMedia  = (CustomScrollBarRecyclerView) findViewById(R.id.grid_photos);
+
+
 
         overridePendingTransition(R.anim.right_to_left,
                 R.anim.left_to_right);
@@ -1077,10 +1086,12 @@ public class LFMainActivity extends SharedMediaActivity {
         });
 
         //set touch listener on recycler view
-        rvAlbums.setOnTouchListener(new View.OnTouchListener() {
+       rvAlbums.setOnTouchListener(new View.OnTouchListener() {
             @Override
             public boolean onTouch(View v, MotionEvent event) {
                 mScaleGestureDetector.onTouchEvent(event);
+                //rlayout.dispatchTouchEvent(event);
+                //swipeRefreshLayout.dispatchTouchEvent(event);
                 return false;
             }
         });
@@ -1089,9 +1100,38 @@ public class LFMainActivity extends SharedMediaActivity {
             @Override
             public boolean onTouch(View v, MotionEvent event) {
                 mScaleGestureDetector.onTouchEvent(event);
+                //swipeRefreshLayout.dispatchTouchEvent(event);
+               //rlayout.dispatchTouchEvent(event);
                 return false;
             }
         });
+
+        rlayout.setOnTouchListener(new OnSwipeTouchListener(this){
+
+            @Override
+            public void onSwipeRight() {
+                //Toast.makeText(LFMainActivity.this,"Camera Opening",Toast.LENGTH_SHORT).show();
+                startActivity(new Intent(LFMainActivity.this, CameraActivity.class));
+                finish();
+
+            }
+
+            @Override
+            public void onSwipeLeft() {
+                //Toast.makeText(LFMainActivity.this,"Accounts",Toast.LENGTH_SHORT).show();
+                startActivity(new Intent(LFMainActivity.this, AccountActivity.class));
+                finish();
+            }
+
+            @Override
+            public boolean onTouch(View v, MotionEvent event) {
+                swipeRefreshLayout.dispatchTouchEvent(event);
+
+
+                return super.onTouch(v, event);
+            }
+        });
+
 
         mediaAdapter = new MediaAdapter(getAlbum().getMedia(), LFMainActivity.this);
 
@@ -4136,4 +4176,5 @@ public class LFMainActivity extends SharedMediaActivity {
                 asyncActivityRef.requestSdCardPermissions();
         }
     }
+
 }

--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/CameraActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/CameraActivity.java
@@ -94,7 +94,6 @@ import java.util.Map;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
-
 import static android.preference.PreferenceManager.getDefaultSharedPreferences;
 
 /**
@@ -174,8 +173,9 @@ public class CameraActivity extends ThemedActivity implements AudioListener.Audi
             debug_time = System.currentTimeMillis();
         }
         super.onCreate(savedInstanceState);
+        hideNavigationBar();
         ButterKnife.bind(this);
-        overridePendingTransition(R.anim.right_to_left,
+        overridePendingTransition(R.anim.left_to_right,
                 R.anim.left_to_right);ButterKnife.bind(this);
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false); // initialise any unset preferences to their default values
         if (MyDebug.LOG)

--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Preview/Preview.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Preview/Preview.java
@@ -47,6 +47,7 @@ import android.widget.Toast;
 
 
 import org.fossasia.phimpme.R;
+import org.fossasia.phimpme.gallery.activities.LFMainActivity;
 import org.fossasia.phimpme.opencamera.Camera.CameraActivity;
 import org.fossasia.phimpme.opencamera.Camera.MyDebug;
 import org.fossasia.phimpme.opencamera.Camera.TakePhoto;
@@ -500,6 +501,16 @@ public class Preview implements SurfaceHolder.Callback, TextureView.SurfaceTextu
 				Log.d(TAG, "tol: " + tol);
 			}
 			if( dist2 > tol*tol ) {
+
+			    if(x>touch_orig_x){
+                    Log.d(TAG, "left");
+
+                }else{
+                    Log.d(TAG, "right");
+                    ((Activity)this.getContext()).startActivity(new Intent(((Activity)this.getContext()),LFMainActivity.class));
+                    ((Activity) this.getContext()).finish();
+
+                }
 				if( MyDebug.LOG )
 					Log.d(TAG, "touch was a swipe");
 				return true;

--- a/app/src/main/res/layout/activity_leafpic.xml
+++ b/app/src/main/res/layout/activity_leafpic.xml
@@ -96,6 +96,12 @@
 
                     </RelativeLayout>
                 </android.support.v4.widget.SwipeRefreshLayout>
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:id="@+id/rlayout">
+
+                </RelativeLayout>
             </FrameLayout>
         </android.support.v4.widget.NestedScrollView>
 


### PR DESCRIPTION
Adds the feaure to swipe between different tabs and removes the
BottomNavigationVIew form the CameraActivity to maximize the Camera Size
To move from cameraActivity to LFMainActivity swipe right.

Fixed #2434

Changes: OnSwipeTouchListener.java(added),AccountActivity.java,LFMainActivity.java,CameraActivity.java,Preview.java,activity_leafpic.xml