### PR TITLE
Fix #2567 Include all options in excluded item list

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/ExcludedAlbumsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/ExcludedAlbumsActivity.java
@@ -14,7 +14,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.mikepenz.google_material_typeface_library.GoogleMaterial;
 import com.mikepenz.iconics.view.IconicsImageView;
@@ -28,7 +27,6 @@ import org.fossasia.phimpme.utilities.SnackBarHandler;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.TimerTask;
 
 /**
  * Created by Jibo on 04/04/2016.

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/ExcludedAlbumsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/ExcludedAlbumsActivity.java
@@ -6,10 +6,13 @@ import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.mikepenz.google_material_typeface_library.GoogleMaterial;
 import com.mikepenz.iconics.view.IconicsImageView;
@@ -47,6 +50,30 @@ public class ExcludedAlbumsActivity extends ThemedActivity {
         TextView a = findViewById(R.id.nothing_to_show);
         a.setTextColor(getTextColor());
         a.setVisibility(excludedFolders.size() == 0 ? View.VISIBLE : View.GONE);
+    }
+
+    public void restoreAll(int itemcount){
+        if (excludedFolders.size()!=0){
+            for (int i=0;i<itemcount;i++){
+                h.clearAlbumExclude(excludedFolders.remove(0).getAbsolutePath());
+            }
+            Toast.makeText(ExcludedAlbumsActivity.this,"All folders are restored!",Toast.LENGTH_SHORT).show();
+            finish();
+        }
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.menu_excluded_items,menu);
+       menu.findItem(R.id.restore_all).setVisible(excludedFolders.size()!=0);
+        return true;
+    }
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId()==R.id.restore_all){
+            restoreAll(excludedFolders.size());
+        }
+        return true;
     }
 
     private void initUI() {

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/ExcludedAlbumsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/ExcludedAlbumsActivity.java
@@ -1,6 +1,8 @@
 package org.fossasia.phimpme.gallery.activities;
 
 import android.os.Bundle;
+import android.os.Handler;
+import android.support.design.widget.Snackbar;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -22,9 +24,11 @@ import org.fossasia.phimpme.R;
 import org.fossasia.phimpme.base.ThemedActivity;
 import org.fossasia.phimpme.gallery.data.CustomAlbumsHelper;
 import org.fossasia.phimpme.utilities.ActivitySwitchHelper;
+import org.fossasia.phimpme.utilities.SnackBarHandler;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.TimerTask;
 
 /**
  * Created by Jibo on 04/04/2016.
@@ -57,8 +61,13 @@ public class ExcludedAlbumsActivity extends ThemedActivity {
             for (int i=0;i<itemcount;i++){
                 h.clearAlbumExclude(excludedFolders.remove(0).getAbsolutePath());
             }
-            Toast.makeText(ExcludedAlbumsActivity.this,"All folders are restored!",Toast.LENGTH_SHORT).show();
-            finish();
+            SnackBarHandler.show(findViewById(R.id.rl_ea), "All folders are restored", Snackbar.LENGTH_SHORT).show();
+            new Handler().postDelayed(new Runnable() {
+               @Override
+               public void run() {
+                   finish();
+               }
+            },1000);
         }
     }
 

--- a/app/src/main/res/layout/activity_excluded.xml
+++ b/app/src/main/res/layout/activity_excluded.xml
@@ -5,12 +5,26 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <include
+    <!--<include-->
+        <!--android:id="@+id/toolbar"-->
+        <!--layout="@layout/toolbar"-->
+        <!--android:background="@color/md_dark_appbar"-->
+        <!--android:windowActionBarOverlay="true"-->
+        <!--/>-->
+    <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"
-        layout="@layout/toolbar"
         android:background="@color/md_dark_appbar"
         android:windowActionBarOverlay="true"
-        />
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        style="@style/MyToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_scrollFlags="scroll|enterAlways"
+        app:titleTextAppearance="@style/ToolbarTitle"
+        app:popupTheme="@style/ThemeOverlay.excludedMenuPopup">
+
+    </android.support.v7.widget.Toolbar>
 
     <RelativeLayout
         android:id="@+id/rl_ea"

--- a/app/src/main/res/menu/menu_excluded_items.xml
+++ b/app/src/main/res/menu/menu_excluded_items.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/restore_all"
+        android:title="Restore All"
+        app:showAsAction="never"/>
+
+</menu>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -239,4 +239,9 @@
         <item name="android:colorForeground">@color/accent_grey</item>
     </style>
 
+    <style name="ThemeOverlay.excludedMenuPopup"
+        parent="ThemeOverlay.AppCompat.Light">
+        <item name="android:colorBackground">@color/accent_white</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Fixed #2567 

Changes: Restore all excluded items directly instead of selecting one by one

Screenshots of the change: 
![image](https://user-images.githubusercontent.com/35160400/52917978-626bb100-3317-11e9-9052-ca0d80834184.png)

