### PR TITLE
Fix #2534 After orientation change showing two selected option in edit mode

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
@@ -174,7 +174,7 @@ public class EditImageActivity extends EditBaseActivity implements View.OnClickL
     private void setInitialFragments() {
         getSupportFragmentManager()
                 .beginTransaction()
-                .add(R.id.controls_container, getFragment(initalBottomFragment))
+                .replace(R.id.controls_container, getFragment(initalBottomFragment))
                 .commit();
 
         changeMiddleFragment(initalMiddleFragment);


### PR DESCRIPTION
Fixed #2534 

Changes: [Changing the orientation does not destroy the fragment , it detached the fragment so when the activity recreated it attach the fragment so when we again call the method setInitialFragments has add method  which add another fragment cause two selected option.]

GIF of the change: 

![2019_02_14_03_00_47](https://user-images.githubusercontent.com/22986571/52745739-d6e7dc80-3005-11e9-8378-c6fa99df08fa.gif)