### PR TITLE
unnecessary gap in text and paint color palette dialog removed.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SettingsActivity.java
@@ -834,6 +834,7 @@ public class SettingsActivity extends ThemedActivity {
         final View dialogLayout = getLayoutInflater().inflate(R.layout.color_piker_accent, null);
         final LineColorPicker colorPicker = dialogLayout.findViewById(R.id.color_picker_accent);
         final LineColorPicker colorPicker2 = dialogLayout.findViewById(R.id.color_picker_accent_2);
+        colorPicker2.setVisibility(View.VISIBLE);
         final TextView dialogTitle = dialogLayout.findViewById(R.id.cp_accent_title);
         CardView cv = dialogLayout.findViewById(R.id.cp_accent_card);
         cv.setCardBackgroundColor(getCardBackgroundColor());

--- a/app/src/main/res/layout/color_piker_accent.xml
+++ b/app/src/main/res/layout/color_piker_accent.xml
@@ -50,6 +50,7 @@
                         xmlns:app="http://schemas.android.com/apk/res-auto"
                         android:id="@+id/color_picker_accent_2"
                         android:layout_width="match_parent"
+                        android:visibility="gone"
                         android:layout_height="@dimen/size_40"
                         app:orientation="horizontal"
                         app:selectedColorIndex="0"


### PR DESCRIPTION
Fixed #2671 

Changes: 
unnecessary gap in dialog removed.

Screenshots of the change: 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/31561661/54210848-40c0ac80-4506-11e9-94c4-77afa44e1449.gif)
