### PR TITLE
fix: Toast shown when image is compressed.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/CompressImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/CompressImageActivity.java
@@ -20,6 +20,7 @@ import android.widget.ImageButton;
 import android.widget.ListView;
 import android.widget.SeekBar;
 import android.widget.TextView;
+import android.widget.Toast;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import id.zelory.compressor.Compressor;
@@ -203,6 +204,7 @@ public class CompressImageActivity extends ThemedActivity {
       String name = saveFilePath.substring(saveFilePath.lastIndexOf("/") + 1);
       FileUtil.albumUpdate(context, FileUtilsCompress.createFolders().getPath() + "/" + name);
       dialog1.dismiss();
+      Toast.makeText(context, R.string.compress, Toast.LENGTH_SHORT).show();
     }
   }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1011,6 +1011,7 @@
     <string name="frame">Frame</string>
     <string name="write">Write</string>
     <string name="share">share</string>
+    <string name="compress">The image has been compressed successfully.</string>
 
     <!--ACCOUNTS-->
     <string name="internet_is_off">You are not connected to the internet</string>


### PR DESCRIPTION
Fixed #2629 

Changes: A toast is shown when a user compresses an image. (A toast is shown as snackbar is not visible properly due to the presence of a background dialog)
