### PR TITLE
Fix #2570 security password dialog issue

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -94,10 +94,16 @@ public class SecurityActivity extends ThemedActivity {
                 securityObj.updateSecuritySetting();
                 updateSwitchColor(swActiveSecurity, getAccentColor());
                 llbody.setEnabled(swActiveSecurity.isChecked());
-                if (isChecked)
+                String password = SP.getString(getString(R.string.preference_password_value),"");
+                if (password.isEmpty() && isChecked)
                     setPasswordDialog();
+                else if (isChecked) {
+                    swActiveSecurity.setChecked(true);
+                    editor.putBoolean(getString(R.string.preference_use_password), true);
+                    editor.commit();
+                    toggleEnabledChild(true);
+                }
                 else {
-                    editor.putString(getString(R.string.preference_password_value), "");
                     editor.putBoolean(getString(R.string.preference_use_password), false);
                     editor.commit();
                     toggleEnabledChild(false);

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -102,8 +102,7 @@ public class SecurityActivity extends ThemedActivity {
                     editor.putBoolean(getString(R.string.preference_use_password), true);
                     editor.commit();
                     toggleEnabledChild(true);
-                }
-                else {
+                } else {
                     editor.putBoolean(getString(R.string.preference_use_password), false);
                     editor.commit();
                     toggleEnabledChild(false);


### PR DESCRIPTION
Fixed #2570 

Changes: [Check for password if it's already done then simply turn on security and if not the make new password setup.]

GIF of the change: 

<img src = "https://user-images.githubusercontent.com/22986571/52885506-7be5ef00-3197-11e9-840b-80e80e7c8065.gif" width = 220 height = 400>