### PR TITLE
accent color change dialog button changed to yes and no

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
@@ -688,8 +688,8 @@ public class SettingsActivity extends ThemedActivity {
         AlertDialog.Builder builder = new AlertDialog.Builder(SettingsActivity.this, getDialogStyle());
         AlertDialogsHelper.getTextDialog(SettingsActivity.this, builder,
                 R.string.accent_color, R.string.accent_primary_same_mssg, null);
-        builder.setNegativeButton(this.getString(R.string.cancel).toUpperCase(), null);
-        builder.setPositiveButton(this.getString(R.string.ok).toUpperCase(), new DialogInterface.OnClickListener() {
+        builder.setNegativeButton(this.getString(R.string.no_action).toUpperCase(), null);
+        builder.setPositiveButton(this.getString(R.string.yes_action).toUpperCase(), new DialogInterface.OnClickListener() {
             @Override public void onClick(DialogInterface dialogInterface, int i) {
                 SP.putInt(getString(R.string.preference_accent_color), color);
                 updateTheme();


### PR DESCRIPTION
Fixed #2477 

Changes: 
accent color change dialog button changed to yes and no
Screenshots of the change: 
![whatsapp image 2019-02-04 at 03 21 34](https://user-images.githubusercontent.com/31561661/52183239-0a6b7f80-282c-11e9-9a08-629510861281.jpeg)
