### PR TITLE
Fix for issue#2528: Now description will always be visible.

### DIFF
--- a/app/src/main/res/layout/image_description.xml
+++ b/app/src/main/res/layout/image_description.xml
@@ -2,34 +2,34 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app2="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+    android:fitsSystemWindows="true"
+    android:orientation="vertical">
 
     <LinearLayout
+        android:id="@+id/image_desc_top"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:id="@+id/image_desc_top"
         android:padding="13dp">
 
         <ImageButton
+            android:id="@+id/img_desc_back_arrow"
             android:layout_width="48dp"
             android:layout_height="48dp"
             android:layout_gravity="center"
-            android:id="@+id/img_desc_back_arrow"
-            android:background="@drawable/back_arrow"/>
+            android:background="@drawable/back_arrow" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:gravity="center"
             android:layout_gravity="center"
-            android:textSize="@dimen/sub_big_text"
+            android:gravity="center"
+            android:text="@string/details"
             android:textColor="@color/white"
-            android:textStyle="bold"
-            android:text="@string/details"/>
+            android:textSize="@dimen/sub_big_text"
+            android:textStyle="bold" />
 
     </LinearLayout>
 
@@ -37,47 +37,52 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbarSize="4dp">
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:layout_margin="@dimen/medium_spacing">
+            android:orientation="vertical">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/medium_spacing"
+                android:layout_marginTop="@dimen/medium_spacing"
                 android:orientation="horizontal">
 
                 <com.mikepenz.iconics.view.IconicsImageView
+                    android:id="@+id/date_icon"
                     android:layout_width="30dp"
                     android:layout_height="30dp"
-                    android:id="@+id/date_icon"
-                    app2:iiv_icon="gmd-access-time"
-                    android:layout_gravity="center"/>
+                    android:layout_gravity="center"
+                    app2:iiv_icon="gmd-access-time" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginLeft="10dp">
+                    android:layout_marginLeft="10dp"
+                    android:orientation="vertical">
+
                     <TextView
+                        android:id="@+id/date_label"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="@string/date"
-                        android:id="@+id/date_label"
-                        android:textStyle="bold"
                         android:textColor="@color/md_grey_200"
-                        android:textSize="@dimen/sub_big_text" />
+                        android:textSize="@dimen/sub_big_text"
+                        android:textStyle="bold" />
+
                     <View
                         android:layout_width="match_parent"
-                        android:layout_height="1dp"/>
+                        android:layout_height="1dp" />
+
                     <TextView
+                        android:id="@+id/image_desc_date"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
-                        android:id="@+id/image_desc_date"
-                        tools:text="28/September/2018"
                         android:textColor="@color/md_grey_400"
-                        android:textSize="@dimen/medium_text"/>
+                        android:textSize="@dimen/medium_text"
+                        tools:text="28/September/2018" />
 
                 </LinearLayout>
 
@@ -85,43 +90,47 @@
 
             <View
                 android:layout_width="match_parent"
-                android:layout_height="20dp"/>
+                android:layout_height="20dp" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_margin="@dimen/medium_spacing"
                 android:orientation="horizontal">
 
                 <com.mikepenz.iconics.view.IconicsImageView
+                    android:id="@+id/loca_icon"
                     android:layout_width="30dp"
                     android:layout_height="30dp"
-                    android:id="@+id/loca_icon"
                     android:layout_gravity="center"
-                    app2:iiv_icon="gmd-location-on"/>
+                    app2:iiv_icon="gmd-location-on" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginLeft="10dp">
+                    android:layout_marginLeft="10dp"
+                    android:orientation="vertical">
+
                     <TextView
+                        android:id="@+id/location_label"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="@string/location"
-                        android:id="@+id/location_label"
-                        android:textStyle="bold"
                         android:textColor="@color/md_grey_200"
-                        android:textSize="@dimen/sub_big_text" />
+                        android:textSize="@dimen/sub_big_text"
+                        android:textStyle="bold" />
+
                     <View
                         android:layout_width="match_parent"
-                        android:layout_height="1dp"/>
+                        android:layout_height="1dp" />
+
                     <TextView
+                        android:id="@+id/image_desc_loc"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="@string/no_location"
-                        android:id="@+id/image_desc_loc"
                         android:textColor="@color/md_grey_400"
-                        android:textSize="@dimen/medium_text"/>
+                        android:textSize="@dimen/medium_text" />
 
                 </LinearLayout>
 
