### PR TITLE
Fix for issue#2535: Changed highlight colors in dark and amoled theme.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -1253,7 +1253,10 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 editTextNewName.setSelectAllOnFocus(true);
                 editTextNewName.setHint(R.string.description_hint);
                 editTextNewName.setHintTextColor(ContextCompat.getColor(getApplicationContext(), R.color.grey));
-                editTextNewName.setHighlightColor(ContextCompat.getColor(getApplicationContext(), R.color.cardview_shadow_start_color));
+                if(getBaseTheme() == ThemeHelper.DARK_THEME || getBaseTheme() == ThemeHelper.AMOLED_THEME){
+                    editTextNewName.setTextColor(R.color.black);
+                    editTextNewName.setHighlightColor(ContextCompat.getColor(getApplicationContext(), R.color.accent_grey));
+                } else editTextNewName.setHighlightColor(ContextCompat.getColor(getApplicationContext(), R.color.cardview_shadow_start_color));
                 editTextNewName.selectAll();
                 editTextNewName.setSingleLine(false);
                 AlertDialogsHelper.getInsertTextDialog(SingleMediaActivity.this, renameDialogBuilder,


### PR DESCRIPTION
Fixed #2535 

Changes: Colors for highlighting the text in dark and amoled themes have been changed so that they are properly visible.

Screenshots of the change: 

![screencap](https://user-images.githubusercontent.com/41234408/52714849-f6104b00-2fc0-11e9-8ff0-40f75ce9ff17.png)

![screencap1](https://user-images.githubusercontent.com/41234408/52714856-f872a500-2fc0-11e9-9c60-952b05e964e1.png)

![screencap2](https://user-images.githubusercontent.com/41234408/52714860-fad4ff00-2fc0-11e9-8750-c1a4359aa08f.png)