### PR TITLE
Fix #2553 reappear of password dialog

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1494,6 +1494,10 @@ public class LFMainActivity extends SharedMediaActivity {
                 findViewById(R.id.ll_drawer_Default).setBackgroundColor(Color.TRANSPARENT);
                 findViewById(R.id.ll_drawer_hidden).setBackgroundColor(getHighlightedItemColor());
                 tint();
+                if (hidden) {
+                    mDrawerLayout.closeDrawer(GravityCompat.START);
+                    return;
+                }
                 if (securityObj.isActiveSecurity() && securityObj.isPasswordOnHidden()) {
                     final boolean[] passco = {false};
                     AlertDialog.Builder passwordDialogBuilder = new AlertDialog.Builder(LFMainActivity.this, getDialogStyle());


### PR DESCRIPTION
Fixed #2553

Changes: [Add a condition where it checks if we are in hidden folder or not then it proceeds.]

GIF of the change: 

<img src="https://user-images.githubusercontent.com/22986571/56459019-ba707380-63ab-11e9-9cf1-a17465b231b9.gif" width = 220 height=420/>
