### PR TITLE
fix: Added alert if user clicks tick button in stickers section without adding any stickers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: android
 jdk: oraclejdk8
 sudo: false
+dist: trusty
+
 env:
   global:
     - ANDROID_API_LEVEL=22

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
@@ -1,5 +1,6 @@
 package org.fossasia.phimpme.editor.fragment;
 
+import android.content.DialogInterface;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
@@ -7,6 +8,7 @@ import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.os.Bundle;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -29,6 +31,7 @@ import org.fossasia.phimpme.editor.EditImageActivity;
 import org.fossasia.phimpme.editor.task.StickerTask;
 import org.fossasia.phimpme.editor.view.StickerItem;
 import org.fossasia.phimpme.editor.view.StickerView;
+import org.fossasia.phimpme.gallery.util.AlertDialogsHelper;
 
 public class StickersFragment extends BaseEditFragment implements View.OnClickListener {
 
@@ -137,7 +140,30 @@ public class StickersFragment extends BaseEditFragment implements View.OnClickLi
   public void onClick(View v) {
     switch (v.getId()) {
       case R.id.sticker_apply:
-        applyStickers();
+        if (!mStickerView.getBank().isEmpty()) {
+          applyStickers();
+        } else {
+          new AlertDialog.Builder(getContext())
+              .setTitle(R.string.no_stickers)
+              .setMessage(R.string.exit_no_stickers)
+              .setPositiveButton(
+                  android.R.string.yes,
+                  new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+                      dialog.dismiss();
+                      backToMain();
+                    }
+                  })
+              .setNegativeButton(
+                  android.R.string.cancel,
+                  new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+                      dialog.dismiss();
+                    }
+                  })
+              .setIcon(R.drawable.ic_red_dialog_alert)
+              .show();
+        }
         break;
       case R.id.sticker_cancel:
         backToMain();

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
@@ -31,7 +31,6 @@ import org.fossasia.phimpme.editor.EditImageActivity;
 import org.fossasia.phimpme.editor.task.StickerTask;
 import org.fossasia.phimpme.editor.view.StickerItem;
 import org.fossasia.phimpme.editor.view.StickerView;
-import org.fossasia.phimpme.gallery.util.AlertDialogsHelper;
 
 public class StickersFragment extends BaseEditFragment implements View.OnClickListener {
 

--- a/app/src/main/res/drawable/ic_red_dialog_alert.xml
+++ b/app/src/main/res/drawable/ic_red_dialog_alert.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<bitmap
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:src="@android:drawable/ic_dialog_alert"
+    android:tint="#FF0000"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1011,6 +1011,8 @@
     <string name="frame">Frame</string>
     <string name="write">Write</string>
     <string name="share">share</string>
+    <string name="no_stickers">No stickers applied !</string>
+    <string name="exit_no_stickers">Are you sure you want to exit without adding any stickers?</string>
 
     <!--ACCOUNTS-->
     <string name="internet_is_off">You are not connected to the internet</string>


### PR DESCRIPTION
Fixed #2656 

Changes: If user presses tick button in stickers section without using any sticker, an alert is shown. 
I have not used `button.setEnabled(false);` because it will make the user confused as to why the tick button is not working.

Screenshots of the change: 


![screencap](https://user-images.githubusercontent.com/41234408/59272230-316f0d80-8c73-11e9-9e19-b761b8a23df5.png)

