### PR TITLE
password dialog dismissed after execution

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
@@ -324,6 +324,7 @@ public class UploadHistory extends ThemedActivity {
                         public void onClick(View v) {
                             // if password is correct, call DeletePhotos and perform deletion
                             if (securityObj.checkPassword(editTextPassword.getText().toString())) {
+                                passwordDialog.dismiss();
                                new DeleteHistory().execute();
                             }
                             // if password is incorrect, don't delete and notify user of incorrect password


### PR DESCRIPTION
Fixed #2508

Changes:
password dialog now dismisses after giving correct password.


