### PR TITLE
Fix #2612 in slide show, toast replaced by snackbar and keyboard doesn't close on invalid time interval

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -54,6 +54,7 @@ import android.view.animation.AccelerateInterpolator;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.view.animation.DecelerateInterpolator;
+import android.view.inputmethod.EditorInfo;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageButton;
@@ -61,7 +62,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 import android.widget.ViewSwitcher;
 
 import com.bumptech.glide.Glide;
@@ -2000,10 +2000,10 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
         dialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.ok_action).toUpperCase(), (DialogInterface.OnClickListener) null);
         dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
 
-        dialog.setOnKeyListener(new DialogInterface.OnKeyListener() {
+        editTextTimeInterval.setOnEditorActionListener(new TextView.OnEditorActionListener() {
             @Override
-            public boolean onKey(DialogInterface dialogInterface, int keyCode, KeyEvent keyEvent) {
-                if (keyEvent.getAction() == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_ENTER){
+            public boolean onEditorAction(TextView textView, int keyCode, KeyEvent keyEvent) {
+                if ( keyCode == EditorInfo.IME_ACTION_DONE || keyCode == EditorInfo.IME_ACTION_NEXT) {
                     String value = editTextTimeInterval.getText().toString();
                     if (!"".equals(value)) {
                         slideshow = true;
@@ -2022,11 +2022,11 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                             til.setError(getString(R.string.slide_max_value));
                         }
                     }
+                    return true;
                 }
                 return false;
             }
         });
-
         dialog.setOnShowListener(new DialogInterface.OnShowListener() {
             @Override
             public void onShow(DialogInterface dialogInterface) {

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -2012,7 +2012,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                         if (SLIDE_SHOW_INTERVAL > 1000 && SLIDE_SHOW_INTERVAL <= 10000) {
                             dialog.dismiss();
                             hideSystemUI();
-                            Toast.makeText(SingleMediaActivity.this, getString(R.string.slide_start), Toast.LENGTH_SHORT).show();
+                            SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.slide_start), 0);
                             handler.postDelayed(slideShowRunnable, SLIDE_SHOW_INTERVAL);
                         } else if (SLIDE_SHOW_INTERVAL < 2000) {
                             editTextTimeInterval.requestFocus();
@@ -2042,7 +2042,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                             if (SLIDE_SHOW_INTERVAL > 1000 && SLIDE_SHOW_INTERVAL <= 10000) {
                                 dialog.dismiss();
                                 hideSystemUI();
-                                Toast.makeText(SingleMediaActivity.this, getString(R.string.slide_start), Toast.LENGTH_SHORT).show();
+                                SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.slide_start), 0);
                                 handler.postDelayed(slideShowRunnable, SLIDE_SHOW_INTERVAL);
                             } else if (SLIDE_SHOW_INTERVAL < 2000) {
                                 editTextTimeInterval.requestFocus();


### PR DESCRIPTION
Fixed #2612 

Changes: Toast replaced with snackbar, key listener added on alert Dialog EditText

Screenshots of the change: 
![20190222_105256](https://user-images.githubusercontent.com/32041242/53221750-cd5b1600-3690-11e9-83e2-2e6551ced34e.gif)
