### PR TITLE
Folder name can be clicked to check the check box in secure folders dialog.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -610,12 +610,23 @@ public class SecurityActivity extends ThemedActivity {
             return new ViewHolder(v);
         }
 
-        @Override public void onBindViewHolder(ViewHolder holder, int position) {
+        @Override public void onBindViewHolder(final ViewHolder holder, int position) {
             final Album a = albums.get(position);
             holder.foldername.setText(a.getName());
             holder.foldername.setTextColor(getTextColor());
             holder.foldercheckbox.setOnCheckedChangeListener(null);
             holder.foldercheckbox.setChecked(a.getsecured());
+            //name of the folder can be clicked to check the box instead of the checkbox itself
+            TextView folderName = holder.foldername;
+            folderName.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    boolean no = holder.foldercheckbox.isChecked();
+                    if (no) {
+                        holder.foldercheckbox.setChecked(false);
+                    } else holder.foldercheckbox.setChecked(true);
+                }
+            });
             //holder.foldercheckbox.setButtonTintList();
             holder.foldercheckbox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                 @Override public void onCheckedChanged(CompoundButton compoundButton, boolean b) {


### PR DESCRIPTION
Fixed #2565 

Changes: User can now click on the folder name as well as the checkbox to select the folder to be secured.

GIF of the change: 

![ezgif com-video-to-gif 12](https://user-images.githubusercontent.com/41234408/52909089-1e8d9300-32a8-11e9-92a3-ffbfaa3f4c8b.gif)
