### PR TITLE
added cancel button to request sd permissions dialog

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1309,6 +1309,7 @@ public class LFMainActivity extends SharedMediaActivity {
                     startActivityForResult(new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE), REQUEST_CODE_SD_CARD_PERMISSIONS);
             }
         });
+        dialogBuilder.setNegativeButton(getString(R.string.cancel).toUpperCase(),null);
         AlertDialog alertDialog = dialogBuilder.create();
         alertDialog.show();
         AlertDialogsHelper.setButtonTextColor(new int[]{DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE}, getAccentColor(), alertDialog);


### PR DESCRIPTION
Fixed #2632 

Changes: 
cancel button added to request sd card permissions. now the user can exit the dialog without giving permissions.

Screenshots of the change: 
![whatsapp image 2019-02-24 at 16 24 21](https://user-images.githubusercontent.com/31561661/53298225-d0046980-3850-11e9-9b03-ee4b3fa6da71.jpeg)