@@ -129,57 +138,61 @@
 
             <View
                 android:layout_width="match_parent"
-                android:layout_height="20dp"/>
+                android:layout_height="20dp" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/medium_spacing"
                 android:orientation="horizontal">
 
                 <com.mikepenz.iconics.view.IconicsImageView
+                    android:id="@+id/detail_icon"
                     android:layout_width="30dp"
                     android:layout_height="30dp"
-                    android:id="@+id/detail_icon"
                     android:layout_gravity="fill"
-                    app2:iiv_icon="gmd-camera-roll"/>
+                    app2:iiv_icon="gmd-camera-roll" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginLeft="10dp">
+                    android:layout_marginLeft="10dp"
+                    android:orientation="vertical">
 
                     <TextView
+                        android:id="@+id/details_label"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="@string/details"
-                        android:id="@+id/details_label"
-                        android:textStyle="bold"
                         android:textColor="@color/md_grey_200"
-                        android:textSize="@dimen/sub_big_text" />
+                        android:textSize="@dimen/sub_big_text"
+                        android:textStyle="bold" />
+
                     <View
                         android:layout_width="match_parent"
-                        android:layout_height="@dimen/fab_margin"/>
+                        android:layout_height="@dimen/fab_margin" />
 
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:layout_marginBottom="2dp">
+                        android:layout_marginBottom="2dp"
+                        android:orientation="horizontal">
+
                         <TextView
+                            android:id="@+id/title_label"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/details_title"
-                            android:id="@+id/title_label"
-                            android:textStyle="bold"
-                            android:textSize="@dimen/sub_big_text"/>
+                            android:textSize="@dimen/sub_big_text"
+                            android:textStyle="bold" />
+
                         <TextView
+                            android:id="@+id/image_desc_title"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginLeft="5dp"
-                            android:id="@+id/image_desc_title"
-                            android:textSize="@dimen/medium_text"
-                            android:layout_marginBottom="2dp"/>
+                            android:layout_marginBottom="2dp"
+                            android:textSize="@dimen/medium_text" />
 
                     </LinearLayout>
 
@@ -191,172 +204,187 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal">
+
                         <TextView
+                            android:id="@+id/type_label"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/type"
-                            android:id="@+id/type_label"
-                            android:textStyle="bold"
-                            android:textSize="@dimen/sub_big_text"/>
+                            android:textSize="@dimen/sub_big_text"
+                            android:textStyle="bold" />
+
                         <TextView
+                            android:id="@+id/image_desc_type"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:id="@+id/image_desc_type"
                             android:layout_marginLeft="5dp"
-                            android:textSize="@dimen/medium_text"
-                            android:layout_marginBottom="2dp"/>
+                            android:layout_marginBottom="2dp"
+                            android:textSize="@dimen/medium_text" />
 
                     </LinearLayout>
 
                     <View
                         android:layout_width="match_parent"
-                        android:layout_height="8dp"/>
+                        android:layout_height="8dp" />
 
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal">
+
                         <TextView
+                            android:id="@+id/size_label"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/size"
-                            android:id="@+id/size_label"
-                            android:textStyle="bold"
-                            android:textSize="@dimen/sub_big_text"/>
+                            android:textSize="@dimen/sub_big_text"
+                            android:textStyle="bold" />
+
                         <TextView
+                            android:id="@+id/image_desc_size"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:id="@+id/image_desc_size"
                             android:layout_marginLeft="5dp"
-                            android:textSize="@dimen/medium_text"
-                            android:layout_marginBottom="2dp"/>
+                            android:layout_marginBottom="2dp"
+                            android:textSize="@dimen/medium_text" />
 
                     </LinearLayout>
 
                     <View
                         android:layout_width="match_parent"
-                        android:layout_height="8dp"/>
+                        android:layout_height="8dp" />
 
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal">
+
                         <TextView
+                            android:id="@+id/resolution_label"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/resolution"
-                            android:id="@+id/resolution_label"
-                            android:textStyle="bold"
-                            android:textSize="@dimen/sub_big_text"/>
+                            android:textSize="@dimen/sub_big_text"
+                            android:textStyle="bold" />
+
                         <TextView
+                            android:id="@+id/image_desc_res"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:id="@+id/image_desc_res"
                             android:layout_marginLeft="5dp"
