### PR TITLE
fix: An alert is shown to the user asking whether app should be restarted or not.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/MyPreferenceFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/opencamera/Camera/MyPreferenceFragment.java
@@ -266,20 +266,37 @@ public class MyPreferenceFragment extends PreferenceFragment implements OnShared
             pref.setOnPreferenceClickListener(new OnPreferenceClickListener() {
                 @Override
                 public boolean onPreferenceClick(Preference arg0) {
-                	if( pref.getKey().equals("preference_use_camera2") ) {
-                		if( MyDebug.LOG )
-                			Log.d(TAG, "user clicked camera2 API - need to restart");
-                		// see http://stackoverflow.com/questions/2470870/force-application-to-restart-on-first-activity
-                		Intent i = getActivity().getBaseContext().getPackageManager().getLaunchIntentForPackage( getActivity().getBaseContext().getPackageName() );
-	                	i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-	                	startActivity(i);
-	                	return false;
-                	}
+					AlertDialog.Builder builder;
+					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+						builder = new AlertDialog.Builder(getContext(), android.R.style.Theme_Material_Dialog_Alert);
+					} else {
+						builder = new AlertDialog.Builder(getContext());
+					}
+					builder.setTitle("Alert")
+							.setMessage("Changes will take place after the app is restarted. Restart now?")
+							.setPositiveButton("Restart now", new DialogInterface.OnClickListener() {
+								public void onClick(DialogInterface dialog, int which) {
+									if( pref.getKey().equals("preference_use_camera2") ) {
+										if( MyDebug.LOG )
+											Log.d(TAG, "user clicked camera2 API - need to restart");
+										// see http://stackoverflow.com/questions/2470870/force-application-to-restart-on-first-activity
+										Intent i = getActivity().getBaseContext().getPackageManager().getLaunchIntentForPackage( getActivity().getBaseContext().getPackageName() );
+										i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+										startActivity(i);
+									}
+								}
+							})
+							.setNegativeButton("Restart Later", new DialogInterface.OnClickListener() {
+								public void onClick(DialogInterface dialog, int which) {
+									// do nothing
+								}
+							})
+							.setIcon(android.R.drawable.ic_dialog_alert)
+							.show();
                 	return false;
                 }
             });
         }
-        
 
         {
         	Preference pref = findPreference("preference_save_location");


### PR DESCRIPTION
Fixed #2521 

Changes: The user is given the choice of restarting the app immediately or later. If the user does not want to restart the app immediately, the changes are made when the app is closed and restarted by the user whenever the user closes the app and restarts it manually.

Screenshot of the change: 

![screencap](https://user-images.githubusercontent.com/41234408/52901960-2c073680-3230-11e9-97bf-0d4b1b5357f9.png)