### PR TITLE
fix: Added snackbars when image is deleted from SingleMediaActivity.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1600,24 +1600,6 @@ public class LFMainActivity extends SharedMediaActivity {
     }
   }
 
-  private void showsnackbar(Boolean result) {
-    if (result) {
-      Snackbar snackbar =
-          SnackBarHandler.show(
-              mDrawerLayout,
-              getApplicationContext().getString(R.string.photo_deleted_msg),
-              navigationView.getHeight());
-      snackbar.show();
-    } else {
-      Snackbar snackbar =
-          SnackBarHandler.show(
-              mDrawerLayout,
-              getApplicationContext().getString(R.string.photo_deletion_failed),
-              navigationView.getHeight());
-      snackbar.show();
-    }
-  }
-
   private void checkNoSearchResults(String result, int length) {
     if (length > 0) {
       textView.setText(getString(R.string.null_search_result) + " " + '"' + result + '"');
@@ -2088,6 +2070,12 @@ public class LFMainActivity extends SharedMediaActivity {
                     getAlbum().clearSelectedPhotos();
                   } else {
                     succ = getAlbum().deleteSelectedMedia(getApplicationContext());
+                    Snackbar snackbar =
+                        SnackBarHandler.show(
+                            mDrawerLayout,
+                            getApplicationContext().getString(R.string.photo_deleted_msg),
+                            navigationView.getHeight());
+                    snackbar.show();
                   }
                 } else if (all_photos && !fav_photos) {
                   checkForShare(selectedMedias);
@@ -2120,6 +2108,12 @@ public class LFMainActivity extends SharedMediaActivity {
                                 MediaStore.Images.Media.EXTERNAL_CONTENT_URI, id);
                         contentResolver.delete(deleteUri, null, null);
                         succ = true;
+                        Snackbar snackbar =
+                            SnackBarHandler.show(
+                                mDrawerLayout,
+                                getApplicationContext().getString(R.string.photo_deleted_msg),
+                                navigationView.getHeight());
+                        snackbar.show();
                       } else {
                         succ = false;
                         // File not found in media store DB
@@ -2162,6 +2156,12 @@ public class LFMainActivity extends SharedMediaActivity {
                   } else {
                     succ = getAlbums().deleteAlbum(getAlbum(), getApplicationContext());
                     getAlbum().getMedia().clear();
+                    Snackbar snackbar =
+                        SnackBarHandler.show(
+                            mDrawerLayout,
+                            getApplicationContext().getString(R.string.photo_deleted_msg),
+                            navigationView.getHeight());
+                    snackbar.show();
                   }
                 } else {
                   checkForShare(favouriteslist);
@@ -2190,6 +2190,12 @@ public class LFMainActivity extends SharedMediaActivity {
                 getAlbums().clearSelectedAlbums();
                 mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
                 albumsAdapter.notifyDataSetChanged();
+                Snackbar snackbar =
+                    SnackBarHandler.show(
+                        mDrawerLayout,
+                        getApplicationContext().getString(R.string.album_deleted),
+                        navigationView.getHeight());
+                snackbar.show();
               } else {
                 if (!all_photos && !fav_photos) {
                   // if all media in current album have been deleted, delete current album too.
@@ -2197,7 +2203,6 @@ public class LFMainActivity extends SharedMediaActivity {
                     getAlbums().removeCurrentAlbum();
                     albumsAdapter.notifyDataSetChanged();
                     displayAlbums();
-                    showsnackbar(succ);
                     swipeRefreshLayout.setRefreshing(true);
                   } else mediaAdapter.swapDataSet(getAlbum().getMedia(), false);
                 } else if (all_photos && !fav_photos) {
@@ -2205,7 +2210,6 @@ public class LFMainActivity extends SharedMediaActivity {
                   listAll = StorageProvider.getAllShownImages(LFMainActivity.this);
                   media = listAll;
                   size = listAll.size();
-                  showsnackbar(succ);
                   Collections.sort(
                       listAll,
                       MediaComparators.getComparator(

--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -106,6 +106,7 @@ import org.fossasia.phimpme.gallery.util.StringUtils;
 import org.fossasia.phimpme.gallery.util.ThemeHelper;
 import org.fossasia.phimpme.gallery.views.PagerRecyclerView;
 import org.fossasia.phimpme.share.SharingActivity;
+import org.fossasia.phimpme.trashbin.TrashBinActivity;
 import org.fossasia.phimpme.utilities.ActivitySwitchHelper;
 import org.fossasia.phimpme.utilities.BasicCallBack;
 import org.fossasia.phimpme.utilities.SnackBarHandler;
@@ -864,8 +865,29 @@ public class SingleMediaActivity extends SharedMediaActivity
     if (!allPhotoMode && !favphotomode && !upoadhis && !trashdis) {
       if (AlertDialogsHelper.check) {
         success = addToTrash();
+        Snackbar snackbar =
+            SnackBarHandler.showWithBottomMargin(
+                parentView,
+                getString(R.string.trashbin_move_onefile),
+                bottomBar.getHeight() + navigationView.getHeight(),
+                Snackbar.LENGTH_SHORT);
+        snackbar.setAction(
+            R.string.open,
+            new View.OnClickListener() {
+              @Override
+              public void onClick(View view) {
+                startActivity(new Intent(SingleMediaActivity.this, TrashBinActivity.class));
+              }
+            });
+        snackbar.show();
       } else {
         success = getAlbum().deleteCurrentMedia(getApplicationContext());
+        Snackbar snackbar =
+            SnackBarHandler.showWithBottomMargin(
+                parentView,
+                getApplicationContext().getString(R.string.photo_deleted_msg),
+                bottomBar.getHeight() + navigationView.getHeight());
+        snackbar.show();
       }
       if (!success) {
         final AlertDialog.Builder dialogBuilder =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -671,6 +671,7 @@
     <string name="new_folder_message">The new folder will be created in the current path, and
         then the media will be copied or moved in the new folder.
     </string>
+    <string name="album_deleted">Selected album(s) deleted</string>
     <string name="enter_time">Enter time interval</string>
     <string name="time_interval">Time interval (seconds) (>1sec)</string>
     <string name="discard_changes_message">Are you sure you want to discard all changes?</string>
@@ -728,6 +729,7 @@
     <string name="insert_a_name">Insert something</string>
     <string name="nothing_changed">Nothing changed!</string>
     <string name="install_shortcut">Install shortcut</string>
+    <string name="open">OPEN</string>
 
     <!--SETTINGS PREFERENCES-->
     <string name="general_setting">General Setting</string>
@@ -1352,7 +1354,7 @@
     <string name="slide_start">Slideshow Started!</string>
 
     <!-- Photo deletion toast messages -->
-    <string name="photo_deleted_msg">Photo deleted</string>
+    <string name="photo_deleted_msg">Photo(s) deleted</string>
     <string name="photo_deleted_from_fav_msg">Photo deleted from favourites</string>
     <string name="photo_deletion_failed">Photo deletion failed</string>
     <string name="remove">Remove</string>


### PR DESCRIPTION
Fixed #2590 

Changes: If an image is deleted or moved to trashbin from the SingleMediaActivity, a snackbar is shown. Removed the `showsnackbar` method as we need different messages when albums and images are deleted.
