### PR TITLE
access by password and apply theme were made toggleable

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SecurityActivity.java
@@ -86,6 +86,18 @@ public class SecurityActivity extends ThemedActivity {
 
         /** - SWITCHES - **/
         /** - ACTIVE SECURITY - **/
+        LinearLayout linearLayout=findViewById(R.id.ll_active_security);
+        linearLayout.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                boolean no = swActiveSecurity.isChecked();
+                if(no){
+                    swActiveSecurity.setChecked(false);
+                }else {
+                    swActiveSecurity.setChecked(true);
+                }
+            }
+        });
         swActiveSecurity.setChecked(securityObj.isActiveSecurity());
         swActiveSecurity.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
@@ -904,6 +904,18 @@ public class SettingsActivity extends ThemedActivity {
 
         View dialogLayout = getLayoutInflater().inflate(R.layout.dialog_media_viewer_theme, null);
         final SwitchCompat swApplyTheme_Viewer = dialogLayout.findViewById(R.id.apply_theme_3th_act_enabled);
+        LinearLayout linearLayout=dialogLayout.findViewById(R.id.ll_apply_theme_3thAct);
+        linearLayout.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                boolean no=swApplyTheme_Viewer.isChecked();
+                if (no){
+                    swApplyTheme_Viewer.setChecked(false);
+                }else {
+                    swApplyTheme_Viewer.setChecked(true);
+                }
+            }
+        });
 
         ((CardView) dialogLayout.findViewById(R.id.third_act_theme_card)).setCardBackgroundColor(getCardBackgroundColor());
         dialogLayout.findViewById(R.id.third_act_theme_title).setBackgroundColor(getPrimaryColor());//or GetPrimary


### PR DESCRIPTION
Fixed #2676

Changes:
access by password and apply theme were made toggleable, i.e, now they can turned on just by tapping on the view.

Screenshots of the change: 

![WhatsAppVideo20190310at00](https://user-images.githubusercontent.com/31561661/54076257-a0814280-42cf-11e9-87a7-46251e0ac483.gif)
![WhatsAppVideo20190310at00 (1)](https://user-images.githubusercontent.com/31561661/54076264-b8f15d00-42cf-11e9-8972-b3d2c3514aaf.gif)
