### PR TITLE
snackbar to restart after theme change added

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
@@ -26,6 +26,7 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.CompoundButton;
 import android.widget.EditText;
+import android.widget.FrameLayout;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.ScrollView;
@@ -603,6 +604,27 @@ public class SettingsActivity extends ThemedActivity {
             public void onClick(DialogInterface dialog, int which) {
                 SP.putInt(getString(R.string.preference_base_theme), getBaseTheme());
                 setTheme();
+                Snackbar snackbar = Snackbar
+                        .make(parent, R.string.restart_app, Snackbar.LENGTH_SHORT)
+                        .setAction(getString(R.string.restart).toUpperCase(), new View.OnClickListener() {
+                            @Override
+                            public void onClick(View view) {
+                                Intent restartIntent = getBaseContext().getPackageManager()
+                                        .getLaunchIntentForPackage(getBaseContext().getPackageName());
+                                assert restartIntent != null;
+                                restartIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                                startActivity(restartIntent);
+                            }
+                        })
+                        .setActionTextColor(getAccentColor());
+                View sbView = snackbar.getView();
+                final FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) sbView.getLayoutParams();
+                params.setMargins(params.leftMargin,
+                        params.topMargin,
+                        params.rightMargin,
+                        params.bottomMargin);
+                sbView.setLayoutParams(params);
+                snackbar.show();
             }
         });
         dialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), new DialogInterface.OnClickListener() {

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
@@ -611,7 +611,6 @@ public class SettingsActivity extends ThemedActivity {
                             public void onClick(View view) {
                                 Intent restartIntent = getBaseContext().getPackageManager()
                                         .getLaunchIntentForPackage(getBaseContext().getPackageName());
-                                assert restartIntent != null;
                                 restartIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                                 startActivity(restartIntent);
                             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1308,6 +1308,7 @@
     <string name="empty_trashbin_mssg">No Items present currently</string>
     <string name="trashbin_mssg">Only images deleted in the Phimpme Android app are present here.</string>
     <string name="install_facebook">Facebook not installed</string>
+    <string name="restart">Restart</string>
     <string name="restart_app">Please restart the app for better results!</string>
     <string name="press_back_again_to_exit">Press back again to exit</string>
     <string name="photos_moved_successfully">Photos moved successfully</string>


### PR DESCRIPTION
Fixed #2518 
Changes:
snackbar to restart the app after theme change was added.


