### PR TITLE
fix: Made location text color same as accent color.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -1897,7 +1897,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 imgLocation.setText(R.string.no_location);
             } else {
                 imgLocation.setText(mediaDetailsMap.get("Location").toString());
-                imgLocation.setTextColor(getResources().getColor(R.color.accent_orange, null));
+                imgLocation.setTextColor(getAccentColor());
             }
         } catch (Exception e) {
             //Raised if null values is found, no need to handle


### PR DESCRIPTION
Fixed #2603 

Changes: Location text color in image details is now the same as an accent color for the app instead of staying yellow all the time.

Screenshots of the change: 

![screencap](https://user-images.githubusercontent.com/41234408/53152942-ee622f00-35dc-11e9-9b1b-12cad81e89fa.png)
