### PR TITLE
deleting from favourite now requires selecting an image first

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1887,6 +1887,9 @@ public class LFMainActivity extends SharedMediaActivity {
         menu.findItem(R.id.zipAlbumButton).setVisible(editMode && !all_photos && albumsMode && !fav_photos && !hidden &&
                 getAlbums().getSelectedCount() == 1);
         menu.findItem(R.id.delete_action).setVisible((!albumsMode || editMode) && (!all_photos || editMode));
+        if (fav_photos){
+            menu.findItem(R.id.delete_action).setVisible(editMode);
+        }
         if(fav_photos && favouriteslist.size() == 0 ){
             menu.findItem(R.id.delete_action).setVisible(false);
             menu.findItem(R.id.sort_action).setVisible(false);


### PR DESCRIPTION
Fixed #2485 

Changes:
delete action made invisible unless some media is selected.


