### PR TITLE
fix: App bar does not pop up while deleting photos from favourites.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -945,6 +945,7 @@ public class LFMainActivity extends SharedMediaActivity {
         } else {
             toolbar.setTitle(getString(R.string.hidden_folder));
         }
+        showNavigationBar();
         toolbar.setNavigationIcon(getToolbarIcon(GoogleMaterial.Icon.gmd_menu));
         mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
         albumsAdapter.swapDataSet(getAlbums().dispAlbums);
@@ -2293,6 +2294,7 @@ public class LFMainActivity extends SharedMediaActivity {
                 AlertDialog.Builder deleteDialog = new AlertDialog.Builder(LFMainActivity.this, getDialogStyle());
 
                 if(fav_photos && !all_photos){
+                    hideNavigationBar();
                     AlertDialogsHelper.getTextDialog(this, deleteDialog, R.string.remove_from_favourites, R.string.remove_favourites_body, null);
                     deleteDialog.setNegativeButton(getString(R.string.cancel).toUpperCase(), null);
                     deleteDialog.setPositiveButton(getString(R.string.remove).toUpperCase(), new DialogInterface.OnClickListener() {


### PR DESCRIPTION
Fixed #2649 

Changes: The bottom bar of the app does not pop up while deleting multiple photos from favorites.
