### PR TITLE
fix: Fixed visibility of menu buttons.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -727,6 +727,10 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
             menu.setGroupVisible(R.id.only_photos_options, false);
             menu.findItem(R.id.sort_action).setVisible(false);
         }
+        if(getAlbum().getCount() == 1){
+            menu.findItem(R.id.action_cover).setVisible(false);
+            menu.findItem(R.id.slide_show).setVisible(false);
+        }
         return true;
     }
 


### PR DESCRIPTION
Fixed #2630 

Changes: Album cover and slideshow buttons show up only if there are two or more images in an album.
