### PR TITLE
fix: If photo is not being saved, user is guided to the permission setting to give proper permission.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
@@ -6,8 +6,10 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.support.annotation.StringRes;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
@@ -18,6 +20,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.ImageButton;
 import android.widget.ProgressBar;
+import android.widget.Toast;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import java.io.File;
@@ -668,8 +671,42 @@ public class EditImageActivity extends EditBaseActivity
         resetOpTimes();
         onSaveTaskDone();
       } else {
-        Snackbar snackbar = SnackBarHandler.show(parentLayout, getString(R.string.save_error));
-        snackbar.show();
+        final AlertDialog.Builder discardChangesDialogBuilder =
+            new AlertDialog.Builder(EditImageActivity.this, getDialogStyle());
+        AlertDialogsHelper.getTextDialog(
+            EditImageActivity.this,
+            discardChangesDialogBuilder,
+            R.string.save_error,
+            R.string.permissions_error,
+            null);
+        discardChangesDialogBuilder.setPositiveButton(
+            getString(R.string.ok).toUpperCase(),
+            new DialogInterface.OnClickListener() {
+              @Override
+              public void onClick(DialogInterface dialog, int which) {
+                Intent intent = new Intent();
+                intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                Uri uri = Uri.fromParts("package", getPackageName(), null);
+                intent.setData(uri);
+                startActivity(intent);
+              }
+            });
+        discardChangesDialogBuilder.setNegativeButton(
+            getString(R.string.cancel).toUpperCase(),
+            new DialogInterface.OnClickListener() {
+              @Override
+              public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
+                Toast.makeText(getBaseContext(), R.string.no_save, Toast.LENGTH_LONG).show();
+              }
+            });
+
+        AlertDialog alertDialog = discardChangesDialogBuilder.create();
+        alertDialog.show();
+        AlertDialogsHelper.setButtonTextColor(
+            new int[] {DialogInterface.BUTTON_POSITIVE, DialogInterface.BUTTON_NEGATIVE},
+            getAccentColor(),
+            alertDialog);
       }
     }
   }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -995,7 +995,9 @@
 
     <string name="no_choose">please choose a image for edit</string>
     <string name="auto_newline">AutoNewline</string>
-    <string name="save_error">Save error!</string>
+    <string name="save_error">Save Error</string>
+    <string name="no_save">Images will not be saved successfully until proper permissions are granted</string>
+    <string name="permissions_error">The app has not been granted proper permissions. Please click OK to give permissions. In the permission settings, toggle the storage permission off and on.\n(This has to be done even if storage permission is already toggled on.)</string>
 
     <string name="tune">Tune</string>
     <string name="exit_without_save">The edited image is not saved. Do you want to exit?</string>


### PR DESCRIPTION
Fixed #2771 

Changes: If the user is not able to save images, the user is directed to the permission settings.

Screenshots of the change: 

![screencap](https://user-images.githubusercontent.com/41234408/59763028-3ad12900-92b6-11e9-9605-f5922882f056.png)
