### PR TITLE
fix: Text highlight is visible in all themes.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -1400,8 +1400,10 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 AlertDialog.Builder descriptionDialogBuilder = new AlertDialog.Builder(SingleMediaActivity.this, getDialogStyle());
                 editTextDescription = getDescriptionDialog(SingleMediaActivity.this, descriptionDialogBuilder);
                 editTextDescription.setSelectAllOnFocus(true);
-                editTextDescription.setHighlightColor(ContextCompat.getColor(getApplicationContext(), R.color
-                        .cardview_shadow_start_color));
+                if(getBaseTheme() == ThemeHelper.DARK_THEME || getBaseTheme() == ThemeHelper.AMOLED_THEME){
+                    editTextDescription.setTextColor(R.color.black);
+                    editTextDescription.setHighlightColor(ContextCompat.getColor(getApplicationContext(), R.color.accent_grey));
+                } else editTextDescription.setHighlightColor(ContextCompat.getColor(getApplicationContext(), R.color.cardview_shadow_start_color));
                 editTextDescription.selectAll();
                 editTextDescription.setSingleLine(false);
                 editTextDescription.setHintTextColor(getResources().getColor(R.color.grey, null));


### PR DESCRIPTION
Fixed #2591 

Changes: The highlighted color of text while changing image is visible in every theme.
