### PR TITLE
chore: Made Android 5.0 as minimum SDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         applicationId "org.fossasia.phimpme"
-        minSdkVersion 17
+        minSdkVersion 21
         targetSdkVersion 26
         multiDexEnabled true
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'


### PR DESCRIPTION
Fixed #2735 

Changes: Android 5.0 has been set as the minimum required SDK.
