### PR TITLE
Added button to snackbar to open favourites in single media activity

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -781,7 +781,7 @@ public class LFMainActivity extends SharedMediaActivity {
         super.onCreate(savedInstanceState);
         Log.e("TAG", "lfmain");
         ButterKnife.bind(this);
-      
+
         navigationView = findViewById(R.id.bottombar);
         favicon = findViewById(R.id.Drawer_favourite_Icon);
 
@@ -825,6 +825,11 @@ public class LFMainActivity extends SharedMediaActivity {
                 return LFMainActivity.super.onNavigationItemSelected(item);
             }
         });
+
+        if (getIntent().getBooleanExtra("openFav", false)) {
+            displayfavourites();
+            favourites = false;
+        }
     }
 
     @Override

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -825,7 +825,6 @@ public class LFMainActivity extends SharedMediaActivity {
                 return LFMainActivity.super.onNavigationItemSelected(item);
             }
         });
-
         if (getIntent().getBooleanExtra("openFav", false)) {
             displayfavourites();
             favourites = false;

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -1281,7 +1281,6 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                     }
                     item.getIcon().setColorFilter(getAccentColor(), PorterDuff.Mode.SRC_IN);
                     realm.commitTransaction();
-//                    SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.add_favourite), bottomBar.getHeight());
                     final Snackbar snackbar = SnackBarHandler.showWithBottomMargin(parentView,
                             getResources().getString(R.string.add_favourite),bottomBar.getHeight());
                     snackbar.setAction(R.string.openfav, new View.OnClickListener() {

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -1281,7 +1281,18 @@ public class SingleMediaActivity extends SharedMediaActivity implements ImageAda
                     }
                     item.getIcon().setColorFilter(getAccentColor(), PorterDuff.Mode.SRC_IN);
                     realm.commitTransaction();
-                    SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.add_favourite), bottomBar.getHeight());
+//                    SnackBarHandler.showWithBottomMargin(parentView, getString(R.string.add_favourite), bottomBar.getHeight());
+                    final Snackbar snackbar = SnackBarHandler.showWithBottomMargin(parentView,
+                            getResources().getString(R.string.add_favourite),bottomBar.getHeight());
+                    snackbar.setAction(R.string.openfav, new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            Intent intent = new Intent(SingleMediaActivity.this, LFMainActivity.class);
+                            intent.putExtra("openFav", true);
+                            startActivity(intent);
+                        }
+                    });
+                    snackbar.show();
                 } else {
                     deletefromfav(item);
                 }


### PR DESCRIPTION
Fixed #2639

Changes: Added button to snackbar to open favourites in single media activity

Screenshots of the change: 
![screenshot_20190225-190529](https://user-images.githubusercontent.com/32041242/53341104-a91d6480-3930-11e9-9fae-dff68d2c351f.png)
