### PR TITLE
fix: No action if home button is pressed in gallery itself.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -686,7 +686,9 @@ public class LFMainActivity extends SharedMediaActivity {
                 findViewById(R.id.ll_drawer_Default).setBackgroundColor(getHighlightedItemColor());
                 tint();
               }
-              displayAlbums();
+              if (!albumsMode) {
+                displayAlbums();
+              }
               return true;
             }
             return LFMainActivity.super.onNavigationItemSelected(item);


### PR DESCRIPTION
Fixed #2723 

Changes: 
- If user presses `gallery` button while in albums mode(home screen), refresh action does not take place.
- If the user is viewing photos inside an album, and presses `gallery`, the user is redirected to home.
