### PR TITLE
Fix #2703 undo and redo enable issue

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
@@ -167,6 +167,10 @@ public class StickersFragment extends BaseEditFragment implements View.OnClickLi
         @Override
         public void handleImage(Canvas canvas, Matrix m) {
             LinkedHashMap<Integer, StickerItem> addItems = mStickerView.getBank();
+            if (addItems.size() == 0) {
+                this.cancel(true);
+                return;
+            }
             for (Integer id : addItems.keySet()) {
                 StickerItem item = addItems.get(id);
                 item.matrix.postConcat(m);
@@ -183,6 +187,9 @@ public class StickersFragment extends BaseEditFragment implements View.OnClickLi
     }
 
     public void applyStickers() {
+        if (mStickerView.getBank().size() == 0){
+            backToMain();
+        }
         if (mSaveTask != null) {
             mSaveTask.cancel(true);
         }


### PR DESCRIPTION
Fixed #2703 

Changes: [Added a condition if there is not sticker then do not perform the undo and redo functions]

GIF of the change: 

<img src = "https://user-images.githubusercontent.com/22986571/55503862-27c29b80-566d-11e9-92cc-93294a082544.gif" width = 220 height = 400 />