### PR TITLE
fix: Icons in camera settings made matching with the app theme

### DIFF
--- a/app/src/main/res/drawable/ic_location_on_black_48dp.xml
+++ b/app/src/main/res/drawable/ic_location_on_black_48dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z"/>
+</vector>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -225,7 +225,7 @@
         android:title="@string/preference_category_camera_quality">
 
         <PreferenceScreen
-            android:icon="@drawable/take_photo_pref"
+            android:icon="@drawable/ic_photo_camera_white_48dp"
             android:key="preference_screen_photo_settings"
             android:persistent="false"
             android:title="@string/preference_screen_photo_settings">
@@ -388,14 +388,14 @@
         </PreferenceScreen>
 
         <PreferenceScreen
-            android:icon="@drawable/earth"
+            android:icon="@drawable/ic_location_on_black_48dp"
             android:key="preference_screen_location_settings"
             android:persistent="false"
             android:title="@string/preference_screen_location_settings">
 
             <CheckBoxPreference
                 android:defaultValue="false"
-                android:icon="@drawable/earth"
+                android:icon="@drawable/ic_location_on_black_48dp"
                 android:key="preference_location"
                 android:summary="@string/preference_location_summary"
                 android:title="@string/preference_location" />


### PR DESCRIPTION
Fixed #2654 

Changes: Icons changed to match the entire app theme.

Screenshots of the change: 

![screencap](https://user-images.githubusercontent.com/41234408/59318081-6a46cb00-8ce3-11e9-860d-da22e857cb00.png)
