### PR TITLE
password removed from single media favourite icon

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -1070,86 +1070,13 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
         deleteDialog.setNegativeButton(this.getString(R.string.cancel).toUpperCase(), null);
         deleteDialog.setPositiveButton(ButtonDelete.toUpperCase(), new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {
-                if (securityObj.isActiveSecurity() && securityObj.isPasswordOnDelete()) {
-                    final boolean passco[] = {false};
-                    final AlertDialog.Builder passwordDialogBuilder = new AlertDialog.Builder(SingleMediaActivity.this, getDialogStyle());
-                    final EditText editTextPassword = securityObj.getInsertPasswordDialog
-                            (SingleMediaActivity.this, passwordDialogBuilder);
-                    editTextPassword.setHintTextColor(getResources().getColor(R.color.grey, null));
-                    passwordDialogBuilder.setPositiveButton(getString(R.string.ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
-                        public void onClick(DialogInterface dialog, int which) {
-                            if (securityObj.checkPassword(editTextPassword.getText().toString())) {
-                                //int c = current_image_pos;
-                                //deleteMedia(favouriteslist.get(current_image_pos).getPath());
-                                item.getIcon().clearColorFilter();
-                                deletefav(getAlbum().getCurrentMedia().getPath());
-                            } else
-                                SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.wrong_password), bottomBar.getHeight());
-
-                        }
-                    });
-                    editTextPassword.addTextChangedListener(new TextWatcher() {
-                        @Override
-                        public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-                            //empty method body
-                        }
-
-                        @Override
-                        public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-                            //empty method body
-                        }
-
-                        @Override
-                        public void afterTextChanged(Editable editable) {
-                            if (securityObj.getTextInputLayout().getVisibility() == View.VISIBLE && !passco[0]) {
-                                securityObj.getTextInputLayout().setVisibility(View.INVISIBLE);
-                            } else {
-                                passco[0] = false;
-                            }
-                        }
-                    });
-                    passwordDialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
-                    final AlertDialog passwordDialog = passwordDialogBuilder.create();
-                    passwordDialog.show();
-                    passwordDialog.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE | WindowManager
-                            .LayoutParams.FLAG_ALT_FOCUSABLE_IM);
-                    passwordDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams
-                            .SOFT_INPUT_STATE_ALWAYS_VISIBLE);
-                    AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, getAccentColor(), passwordDialog);
-                    passwordDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View
-                            .OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            if (securityObj.checkPassword(editTextPassword.getText().toString())) {
-                                // int c = current_image_pos;
-                                //deleteMedia(favouriteslist.get(current_image_pos).getPath());
-
-                                passwordDialog.dismiss();
-                                item.getIcon().clearColorFilter();
-                                SnackBarHandler.show(parentView, getApplicationContext().getString(R
-                                        .string.photo_deleted_from_fav_msg));
-                                deletefav(getAlbum().getCurrentMedia().getPath());
-                            } else {
-                                passco[0] = true;
-                                securityObj.getTextInputLayout().setVisibility(View.VISIBLE);
-                                SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.wrong_password), bottomBar.getHeight());
-                                editTextPassword.getText().clear();
-                                editTextPassword.requestFocus();
-                            }
-                        }
-                    });
-                } else {
-                    item.getIcon().clearColorFilter();
-                    SnackBarHandler.show(parentView, getApplicationContext().getString(R.string.photo_deleted_from_fav_msg));
-                    //deleteMedia(favouriteslist.get(current_image_pos).getPath());
-                    deletefav(getAlbum().getCurrentMedia().getPath());
+                item.getIcon().clearColorFilter();
+                deletefav(getAlbum().getCurrentMedia().getPath());
+                SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.photo_deleted_from_fav_msg), bottomBar.getHeight());
                 }
-
-            }
         });
         AlertDialog alertDialog = deleteDialog.create();
         alertDialog.show();
-        SnackBarHandler.show(parentView, getApplicationContext().getString(R.string.photo_deleted_from_fav_msg));
         AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, getAccentColor(), alertDialog);
     }
 


### PR DESCRIPTION
Fixed #2563 

Changes: 
password removed from single media favourite icon.
snackbar is shown when image is removed using the icon.

Screenshots of the change: 
![whatsapp image 2019-02-15 at 18 15 34](https://user-images.githubusercontent.com/31561661/52857648-bdea4300-314d-11e9-9906-9ce753ec0008.jpeg)
