### PR TITLE
fix: Title changes to remove album cover as soon as a photo is set as the album cover.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/SingleMediaActivity.java
@@ -148,6 +148,7 @@ public class SingleMediaActivity extends SharedMediaActivity
   private boolean details = false;
   private ArrayList<Media> favouriteslist;
   public static Media mediacompress = null;
+  private Menu menu;
 
   private ArrayList<Media> uploadhistory;
   private ArrayList<Media> trashbinlistd;
@@ -679,6 +680,7 @@ public class SingleMediaActivity extends SharedMediaActivity
   public boolean onCreateOptionsMenu(Menu menu) {
     // Inflate the menu; this adds items to the action bar if it is present.
     getMenuInflater().inflate(R.menu.menu_view_pager, menu);
+    this.menu = menu;
     return true;
   }
 
@@ -1756,6 +1758,8 @@ public class SingleMediaActivity extends SharedMediaActivity
               getApplicationContext(), getAlbum().getCurrentMedia().getPath());
           SnackBarHandler.showWithBottomMargin(
               parentView, getString(R.string.change_cover), bottomBar.getHeight());
+          MenuItem cover = menu.findItem(R.id.action_cover);
+          cover.setTitle("Remove cover image");
         }
 
         return true;


### PR DESCRIPTION
Fixed #2675 

Changes: Title changes to remove album cover as soon as a photo is set as the album cover.

Screenshots of the change: 

![screencap](https://user-images.githubusercontent.com/41234408/59317001-c0653f80-8cde-11e9-9b5d-426f41f1cc69.png)
