### PR TITLE
Fix #2504 app crash in edit text

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/AddTextFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/AddTextFragment.java
@@ -70,6 +70,9 @@ public class AddTextFragment extends BaseEditFragment implements TextWatcher, Fo
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
+        if (activity.mainBitmap == null) {
+            return;
+        }
         mTextStickerView = getActivity().findViewById(R.id.text_sticker_panel);
 
         View cancel = mainView.findViewById(R.id.text_cancel);
@@ -205,7 +208,7 @@ public class AddTextFragment extends BaseEditFragment implements TextWatcher, Fo
 
     public void backToMain() {
         hideInput();
-        activity.changeMode(EditImageActivity.MODE_WRITE);
+        EditImageActivity.mode = EditImageActivity.MODE_WRITE;
         activity.writeFragment.clearSelection();
         activity.changeBottomFragment(EditImageActivity.MODE_MAIN);
         activity.mainImage.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Fixed #2504 

Changes: [AddTextFragment uses the bitmap from the activity so when the orientation change activity is recreated but fragment not so it uses the null bitmap so i make the condition before using the bitmap]

Screenshots of the change: 

<img src = "https://user-images.githubusercontent.com/22986571/52542680-5e480c80-2dc8-11e9-8d5e-05859dc98922.gif " width = 250 height = 400>