### PR TITLE
fix: Trashbin message for more than one images being deleted.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -3218,7 +3218,7 @@ public class LFMainActivity extends SharedMediaActivity {
                     snackbar.show();
                 }else{
                     Snackbar snackbar = SnackBarHandler.showWithBottomMargin2(mDrawerLayout, String.valueOf(no) + " " + getString(R.string
-                                    .trashbin_move_onefile),
+                                    .trashbin_move_files),
                             navigationView.getHeight
                                     (), Snackbar.LENGTH_SHORT);
                     snackbar.setAction("UNDO", new View.OnClickListener() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -564,6 +564,7 @@
     <string name="delete_permanently">Delete Permanently</string>
     <string name="trashbin_move">images moved to the TrashBin</string>
     <string name="trashbin_move_onefile">Image moved to the TrashBin</string>
+    <string name="trashbin_move_files">Images moved to the TrashBin</string>
     <string name="trashbin_move_error">Error! Images cannot be moved to the TrashBin</string>
     <string name="change_cover">Album cover changed..</string>
     <string name="add_favourite">Image is successfully added to the favourites collection.</string>


### PR DESCRIPTION
Fixed #2583 

Changes: A proper message is shown when more than one image is deleted and moved to trash bin.
