### PR TITLE
Fix #2200 Disabled drawer when selecting albums.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -574,10 +574,13 @@ public class LFMainActivity extends SharedMediaActivity {
                                         albumsAdapter.notifyItemChanged(getAlbums().toggleSelectAlbum(album));
                                         editMode = true;
                                         invalidateOptionsMenu();
-                                        if (getAlbums().getSelectedCount() == 0)
+                                        if (getAlbums().getSelectedCount() == 0) {
                                             getNavigationBar();
+                                            mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
+                                        }
                                         else {
                                             hideNavigationBar();
+                                            mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
                                             hidenav = true;
                                         }
                                     }
@@ -601,10 +604,13 @@ public class LFMainActivity extends SharedMediaActivity {
                     albumsAdapter.notifyItemChanged(getAlbums().toggleSelectAlbum(album));
                     editMode = true;
                     invalidateOptionsMenu();
-                    if (getAlbums().getSelectedCount() == 0)
+                    if (getAlbums().getSelectedCount() == 0) {
                         getNavigationBar();
+                        mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
+                    }
                     else {
                         hideNavigationBar();
+                        mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
                         hidenav = true;
                     }
                 }
@@ -622,10 +628,12 @@ public class LFMainActivity extends SharedMediaActivity {
                 }
                 editMode = true;
                 invalidateOptionsMenu();
-                if (getAlbums().getSelectedCount() == 0)
+                if (getAlbums().getSelectedCount() == 0) {
                     getNavigationBar();
-                else {
+                    mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
+                } else {
                     hideNavigationBar();
+                    mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
                     hidenav = true;
                 }
             }
@@ -653,8 +661,10 @@ public class LFMainActivity extends SharedMediaActivity {
             //int index = Integer.parseInt(v.findViewById(R.id.album_name).getTag().toString());
             if (editMode) {
                 albumsAdapter.notifyItemChanged(getAlbums().toggleSelectAlbum(album));
-                if (getAlbums().getSelectedCount() == 0)
+                if (getAlbums().getSelectedCount() == 0) {
                     getNavigationBar();
+                    mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
+                }
                 invalidateOptionsMenu();
             } else if(securityObj.isActiveSecurity() && securityObj.isPasswordOnfolder()){
                 final boolean[] passco = {false};
@@ -1149,6 +1159,7 @@ public class LFMainActivity extends SharedMediaActivity {
                 getNavigationBar();
                 if (albumsMode) {
                     getAlbums().clearSelectedAlbums();
+                    mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
                     new PrepareAlbumTask(activityContext).execute();
                 } else {
                     if (!all_photos && !fav_photos) {
@@ -1644,6 +1655,7 @@ public class LFMainActivity extends SharedMediaActivity {
         editMode = false;
         if (albumsMode) {
             getAlbums().clearSelectedAlbums();
+            mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
             albumsAdapter.notifyDataSetChanged();
         } else {
             if (!all_photos) {
@@ -2048,6 +2060,7 @@ public class LFMainActivity extends SharedMediaActivity {
                 getAlbums().getSelectedAlbum(0).settings.togglePin(getApplicationContext());
                 getAlbums().sortAlbums();
                 getAlbums().clearSelectedAlbums();
+                mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
                 invalidateOptionsMenu();
                 albumsAdapter.notifyDataSetChanged();
                 return true;
@@ -2237,6 +2250,7 @@ public class LFMainActivity extends SharedMediaActivity {
                             // in albumsMode, the selected albums have been deleted.
                             if (albumsMode) {
                                 getAlbums().clearSelectedAlbums();
+                                mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
                                 albumsAdapter.notifyDataSetChanged();
                             } else {
                                 if (!all_photos && !fav_photos) {
@@ -2867,6 +2881,7 @@ public class LFMainActivity extends SharedMediaActivity {
                                 SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.moved_target_folder_success), SnackBarHandler.LONG);
                                 getAlbums().deleteSelectedAlbums(LFMainActivity.this);
                                 getAlbums().clearSelectedAlbums();
+                                mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
                                 new PrepareAlbumTask(activityContext).execute();
                             } else {
                                 requestSdCardPermissions();
@@ -2994,6 +3009,7 @@ public class LFMainActivity extends SharedMediaActivity {
                             if (success) {
                                 SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.rename_succes), navigationView.getHeight());
                                 getAlbums().clearSelectedAlbums();
+                                mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
                                 invalidateOptionsMenu();
                             } else if (!rename) {
                                 SnackBarHandler.showWithBottomMargin(mDrawerLayout, getString(R.string.rename_error), navigationView.getHeight());
@@ -3761,6 +3777,7 @@ public class LFMainActivity extends SharedMediaActivity {
             SnackBarHandler.show(mDrawerLayout, getResources().getString(R.string.zip_location) +
                     path);
             getAlbums().clearSelectedAlbums();
+            mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
             albumsAdapter.notifyDataSetChanged();
             invalidateOptionsMenu();
         }


### PR DESCRIPTION
Fixed #2200 

Changes: LFMainActivity.java. Disabled drawer when selecting albums and re-enabled it when no albums are selected.

Screenshots of the change: 
![51489028-1e939380-1dcd-11e9-9cc7-888d9d39bde5](https://user-images.githubusercontent.com/37517284/52648621-d7507c80-2f0c-11e9-8a15-1f4717cdb95a.gif)