-                            android:textSize="@dimen/medium_text"
-                            android:layout_marginBottom="2dp"/>
+                            android:layout_marginBottom="2dp"
+                            android:textSize="@dimen/medium_text" />
 
                     </LinearLayout>
 
                     <View
                         android:layout_width="match_parent"
-                        android:layout_height="8dp"/>
+                        android:layout_height="8dp" />
 
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal">
+
                         <TextView
+                            android:id="@+id/path_label"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/path"
-                            android:id="@+id/path_label"
-                            android:textStyle="bold"
-                            android:textSize="@dimen/sub_big_text"/>
+                            android:textSize="@dimen/sub_big_text"
+                            android:textStyle="bold" />
+
                         <TextView
+                            android:id="@+id/image_desc_path"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:id="@+id/image_desc_path"
                             android:layout_marginLeft="5dp"
                             android:layout_marginBottom="2dp"
-                            android:textSize="@dimen/medium_text"/>
+                            android:textSize="@dimen/medium_text" />
 
                     </LinearLayout>
 
                     <View
                         android:layout_width="match_parent"
-                        android:layout_height="8dp"/>
+                        android:layout_height="8dp" />
 
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal">
+
                         <TextView
+                            android:id="@+id/orientation_label"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/orientation"
-                            android:id="@+id/orientation_label"
-                            android:textStyle="bold"
-                            android:textSize="@dimen/sub_big_text"/>
+                            android:textSize="@dimen/sub_big_text"
+                            android:textStyle="bold" />
+
                         <TextView
+                            android:id="@+id/image_desc_orientation"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:id="@+id/image_desc_orientation"
                             android:layout_marginLeft="5dp"
-                            android:textSize="@dimen/medium_text"
-                            android:layout_marginBottom="2dp"/>
+                            android:layout_marginBottom="2dp"
+                            android:textSize="@dimen/medium_text" />
 
                     </LinearLayout>
 
                     <View
                         android:layout_width="match_parent"
-                        android:layout_height="8dp"/>
+                        android:layout_height="8dp" />
 
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal">
+
                         <TextView
+                            android:id="@+id/exif_label"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/exif"
-                            android:id="@+id/exif_label"
-                            android:textStyle="bold"
-                            android:textSize="@dimen/sub_big_text"/>
+                            android:textSize="@dimen/sub_big_text"
+                            android:textStyle="bold" />
+
                         <TextView
+                            android:id="@+id/image_desc_exif"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:textSize="@dimen/medium_text"
-                            android:textColor="@color/md_grey_400"
-                            android:id="@+id/image_desc_exif"
                             android:layout_marginLeft="5dp"
-                            android:layout_marginBottom="2dp"/>
+                            android:layout_marginBottom="2dp"
+                            android:textColor="@color/md_grey_400"
+                            android:textSize="@dimen/medium_text" />
 
                     </LinearLayout>
 
                     <View
                         android:layout_width="match_parent"
-                        android:layout_height="8dp"/>
+                        android:layout_height="8dp" />
 
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/medium_spacing"
                         android:orientation="horizontal">
+
                         <TextView
+                            android:id="@+id/description_label"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/type_description"
-                            android:id="@+id/description_label"
-                            android:textStyle="bold"
-                            android:textSize="@dimen/sub_big_text"/>
+                            android:textSize="@dimen/sub_big_text"
+                            android:textStyle="bold" />
+
                         <TextView
+                            android:id="@+id/image_desc"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:id="@+id/image_desc"
-                            android:textSize="@dimen/medium_text"
-                            android:textColor="@color/md_grey_400"
                             android:layout_marginLeft="5dp"
-                            android:layout_marginBottom="2dp"/>
+                            android:layout_marginBottom="2dp"
+                            android:textColor="@color/md_grey_400"
+                            android:textSize="@dimen/medium_text" />
                     </LinearLayout>
                 </LinearLayout>
             </LinearLayout>


### PR DESCRIPTION
Fixed #2528 

Changes: Earlier the view of image description was not completely scrollable because of a layout margin to the whole of the linear layout. The view is now completely scrollable. The margin has been removed from the main layout and added individually to each child layout. Also fixed some indentation faults in the xml file.

Screenshots of the change: 

![screencap](https://user-images.githubusercontent.com/41234408/52784779-3b458300-307c-11e9-9d17-d52ad9708947.png)
