### PR TITLE
Fix #2525 Back button get stuck when there is deny of permission

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/CameraActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/CameraActivity.java
@@ -2863,7 +2863,6 @@ public class CameraActivity extends ThemedActivity implements AudioListener.Audi
                     if (ActivityCompat.shouldShowRequestPermissionRationale(CameraActivity.this,
                             Manifest.permission.CAMERA)) {
                         // now, user has denied permission (but not permanently!)
-
                     } else {
                         permanentDenyPermission = true;
                     }

--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/CameraActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/CameraActivity.java
@@ -2860,12 +2860,10 @@ public class CameraActivity extends ThemedActivity implements AudioListener.Audi
                         Log.d(TAG, "camera permission granted");
                     preview.retryOpenCamera();
                 } else {
-                    if (ActivityCompat.shouldShowRequestPermissionRationale(CameraActivity.this,
-                            Manifest.permission.CAMERA)) {
-                        // now, user has denied permission (but not permanently!)
-                    } else {
+                    if (!ActivityCompat.shouldShowRequestPermissionRationale(CameraActivity.this,
+                            Manifest.permission.CAMERA))
                         permanentDenyPermission = true;
-                    }
+
                     if (MyDebug.LOG)
                         Log.d(TAG, "camera permission denied");
                     // permission denied, boo! Disable the

--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/CameraActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/CameraActivity.java
@@ -155,6 +155,7 @@ public class CameraActivity extends ThemedActivity implements AudioListener.Audi
 
     public ProgressDialog progressDialog;
     public boolean isFromOutside = false;
+    private boolean permanentDenyPermission;
 
     @BindView(R.id.increase_zoom)
     ImageButton increaseZoom;
@@ -2749,6 +2750,10 @@ public class CameraActivity extends ThemedActivity implements AudioListener.Audi
             return;
         }
 
+        if (permanentDenyPermission) {
+            return;
+        }
+
         if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.CAMERA)) {
             // Show an explanation to the user *asynchronously* -- don't block
             // this thread waiting for the user's response! After the user
@@ -2855,6 +2860,13 @@ public class CameraActivity extends ThemedActivity implements AudioListener.Audi
                         Log.d(TAG, "camera permission granted");
                     preview.retryOpenCamera();
                 } else {
+                    if (ActivityCompat.shouldShowRequestPermissionRationale(CameraActivity.this,
+                            Manifest.permission.CAMERA)) {
+                        // now, user has denied permission (but not permanently!)
+
+                    } else {
+                        permanentDenyPermission = true;
+                    }
                     if (MyDebug.LOG)
                         Log.d(TAG, "camera permission denied");
                     // permission denied, boo! Disable the


### PR DESCRIPTION
Fixed #2525 

Changes: [calling the runtime permission in onResume can create a infinite loop if user deny the permission so i check that if user deny permission temporary or permanent and return if permanent deny the permission.]

GIF of the change: 

<img src = "https://user-images.githubusercontent.com/22986571/52732233-b6a82580-2fe5-11e9-9c71-1b80860d1105.gif " width = 250 height = 400>