### PR TITLE
swipe to disabled for empty ui

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
@@ -118,6 +118,7 @@ public class UploadHistory extends ThemedActivity {
         uploadHistoryRealmModelRealmQuery = realm.where(UploadHistoryRealmModel.class);
         if(uploadHistoryRealmModelRealmQuery.count() == 0){
             emptyLayout.setVisibility(View.VISIBLE);
+            swipeRefreshLayout.setEnabled(false);
         } else {
             String choiceofdisply = preferenceUtil.getString(getString(R.string.upload_view_choice), getString(R.string
                     .last_first));
@@ -375,6 +376,7 @@ public class UploadHistory extends ThemedActivity {
             if(result[0] && uploadHistoryRealmModelRealmQuery.count() == 0){
                 emptyLayout.setVisibility(View.VISIBLE);
                 uploadHistoryRecyclerView.setVisibility(View.GONE);
+                swipeRefreshLayout.setEnabled(false);
             }
             invalidateOptionsMenu();
         }


### PR DESCRIPTION
Fixed #2480

Changes:
1/2
swipe to refresh disabled for empty upload history folder.


