### PR TITLE
If an image it set as the cover image, it can be removed as the cover image if it is opened.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -703,6 +703,9 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
     @Override
     public boolean onPrepareOptionsMenu(final Menu menu) {
 
+        if(getAlbum().getCurrentMedia().getPath().equals(getAlbum().getCoverPath()))
+            menu.findItem(R.id.action_cover).setTitle("Remove cover image");
+
         if (allPhotoMode || favphotomode) {
             menu.findItem(R.id.action_cover).setVisible(false);
         }
@@ -1357,9 +1360,15 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                 return true;
 
             case R.id.action_cover:
-                AlbumSettings albumSettings = AlbumSettings.getSettings(getApplicationContext(), getAlbum());
-                albumSettings.changeCoverPath(getApplicationContext(), getAlbum().getCurrentMedia().getPath());
-                SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.change_cover), bottomBar.getHeight());
+                if(getAlbum().getCurrentMedia().getPath().equals(getAlbum().getCoverPath())){
+                    AlbumSettings albumSettings = AlbumSettings.getSettings(getApplicationContext(), getAlbum());
+                    albumSettings.changeCoverPath(getApplicationContext(), getAlbum().getMedia(0).getPath());
+                    SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.cover_removed), (bottomBar.getHeight()*2) - 22);
+                } else {
+                    AlbumSettings albumSettings = AlbumSettings.getSettings(getApplicationContext(), getAlbum());
+                    albumSettings.changeCoverPath(getApplicationContext(), getAlbum().getCurrentMedia().getPath());
+                    SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.change_cover), bottomBar.getHeight());
+                }
                 return true;
 
             case R.id.action_details:

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -648,6 +648,7 @@
     <string name="delete_album_message">Are you sure you want to delete this album?</string>
     <string name="delete_albums_message">Are you sure you want to delete the selected albums?</string>
     <string name="delete_photo_message">Are you sure you want to delete this media?</string>
+    <string name="cover_removed">Album cover set to first image of the album</string>
     <string name="delete_from_favourites_message">Are you sure you want to remove this media from Favourites?</string>
     <string name="delete_photos_message">Are you sure you want to delete the selected media?</string>
     <string name="hide_albums_message">Are you sure you want to hide the selected albums?</string>


### PR DESCRIPTION
Fixed #2599 

Changes: Once an image is set as the cover photo, it can be removed as the cover photo from the menu in SingleMediaActivity itself.

Screenshots of the change: 

![screencap](https://user-images.githubusercontent.com/41234408/53177136-7cf2a280-3615-11e9-8cb9-eae659f5b8ec.png)
![screencap1](https://user-images.githubusercontent.com/41234408/53177145-7fed9300-3615-11e9-9d4f-4ed69ef447a4.png)
