### PR TITLE
fix: Change the filter titles.

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -671,14 +671,14 @@
         <item>Anax</item>
         <item>Sepia</item>
         <item>Cyano</item>
-        <item>B/W</item>
+        <item>Black & White</item>
         <item>Ansel</item>
         <item>Grain</item>
         <item>Hist Equal</item>
         <item>Threshold</item>
         <item>Negative</item>
         <item>Green Boost</item>
-        <item>Boost Red</item>
+        <item>Red Boost</item>
         <item>Blue Boost</item>
         <item>Colour Enhance</item>
         <item>Cyanisation</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -671,7 +671,7 @@
         <item>Anax</item>
         <item>Sepia</item>
         <item>Cyano</item>
-        <item>Black & White</item>
+        <item>Black and White</item>
         <item>Ansel</item>
         <item>Grain</item>
         <item>Hist Equal</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -671,7 +671,7 @@
         <item>Anax</item>
         <item>Sepia</item>
         <item>Cyano</item>
-        <item>Black and White</item>
+        <item>Black &amp; White</item>
         <item>Ansel</item>
         <item>Grain</item>
         <item>Hist Equal</item>


### PR DESCRIPTION
Fixed #2664 

Changes: Made the tile of red color filter "Red Boost" like the other color filters. Also changes "B/W" to  "Black & White".
 
