### PR TITLE
Fix #2597 sort images menu made invisible when there is only one image in album

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -163,7 +163,7 @@ public class LFMainActivity extends SharedMediaActivity {
 
     private SelectAlbumBottomSheet bottomSheetDialogFragment;
     private BottomNavigationView navigationView;
-    private boolean hidden = false, pickMode = false, editMode = false, albumsMode = true, firstLaunch = true, localFolder = true, hidenav = false;
+    private boolean hidden = false, pickMode = false, editMode = false, albumsMode = true, firstLaunch = true, localFolder = true, hidenav = false, singItemAlbum = false;
 
     //to handle pinch gesture
     private ScaleGestureDetector mScaleGestureDetector;
@@ -781,7 +781,6 @@ public class LFMainActivity extends SharedMediaActivity {
         super.onCreate(savedInstanceState);
         Log.e("TAG", "lfmain");
         ButterKnife.bind(this);
-      
         navigationView = findViewById(R.id.bottombar);
         favicon = findViewById(R.id.Drawer_favourite_Icon);
 
@@ -1844,6 +1843,7 @@ public class LFMainActivity extends SharedMediaActivity {
             }
         } else {
             menu.findItem(R.id.search_action).setVisible(false);
+            singItemAlbum = getAlbum().getCount() < 2;
             if (!all_photos && !fav_photos) {
                 editMode = getAlbum().areMediaSelected();
                 menu.setGroupVisible(R.id.photos_option_men, editMode);
@@ -1913,7 +1913,7 @@ public class LFMainActivity extends SharedMediaActivity {
     }
 
     private void togglePrimaryToolbarOptions(final Menu menu) {
-        menu.setGroupVisible(R.id.general_action, !editMode);
+        menu.setGroupVisible(R.id.general_action, !editMode && !singItemAlbum);
 
     }
 

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1860,6 +1860,7 @@ public class LFMainActivity extends SharedMediaActivity {
                 menu.findItem(R.id.settings).setVisible(!editMode);
                 menu.findItem(R.id.album_details).setVisible(false);
             } else if (!all_photos && fav_photos) {
+                singItemAlbum = favouriteslist.size() < 2;
                 editMode = selectedMedias.size() != 0;
                 menu.setGroupVisible(R.id.photos_option_men, editMode);
                 menu.setGroupVisible(R.id.album_options_menu, !editMode);


### PR DESCRIPTION
Fixed #2597 #2626 

Changes: checked the number of images in album and handled visibility of sort menu

Screenshots of the change: 
![screenshot_20190223-030312](https://user-images.githubusercontent.com/32041242/53273087-10f96280-3719-11e9-9c10-13f8e1a66b31.png)
