### PR TITLE
Fix for issue#2513: Made a convention common for all security dialogs. 

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -682,8 +682,8 @@ public class LFMainActivity extends SharedMediaActivity {
                             }
                         }
                     });
-                    passwordDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
-                    passwordDialogBuilder.setPositiveButton(getString(R.string.ok_action).toUpperCase(),
+                    passwordDialogBuilder.setPositiveButton(getString(R.string.cancel).toUpperCase(), null);
+                    passwordDialogBuilder.setNegativeButton(getString(R.string.ok_action).toUpperCase(),
                             new DialogInterface.OnClickListener() {
                                 @Override
                                 public void onClick(DialogInterface dialog, int which) {
@@ -698,7 +698,7 @@ public class LFMainActivity extends SharedMediaActivity {
                     AlertDialogsHelper.setButtonTextColor(
                             new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE},
                             getAccentColor(), passwordDialog);
-                    passwordDialog.getButton(AlertDialog.BUTTON_POSITIVE)
+                    passwordDialog.getButton(AlertDialog.BUTTON_NEGATIVE)
                             .setOnClickListener(new View.OnClickListener() {
                                 @Override
                                 public void onClick(View v) {
@@ -1466,11 +1466,11 @@ public class LFMainActivity extends SharedMediaActivity {
                     AlertDialog.Builder passwordDialogBuilder = new AlertDialog.Builder(LFMainActivity.this, getDialogStyle());
                     final EditText editTextPassword = securityObj.getInsertPasswordDialog(LFMainActivity.this, passwordDialogBuilder);
                     editTextPassword.setHintTextColor(getResources().getColor(R.color.grey, null));
-                    passwordDialogBuilder.setPositiveButton(getString(R.string.ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
+                    passwordDialogBuilder.setNegativeButton(getString(R.string.ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int which) {
                         }
                     });
-                    passwordDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
+                    passwordDialogBuilder.setPositiveButton(getString(R.string.cancel).toUpperCase(), null);
                     editTextPassword.addTextChangedListener(new TextWatcher() {
                         @Override public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
                             //empty method body
@@ -1494,7 +1494,7 @@ public class LFMainActivity extends SharedMediaActivity {
                     passwordDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
                     passwordDialog.show();
                     AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, getAccentColor(), passwordDialog);
-                    passwordDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View
+                    passwordDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setOnClickListener(new View
                             .OnClickListener() {
                         @Override
                         public void onClick(View v) {
@@ -2297,16 +2297,16 @@ public class LFMainActivity extends SharedMediaActivity {
                             R.string.delete_album_message :
                             R.string.delete_photos_message, null, getResources().getString(R.string.move_to_trashbin), getAccentColor());
 
-                deleteDialog.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
-                deleteDialog.setPositiveButton(getString(R.string.delete).toUpperCase(), new DialogInterface.OnClickListener() {
+                deleteDialog.setPositiveButton(getString(R.string.cancel).toUpperCase(), null);
+                deleteDialog.setNegativeButton(getString(R.string.delete).toUpperCase(), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         if (securityObj.isActiveSecurity() && securityObj.isPasswordOnDelete()) {
                             final boolean passco[] = {false};
                             AlertDialog.Builder passwordDialogBuilder = new AlertDialog.Builder(LFMainActivity.this, getDialogStyle());
                             final EditText editTextPassword = securityObj.getInsertPasswordDialog(LFMainActivity.this, passwordDialogBuilder);
                             editTextPassword.setHintTextColor(getResources().getColor(R.color.grey, null));
-                            passwordDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
-                            passwordDialogBuilder.setPositiveButton(getString(R.string.ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
+                            passwordDialogBuilder.setPositiveButton(getString(R.string.cancel).toUpperCase(), null);
+                            passwordDialogBuilder.setNegativeButton(getString(R.string.ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
                                 @Override
                                 public void onClick(DialogInterface dialog, int which) {
                                     //This should be empty. It will be overwritten later
@@ -2337,7 +2337,7 @@ public class LFMainActivity extends SharedMediaActivity {
                             passwordDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
                             passwordDialog.show();
                             AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, getAccentColor(), passwordDialog);
-                            passwordDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
+                            passwordDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setOnClickListener(new View.OnClickListener() {
                                 @Override
                                 public void onClick(View v) {
                                     // if password is correct, call DeletePhotos and perform deletion
@@ -2390,7 +2390,7 @@ public class LFMainActivity extends SharedMediaActivity {
                 textViewExcludeMessage.setTextColor(getTextColor());
                 excludeDialogBuilder.setView(excludeDialogLayout);
 
-                excludeDialogBuilder.setPositiveButton(this.getString(R.string.exclude).toUpperCase(), new DialogInterface.OnClickListener() {
+                excludeDialogBuilder.setNegativeButton(this.getString(R.string.exclude).toUpperCase(), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
 
                         if ((albumsMode && getAlbums().getSelectedCount() > 1)) {
@@ -2404,7 +2404,7 @@ public class LFMainActivity extends SharedMediaActivity {
                         }
                     }
                 });
-                excludeDialogBuilder.setNegativeButton(this.getString(R.string.cancel).toUpperCase(), null);
+                excludeDialogBuilder.setPositiveButton(this.getString(R.string.cancel).toUpperCase(), null);
                 AlertDialog alertDialogExclude = excludeDialogBuilder.create();
                 alertDialogExclude.show();
                 AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, getAccentColor(), alertDialogExclude);

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
@@ -409,7 +409,7 @@ public class SettingsActivity extends ThemedActivity {
         final boolean[] passco = {false};
         AlertDialog.Builder passwordDialogBuilder = new AlertDialog.Builder(SettingsActivity.this, getDialogStyle());
         final EditText editTextPassword  = securityObj.getInsertPasswordDialog(SettingsActivity.this,passwordDialogBuilder);
-        passwordDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
+        passwordDialogBuilder.setPositiveButton(getString(R.string.cancel).toUpperCase(), null);
         editTextPassword.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
         editTextPassword.setHint(getResources().getString(R.string.enter_password));
         editTextPassword.setHintTextColor(getSubTextColor());
@@ -437,7 +437,7 @@ public class SettingsActivity extends ThemedActivity {
                 }
             }
         });
-        passwordDialogBuilder.setPositiveButton(getString(R.string.ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
+        passwordDialogBuilder.setNegativeButton(getString(R.string.ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 //This should br empty it will be overwrite later
@@ -449,7 +449,7 @@ public class SettingsActivity extends ThemedActivity {
         passwordDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
         passwordDialog.show();
         AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, getAccentColor(), passwordDialog);
-        passwordDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
+        passwordDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setOnClickListener(new View.OnClickListener() {
 
             @Override
             public void onClick(View v) {
@@ -688,8 +688,8 @@ public class SettingsActivity extends ThemedActivity {
         AlertDialog.Builder builder = new AlertDialog.Builder(SettingsActivity.this, getDialogStyle());
         AlertDialogsHelper.getTextDialog(SettingsActivity.this, builder,
                 R.string.accent_color, R.string.accent_primary_same_mssg, null);
-        builder.setNegativeButton(this.getString(R.string.no_action).toUpperCase(), null);
-        builder.setPositiveButton(this.getString(R.string.yes_action).toUpperCase(), new DialogInterface.OnClickListener() {
+        builder.setPositiveButton(this.getString(R.string.no_action).toUpperCase(), null);
+        builder.setNegativeButton(this.getString(R.string.yes_action).toUpperCase(), new DialogInterface.OnClickListener() {
             @Override public void onClick(DialogInterface dialogInterface, int i) {
                 SP.putInt(getString(R.string.preference_accent_color), color);
                 updateTheme();


### PR DESCRIPTION
Fixed #2513 
Changes: A common convention has been made for all security related dialogs. The ok button is on the left and cancel on the right.
