### PR TITLE
added restart action to snackbar

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
@@ -259,7 +259,25 @@ public class SettingsActivity extends ThemedActivity {
                 SP.putBoolean(getString(R.string.preference_translucent_status_bar), isChecked);
                 updateTheme();
                 setStatusBarColor();
-                Snackbar.make(findViewById(android.R.id.content), getString(R.string.restart_app), Snackbar.LENGTH_SHORT).show();
+                Snackbar snack=Snackbar.make(parent, getString(R.string.restart_app), Snackbar.LENGTH_SHORT)
+                        .setAction(getString(R.string.restart).toUpperCase(), new View.OnClickListener() {
+                            @Override
+                            public void onClick(View view) {
+                                Intent intent = getBaseContext().getPackageManager()
+                                        .getLaunchIntentForPackage(getBaseContext().getPackageName());
+                                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                                startActivity(intent);
+                            }
+                        })
+                        .setActionTextColor(getAccentColor());
+                View view = snack.getView();
+                final FrameLayout.LayoutParams param = (FrameLayout.LayoutParams) view.getLayoutParams();
+                param.setMargins(param.leftMargin,
+                        param.topMargin,
+                        param.rightMargin,
+                        param.bottomMargin);
+                view.setLayoutParams(param);
+                snack.show();
                 updateSwitchColor(swStatusBar, getAccentColor());
             }
         });


### PR DESCRIPTION
Fixed #2622 

Changes:
restart action was added to translucent status bar.

Screenshots of the change: 
![whatsapp image 2019-02-22 at 21 23 22](https://user-images.githubusercontent.com/31561661/53254172-d8da2b80-36e8-11e9-9d05-d40e25cca4dc.jpeg)
