### PR TITLE
fix: Keyboard does not push app bottom bar up.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -211,6 +211,7 @@
             android:name=".gallery.activities.SingleMediaActivity"
             android:configChanges="orientation|screenSize|uiMode|touchscreen|screenLayout"
             android:label="@string/app_name"
+            android:windowSoftInputMode="adjustPan"
             android:parentActivityName=".gallery.activities.LFMainActivity"
             android:theme="@style/Theme.AppCompat.NoActionBar">
             <intent-filter>


### PR DESCRIPTION
Fixed #2598
 
Changes: Now the bottom bar is not visible when the keyboard pops up in single media activity.

Screenshots of the change: 

![screencap](https://user-images.githubusercontent.com/41234408/53100738-49007a00-354e-11e9-9a14-8962f97b4842.png)
