### PR TITLE
Fix #2527 actionbar size issue

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -254,6 +254,7 @@
         <activity
             android:name=".gallery.activities.SettingsActivity"
             android:configChanges="orientation|screenSize"
+            android:windowSoftInputMode="adjustNothing"
             android:label="@string/settings"
             android:theme="@style/Theme.AppCompat.NoActionBar">
             <intent-filter>


### PR DESCRIPTION
Fixed #2527 

Changes: [after adding adjustNothing in manifest makes no size change effect on actionbar]

Screenshots of the change: 

<img src = "https://user-images.githubusercontent.com/22986571/52734619-b90d7e00-2feb-11e9-8f3f-997c838a259d.jpeg" width = 250 height = 400>
