### PR TITLE
Fix #2596 text highlight visible in caption dialog in dark amoled theme

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/share/SharingActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/share/SharingActivity.java
@@ -772,7 +772,9 @@ public class SharingActivity extends ThemedActivity implements View.OnClickListe
         captionEditText.setHint(R.string.description_hint);
         captionEditText.setHintTextColor(ContextCompat.getColor(this,R.color.grey));
         captionEditText.setSelectAllOnFocus(true);
-        captionEditText.setHighlightColor(ContextCompat.getColor(getApplicationContext(), R.color.cardview_shadow_start_color));
+        if(getBaseTheme() == ThemeHelper.DARK_THEME || getBaseTheme() == ThemeHelper.AMOLED_THEME){
+            captionEditText.setHighlightColor(ContextCompat.getColor(getApplicationContext(), R.color.accent_grey));
+        } else captionEditText.setHighlightColor(ContextCompat.getColor(getApplicationContext(), R.color.cardview_shadow_start_color));
         captionEditText.selectAll();
         captionEditText.setSingleLine(false);
         captionDialogBuilder.setPositiveButton(getString(R.string.add_action).toUpperCase(), new DialogInterface.OnClickListener() {


### PR DESCRIPTION
Fixed #2596 
Changes: highlight visible in caption dialog

Screenshots of the change: 
![screenshot_20190222-171040](https://user-images.githubusercontent.com/32041242/53240724-7ae81c80-36c5-11e9-9a84-ff5f58b8fc5f.png)
