### PR TITLE
Fix #2209 layout changes issue

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -285,7 +285,6 @@
             android:name=".editor.EditImageActivity"
             android:theme="@style/AppTheme.NoActionBar"
             android:windowSoftInputMode="adjustPan"
-            android:configChanges="orientation|screenSize"
             />
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"

--- a/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
@@ -86,7 +86,8 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
 
     public static int mode;
     public static int effectType;
-
+    private int initalBottomFragment = 0;
+    private int initalMiddleFragment = 2;
     /**
      * Number of times image has been edited. Indicates whether image has been edited or not.
      */
@@ -160,6 +161,8 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
         initView();
         if (savedInstanceState != null) {
             mode =  savedInstanceState.getInt("PREVIOUS_FRAGMENT");
+            initalMiddleFragment = savedInstanceState.getInt("PREVIOUS_MIDDLE_FRAGMENT");
+            initalBottomFragment = savedInstanceState.getInt("PREVIOUS_BOTTOM_FRAGMENT");
         }
         getData();
     }
@@ -171,11 +174,11 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
     private void setInitialFragments() {
         getSupportFragmentManager()
                 .beginTransaction()
-                .add(R.id.controls_container, mainMenuFragment)
+                .add(R.id.controls_container, getFragment(initalBottomFragment))
                 .commit();
 
-        changeMiddleFragment(mode);
-
+        changeMiddleFragment(initalMiddleFragment);
+        mode = initalMiddleFragment;
         setButtonsVisibility();
     }
 
@@ -312,12 +315,17 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
      * @param index integer corresponding to the current editing mode.
      */
     public void changeBottomFragment(int index){
+        initalBottomFragment = index;
         getSupportFragmentManager()
                 .beginTransaction()
                 .replace(R.id.controls_container, getFragment(index))
                 .commit();
 
         setButtonsVisibility();
+    }
+
+    private int getInitalBottomFragment() {
+        return initalBottomFragment;
     }
 
     /**
@@ -367,10 +375,15 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
      * @param index integer representing selected editing mode
      */
     public void changeMiddleFragment(int index){
+            initalMiddleFragment = index;
             getSupportFragmentManager()
                     .beginTransaction()
                     .replace(R.id.preview_container, getFragment(index))
                     .commit();
+    }
+
+    private int getMiddleFragment() {
+        return initalMiddleFragment;
     }
 
     public void changeMainBitmap(Bitmap newBit) {
@@ -658,6 +671,8 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
+        outState.putInt("PREVIOUS_MIDDLE_FRAGMENT", initalMiddleFragment);
+        outState.putInt("PREVIOUS_BOTTOM_FRAGMENT", initalBottomFragment);
         outState.putInt("PREVIOUS_FRAGMENT", mode);
     }
 

--- a/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
@@ -324,10 +324,6 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
         setButtonsVisibility();
     }
 
-    private int getInitalBottomFragment() {
-        return initalBottomFragment;
-    }
-
     /**
      * Handles the visibility of the 'save' button.
      */
@@ -382,9 +378,6 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
                     .commit();
     }
 
-    private int getMiddleFragment() {
-        return initalMiddleFragment;
-    }
 
     public void changeMainBitmap(Bitmap newBit) {
         if (mainBitmap != null) {

--- a/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
@@ -377,8 +377,7 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
                     .replace(R.id.preview_container, getFragment(index))
                     .commit();
     }
-
-
+    
     public void changeMainBitmap(Bitmap newBit) {
         if (mainBitmap != null) {
             if (!mainBitmap.isRecycled()) {


### PR DESCRIPTION
Fixed #2209 

Changes: there is two initial value for middle and bottom fragment which is temporary and after initialization all the fragment changes done by default flow (using mode).

Screenshots of the change: 

<img src = "https://user-images.githubusercontent.com/22986571/52323762-57a24980-2a04-11e9-9d3c-f6862c11987c.gif" width = 250 height = 400>



