### PR TITLE
Fix #2210 Added feature to remove multiple photos from favourites from album itself.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -781,7 +781,6 @@ public class LFMainActivity extends SharedMediaActivity {
         super.onCreate(savedInstanceState);
         Log.e("TAG", "lfmain");
         ButterKnife.bind(this);
-
         navigationView = findViewById(R.id.bottombar);
         favicon = findViewById(R.id.Drawer_favourite_Icon);
 

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -781,7 +781,7 @@ public class LFMainActivity extends SharedMediaActivity {
         super.onCreate(savedInstanceState);
         Log.e("TAG", "lfmain");
         ButterKnife.bind(this);
-      
+
         navigationView = findViewById(R.id.bottombar);
         favicon = findViewById(R.id.Drawer_favourite_Icon);
 
@@ -1883,8 +1883,8 @@ public class LFMainActivity extends SharedMediaActivity {
         getfavouriteslist();
         menu.findItem(R.id.action_copy).setVisible(visible);
         menu.findItem(R.id.action_move).setVisible((visible || editMode) && !fav_photos);
-        menu.findItem(R.id.action_add_favourites).setVisible((visible || editMode) && (!albumsMode && !fav_photos));
         menu.findItem(R.id.action_add_favourites).setVisible((visible || editMode) && (!albumsMode && !fav_photos && !checkfav(favouriteslist,getAlbum().getSelectedMedia())));
+        menu.findItem(R.id.action_remove_favourites).setVisible((visible || editMode) && (!albumsMode && !fav_photos  && checkfav(favouriteslist,getAlbum().getSelectedMedia())));
         menu.findItem(R.id.excludeAlbumButton).setVisible(editMode && !all_photos && albumsMode && !fav_photos);
         menu.findItem(R.id.zipAlbumButton).setVisible(editMode && !all_photos && albumsMode && !fav_photos && !hidden &&
                 getAlbums().getSelectedCount() == 1);
@@ -1918,21 +1918,17 @@ public class LFMainActivity extends SharedMediaActivity {
     }
 
     private boolean checkfav(ArrayList<Media> favlist,ArrayList<Media> selected) {
-        int check = 0;
-        for (Media sm : selected) {
-            check = 0;
-            for (Media fm : favlist) {
-                if (sm.getPath().equals(fm.getPath())) {
-                    check = 1;
-                }
+        if (selected.size() <= favlist.size()) {
+            Boolean found;
+            for (Media sm : selected) {
+                found = false;
+                for (Media fm : favlist) {
+                    if (sm.getPath().equals(fm.getPath()))
+                        found = true;
+                } if (!found) return false;
             }
-            if (check == 0) {
-                return false;
-            }
-        }
-        if (selected.size() == 0) {
-            return false;
-        } else return true;
+            return true;
+        } else return false;
     }
 
     //endregion

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1883,8 +1883,8 @@ public class LFMainActivity extends SharedMediaActivity {
         getfavouriteslist();
         menu.findItem(R.id.action_copy).setVisible(visible);
         menu.findItem(R.id.action_move).setVisible((visible || editMode) && !fav_photos);
+        menu.findItem(R.id.action_add_favourites).setVisible((visible || editMode) && (!albumsMode && !fav_photos));
         menu.findItem(R.id.action_add_favourites).setVisible((visible || editMode) && (!albumsMode && !fav_photos && !checkfav(favouriteslist,getAlbum().getSelectedMedia())));
-        menu.findItem(R.id.action_remove_favourites).setVisible((visible || editMode) && (!albumsMode && !fav_photos  && checkfav(favouriteslist,getAlbum().getSelectedMedia())));
         menu.findItem(R.id.excludeAlbumButton).setVisible(editMode && !all_photos && albumsMode && !fav_photos);
         menu.findItem(R.id.zipAlbumButton).setVisible(editMode && !all_photos && albumsMode && !fav_photos && !hidden &&
                 getAlbums().getSelectedCount() == 1);
@@ -1918,17 +1918,21 @@ public class LFMainActivity extends SharedMediaActivity {
     }
 
     private boolean checkfav(ArrayList<Media> favlist,ArrayList<Media> selected) {
-        if (selected.size() <= favlist.size()) {
-            Boolean found;
-            for (Media sm : selected) {
-                found = false;
-                for (Media fm : favlist) {
-                    if (sm.getPath().equals(fm.getPath()))
-                        found = true;
-                } if (!found) return false;
+        int check = 0;
+        for (Media sm : selected) {
+            check = 0;
+            for (Media fm : favlist) {
+                if (sm.getPath().equals(fm.getPath())) {
+                    check = 1;
+                }
             }
-            return true;
-        } else return false;
+            if (check == 0) {
+                return false;
+            }
+        }
+        if (selected.size() == 0) {
+            return false;
+        } else return true;
     }
 
     //endregion

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1883,8 +1883,8 @@ public class LFMainActivity extends SharedMediaActivity {
         getfavouriteslist();
         menu.findItem(R.id.action_copy).setVisible(visible);
         menu.findItem(R.id.action_move).setVisible((visible || editMode) && !fav_photos);
-        menu.findItem(R.id.action_add_favourites).setVisible((visible || editMode) && (!albumsMode && !fav_photos));
         menu.findItem(R.id.action_add_favourites).setVisible((visible || editMode) && (!albumsMode && !fav_photos && !checkfav(favouriteslist,getAlbum().getSelectedMedia())));
+        menu.findItem(R.id.action_remove_favourites).setVisible((visible || editMode) && (!albumsMode && !fav_photos  && checkfav(favouriteslist,getAlbum().getSelectedMedia())));
         menu.findItem(R.id.excludeAlbumButton).setVisible(editMode && !all_photos && albumsMode && !fav_photos);
         menu.findItem(R.id.zipAlbumButton).setVisible(editMode && !all_photos && albumsMode && !fav_photos && !hidden &&
                 getAlbums().getSelectedCount() == 1);
@@ -1918,21 +1918,17 @@ public class LFMainActivity extends SharedMediaActivity {
     }
 
     private boolean checkfav(ArrayList<Media> favlist,ArrayList<Media> selected) {
-        int check = 0;
-        for (Media sm : selected) {
-            check = 0;
-            for (Media fm : favlist) {
-                if (sm.getPath().equals(fm.getPath())) {
-                    check = 1;
-                }
+        if (selected.size() <= favlist.size()) {
+            Boolean found;
+            for (Media sm : selected) {
+                found = false;
+                for (Media fm : favlist) {
+                    if (sm.getPath().equals(fm.getPath()))
+                        found = true;
+                } if (!found) return false;
             }
-            if (check == 0) {
-                return false;
-            }
-        }
-        if (selected.size() == 0) {
-            return false;
-        } else return true;
+            return true;
+        } else return false;
     }
 
     //endregion

--- a/app/src/main/res/menu/menu_albums.xml
+++ b/app/src/main/res/menu/menu_albums.xml
@@ -71,6 +71,11 @@
             app:showAsAction="never"/>
 
         <item
+            android:id="@+id/action_remove_favourites"
+            android:title="@string/remove_favourite_menu"
+            app:showAsAction="never"/>
+
+        <item
             android:id="@+id/create_gif"
             android:title="Create GIF"
             app:showAsAction="never"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -567,12 +567,15 @@
     <string name="trashbin_move_error">Error! Images cannot be moved to the TrashBin</string>
     <string name="change_cover">Album cover changed..</string>
     <string name="add_favourite">Image is successfully added to the favourites collection.</string>
+    <string name="remove_favourite">Image has been successfully removed from the favourites collection.</string>
     <string name="add_favourite_multiple">Images are successfully added to the favourites collection.</string>
+    <string name="remove_favourite_multiple">Images have been successfully removed from the favourites collection.</string>
     <string name="remove_from_favourite">images removed from favourites section</string>
     <string name="invalid_selection">Invalid Selection</string>
     <string name="single_image_removed">Image removed from favourites section</string>
     <string name="check_favourite">Image is already present in the favourites collection.</string>
     <string name="check_favourite_multipleitems">All the images are already present in the favourite collection.</string>
+    <string name="none_item_favourites">None of the items selected were present in favourites collection.</string>
     <string name="rename_photo_action">Rename photo</string>
     <string name="drawer_open">Open navigation drawer</string>
     <string name="drawer_close">Close navigation drawer</string>
@@ -1386,6 +1389,7 @@
     <string name="photo_deletion_failed">Photo deletion failed</string>
     <string name="remove">Remove</string>
     <string name="remove_from_favourites">Remove From Favourites</string>
+    <string name="remove_favourite_menu">Remove from favourites</string>
     <string name="remove_favourites_body">Are you sure you want to remove the selected media from the favourites folder?
     </string>
 </resources>


### PR DESCRIPTION
Fixed #2210 

Changes: LFMainActivity.java, menu_albums.xml, strings.xml Added option to remove selected photos from favorites in options menu. This option is visible only when any one of the selected photos is in favorites.

Screenshots of the change: 
![51489028-1e939380-1dcd-11e9-9cc7-888d9d39bde5](https://user-images.githubusercontent.com/37517284/52648390-7628a900-2f0c-11e9-8a4e-909f928416dc.gif)
