### PR TITLE
fix: All cancel buttons made upper case

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/CompressImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/CompressImageActivity.java
@@ -126,7 +126,7 @@ public class CompressImageActivity extends ThemedActivity {
     // this is set the view from XML inside AlertDialog
     alert.setView(dialogLayout);
     alert.setNegativeButton(
-        getResources().getString(R.string.cancel),
+        getResources().getString(R.string.cancel).toUpperCase(),
         new DialogInterface.OnClickListener() {
           @Override
           public void onClick(DialogInterface dialog, int which) {
@@ -343,7 +343,7 @@ public class CompressImageActivity extends ThemedActivity {
     AlertDialog.Builder alert = new AlertDialog.Builder(this);
     alert.setView(dialogLayout);
     alert.setNegativeButton(
-        getResources().getString(R.string.cancel),
+        getResources().getString(R.string.cancel).toUpperCase(),
         new DialogInterface.OnClickListener() {
           @Override
           public void onClick(DialogInterface dialog, int which) {

--- a/app/src/main/java/org/fossasia/phimpme/editor/font/FontPickerDialog.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/font/FontPickerDialog.java
@@ -100,7 +100,7 @@ public class FontPickerDialog extends DialogFragment {
     builder.setCustomTitle(titleLinearLayout);
 
     builder.setNegativeButton(
-        R.string.cancel,
+        getString(R.string.cancel).toUpperCase(),
         new DialogInterface.OnClickListener() {
           public void onClick(DialogInterface dialog, int id) {
             // don't have to do anything on cancel

--- a/app/src/main/java/org/fossasia/phimpme/share/SharingActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/share/SharingActivity.java
@@ -377,7 +377,7 @@ public class SharingActivity extends ThemedActivity
             }
           });
       dialogBuilder.setNegativeButton(
-          R.string.cancel,
+          getString(R.string.cancel).toUpperCase(),
           new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialogInterface, int i) {


### PR DESCRIPTION
Fixed #2687 

Changes: All cancel buttons in app have `cancel` in upper case now. 

The `cancel` in the dialog in camera setting can not be made upper case as it is not actually a dialog, but a popup and the cancel button seems to be a default part of the popup as I was unable to find that piece of code anywhere.
