### PR TITLE
Fixes for NDK r19.

### DIFF
--- a/app/src/main/jni/Application.mk
+++ b/app/src/main/jni/Application.mk
@@ -1,5 +1,5 @@
 APP_OPTIM := release
 APP_ABI := armeabi-v7a
-APP_STL := gnustl_static
+APP_STL := c++_static
 APP_CPPFLAGS := -frtti -fexceptions
 APP_PLATFORM := android-25

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -192,7 +192,7 @@
         <item name="cardElevation">@dimen/card_elevation</item>
     </style>
 
-    <style name="Theme.ownCloud.Dialog.ButtonBar" parent="style/Widget.AppCompat.Button.ButtonBar.AlertDialog">
+    <style name="Theme.ownCloud.Dialog.ButtonBar" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
         <!-- Making sure, the button bar uses parent width and is not restricted in height -->
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.0'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
         classpath "io.realm:realm-gradle-plugin:$realm_version"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 09 04:17:45 IST 2017
+#Tue Mar 12 10:01:06 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
* Use a supported STL.
* Fix bad style reference (aapt2 catches this).
* Update gradle plugin to one compatible with NDK r16+.

This still isn't sufficient because the OpenCV prebuilts are gnustl
only, but it's a starting place for anyone that can tackle that.
