### PR TITLE
Fix #2540 first locked image should not be visible

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
@@ -96,7 +96,7 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
         else
             holder.pin.setVisibility(View.INVISIBLE);
         String path="";
-        if (!filterCheck(a.getPath(),securityObj.getSecuredfolders()))
+        if (!securityObj.isPasswordOnfolder()||!filterCheck(a.getPath(),securityObj.getSecuredfolders()))
             path=f.getPath();
             Glide.with(holder.picture.getContext())
                     .load(path)

--- a/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
@@ -49,7 +49,6 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
     private BitmapDrawable placeholder;
     Context context;
     private SecurityHelper securityObj;
-    private String[] securedFolders;
 
     public AlbumsAdapter(ArrayList<Album> ph, Context context) {
         albums = ph;
@@ -61,7 +60,7 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
 
     public void updateTheme() {
         theme.updateTheme();
-        Drawable drawable = ContextCompat.getDrawable(context, R.drawable.placeholder);
+        Drawable drawable = ContextCompat.getDrawable(context, R.drawable.ic_error);
         placeholder = (BitmapDrawable) drawable;
     }
 
@@ -78,8 +77,7 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
         Album a = SharedMediaActivity.getAlbums().dispAlbums.get(position);
         Media f = a.getCoverAlbum();
         securityObj.updateSecuritySetting();
-        securedFolders=securityObj.getSecuredfolders();
-      
+
         if(a.getPath().contains(Environment.getExternalStorageDirectory().getPath())){
             holder.storage.setVisibility(View.INVISIBLE);
         } else {
@@ -97,9 +95,11 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
         }
         else
             holder.pin.setVisibility(View.INVISIBLE);
-        if (!filterCheck(a.getPath(),securedFolders)) {
+        String path="";
+        if (!filterCheck(a.getPath(),securityObj.getSecuredfolders()))
+            path=f.getPath();
             Glide.with(holder.picture.getContext())
-                    .load(f.getPath())
+                    .load(path)
                     .asBitmap()
                     .diskCacheStrategy(DiskCacheStrategy.RESULT)
                     .priority(Priority.HIGH)
@@ -122,13 +122,6 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
                         }
                     })
                     .into(holder.picture);
-        }
-        else{
-            Glide.with(holder.picture.getContext())
-                    .load(R.drawable.ic_error)
-                    .into(holder.picture);
-        }
-
 
         holder.name.setTag(a);
 

--- a/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
@@ -31,6 +31,7 @@ import org.fossasia.phimpme.gallery.data.Album;
 import org.fossasia.phimpme.gallery.data.Media;
 import org.fossasia.phimpme.gallery.util.ColorPalette;
 import org.fossasia.phimpme.gallery.util.PreferenceUtil;
+import org.fossasia.phimpme.gallery.util.SecurityHelper;
 import org.fossasia.phimpme.gallery.util.ThemeHelper;
 
 import java.util.ArrayList;
@@ -47,12 +48,15 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
     private ThemeHelper theme;
     private BitmapDrawable placeholder;
     Context context;
+    private SecurityHelper securityObj;
+    private String[] securedFolders;
 
     public AlbumsAdapter(ArrayList<Album> ph, Context context) {
         albums = ph;
         theme = new ThemeHelper(context);
         this.context = context;
         updateTheme();
+        securityObj=new SecurityHelper(context);
     }
 
     public void updateTheme() {
@@ -73,6 +77,8 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
     public void onBindViewHolder(final AlbumsAdapter.ViewHolder holder, int position) {
         Album a = SharedMediaActivity.getAlbums().dispAlbums.get(position);
         Media f = a.getCoverAlbum();
+        securityObj.updateSecuritySetting();
+        securedFolders=securityObj.getSecuredfolders();
       
         if(a.getPath().contains(Environment.getExternalStorageDirectory().getPath())){
             holder.storage.setVisibility(View.INVISIBLE);
@@ -91,31 +97,38 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
         }
         else
             holder.pin.setVisibility(View.INVISIBLE);
+        if (!filterCheck(a.getPath(),securedFolders)) {
+            Glide.with(holder.picture.getContext())
+                    .load(f.getPath())
+                    .asBitmap()
+                    .diskCacheStrategy(DiskCacheStrategy.RESULT)
+                    .priority(Priority.HIGH)
+                    .signature(f.getSignature())
+                    .centerCrop()
+                    .error(R.drawable.ic_error)
+                    .placeholder(placeholder)
+                    .animate(R.anim.fade_in)
+                    .listener(new RequestListener<String, Bitmap>() {
+                        @Override
+                        public boolean onException(Exception e, String model, Target<Bitmap> target, boolean isFirstResource) {
+                            PreferenceUtil SP = PreferenceUtil.getInstance(context);
+                            SP.putBoolean(holder.picture.getContext().getString(R.string.preference_use_alternative_provider), true);
+                            return false;
+                        }
 
-        Glide.with(holder.picture.getContext())
-                .load(f.getPath())
-                .asBitmap()
-                .diskCacheStrategy(DiskCacheStrategy.RESULT)
-                .priority(Priority.HIGH)
-                .signature(f.getSignature())
-                .centerCrop()
-                .error(R.drawable.ic_error)
-                .placeholder(placeholder)
-                .animate(R.anim.fade_in)
-                .listener(new RequestListener<String, Bitmap>() {
-                    @Override
-                    public boolean onException(Exception e, String model, Target<Bitmap> target, boolean isFirstResource) {
-                        PreferenceUtil SP = PreferenceUtil.getInstance(context);
-                        SP.putBoolean(holder.picture.getContext().getString(R.string.preference_use_alternative_provider), true);
-                        return false;
-                    }
+                        @Override
+                        public boolean onResourceReady(Bitmap resource, String model, Target<Bitmap> target, boolean isFromMemoryCache, boolean isFirstResource) {
+                            return false;
+                        }
+                    })
+                    .into(holder.picture);
+        }
+        else{
+            Glide.with(holder.picture.getContext())
+                    .load(R.drawable.ic_error)
+                    .into(holder.picture);
+        }
 
-                    @Override
-                    public boolean onResourceReady(Bitmap resource, String model, Target<Bitmap> target, boolean isFromMemoryCache, boolean isFirstResource) {
-                        return false;
-                    }
-                })
-                .into(holder.picture);
 
         holder.name.setTag(a);
 
@@ -182,6 +195,15 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
     @Override
     public int getItemCount() {
         return SharedMediaActivity.getAlbums().dispAlbums.size();
+    }
+    public boolean filterCheck(String foldername,String[] securedFolders){
+        if (securedFolders!=null){
+            for (String s:securedFolders){
+                if (s.equals(foldername))
+                    return true;
+            }
+        }
+        return false;
     }
 
     static class ViewHolder extends RecyclerView.ViewHolder {


### PR DESCRIPTION
Fixed #2540 for better privacy, first image of locked folders are not visible. 

Changes: Albums adapter is slightly modified.

**Screenshots** 
![image](https://user-images.githubusercontent.com/35160400/52734382-16ed9600-2feb-11e9-9941-f0aaca2d68f0.png)
