### PR TITLE
empty favourite photos ui improved

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -251,6 +251,8 @@ public class LFMainActivity extends SharedMediaActivity {
     protected TextView hiddenText;
     @BindView(R.id.star_image_view)
     protected ImageView starImageView;
+    @BindView(R.id.no_fav_msg)
+    protected TextView noFavMsg;
 
     /*
     editMode-  When true, user can select items by clicking on them one by one
@@ -1676,14 +1678,17 @@ public class LFMainActivity extends SharedMediaActivity {
                 ().getMedia().size() == 0 && !fav_photos) || (fav_photos && favouriteslist.size() == 0) ? View
                 .VISIBLE : View
                 .GONE);
+        noFavMsg.setVisibility((albumsMode && getAlbums().dispAlbums.size() == 0 && !fav_photos) || (!albumsMode && getAlbum
+                ().getMedia().size() == 0 && !fav_photos) || (fav_photos && favouriteslist.size() == 0) ? View
+                .VISIBLE : View
+                .GONE);
+        noFavMsg.setText(R.string.no_favourites_message);
+        noFavMsg.setTextColor(getTextColor());
         starImageView.setVisibility((albumsMode && getAlbums().dispAlbums.size() == 0 && !fav_photos) || (!albumsMode && getAlbum
                 ().getMedia().size() == 0 && !fav_photos) || (fav_photos && favouriteslist.size() == 0) ? View
                 .VISIBLE : View
                 .GONE);
-        if (getBaseTheme() != LIGHT_THEME)
-            starImageView.setColorFilter(ContextCompat.getColor(this, R.color.white), PorterDuff.Mode.SRC_ATOP);
-        else
-            starImageView.setColorFilter(ContextCompat.getColor(this, R.color.accent_grey), PorterDuff.Mode.SRC_ATOP);
+        starImageView.setColorFilter(getPrimaryColor());
     }
 
 
@@ -3453,6 +3458,7 @@ public class LFMainActivity extends SharedMediaActivity {
         rvMedia.setVisibility(albumsMode ? View.GONE : View.VISIBLE);
         nothingToShow.setVisibility(View.GONE);
         starImageView.setVisibility(View.GONE);
+        noFavMsg.setVisibility(View.GONE);
         if (albumsMode)
             fabScrollUp.hide();
         //touchScrollBar.setScrollBarHidden(albumsMode);

--- a/app/src/main/res/layout/activity_leafpic.xml
+++ b/app/src/main/res/layout/activity_leafpic.xml
@@ -77,11 +77,27 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_centerInParent="true"
+                            android:layout_marginTop="@dimen/sub_small_spacing"
                             android:elevation="12dp"
                             android:gravity="center"
                             android:text="@string/there_is_nothing_to_show"
                             android:textColor="@color/md_white_1000"
-                            android:textSize="16sp"
+                            android:textStyle="bold"
+                            android:textSize="@dimen/sub_big_text"
+                            android:visibility="invisible"
+                            tools:targetApi="lollipop" />
+                        <TextView
+                            android:layout_below="@+id/nothing_to_show"
+                            android:layout_marginTop="@dimen/sub_medium_spacing"
+                            android:id="@+id/no_fav_msg"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:elevation="12dp"
+                            android:gravity="center"
+                            android:layout_centerInParent="true"
+                            android:text="@string/no_favourites_message"
+                            android:textColor="@color/md_white_1000"
+                            android:textSize="@dimen/medium_text"
                             android:visibility="invisible"
                             tools:targetApi="lollipop" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1348,7 +1348,8 @@
     <string name="move_all_photos">All the photos will be moved to the selected folder. Do you wish to continue?</string>
     <string name="moved_target_folder_success">Moved to target folder successfully.</string>
 
-    <string name="no_favourites_text">There are no favourites presently. To mark a picture as favourite, long-select the
+    <string name="no_favourites_text">There are no favourites presently.</string>
+    <string name="no_favourites_message">To mark a picture as favourite, long-select the
         picture and tap on \"Add to Favourites\" from the overflow menu or click on the picture and tap the heart icon at the bottom.
     </string>
 


### PR DESCRIPTION
Fixed #2476 

Changes:
star image now changes color as per the primary color.
empty favourite string was split into two parts.
styling of the textview was done.

Screenshots of the change: 
![whatsapp image 2019-02-04 at 02 52 05](https://user-images.githubusercontent.com/31561661/52182916-7cda6080-2828-11e9-9618-f405726342a3.jpeg)
![whatsapp image 2019-02-04 at 02 52 05 2](https://user-images.githubusercontent.com/31561661/52182917-806de780-2828-11e9-9afd-f400cd0e349c.jpeg)
![whatsapp image 2019-02-04 at 02 52 05 1](https://user-images.githubusercontent.com/31561661/52182918-82d04180-2828-11e9-838d-fec57c143188.jpeg)
