### PR TITLE
fix: Edited changes are saved on orientation change.

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/AddTextFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/AddTextFragment.java
@@ -45,6 +45,7 @@ public class AddTextFragment extends BaseEditFragment
 
   private InputMethodManager imm;
   private SaveTextStickerTask mSaveTask;
+  private String text = null;
 
   public static AddTextFragment newInstance() {
     return new AddTextFragment();
@@ -79,6 +80,10 @@ public class AddTextFragment extends BaseEditFragment
     ((ImageButton) cancel).setColorFilter(Color.BLACK);
     ((ImageButton) apply).setColorFilter(Color.BLACK);
 
+    if (savedInstanceState != null) {
+      text = savedInstanceState.getString("Edit Text");
+    }
+
     mInputText = mainView.findViewById(R.id.text_input);
     mTextColorSelector = mainView.findViewById(R.id.text_color);
     mTextColorSelector.setImageDrawable(
@@ -94,6 +99,9 @@ public class AddTextFragment extends BaseEditFragment
         });
     mTextColorSelector.setOnClickListener(new SelectColorBtnClick());
     mInputText.addTextChangedListener(this);
+    if (text != null) {
+      mInputText.setText(text);
+    }
     boolean focus = mInputText.requestFocus();
     if (focus) {
       imm.showSoftInput(mInputText, InputMethodManager.SHOW_IMPLICIT);
@@ -108,6 +116,13 @@ public class AddTextFragment extends BaseEditFragment
             showFontChoiceBox();
           }
         });
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    outState.putString("Edit Text", mInputText.getText().toString());
+    // outState.putString("text", text);
   }
 
   private void showFontChoiceBox() {
@@ -221,8 +236,8 @@ public class AddTextFragment extends BaseEditFragment
   public void onShow() {
     activity.changeMode(EditImageActivity.MODE_TEXT);
     activity.mainImage.setImageBitmap(activity.mainBitmap);
-    activity.addTextFragment.getmTextStickerView().mainImage = activity.mainImage;
-    activity.addTextFragment.getmTextStickerView().mainBitmap = activity.mainBitmap;
+    getmTextStickerView().mainImage = activity.mainImage;
+    getmTextStickerView().mainBitmap = activity.mainBitmap;
     mTextStickerView.setVisibility(View.VISIBLE);
     mInputText.clearFocus();
   }

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/CropFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/CropFragment.java
@@ -39,11 +39,13 @@ public class CropFragment extends BaseEditFragment {
   private LinearLayout ratioList, imageList, combinedList;
   private static List<RatioItem> dataList = new ArrayList<RatioItem>();
   private List<TextView> textViewList = new ArrayList<TextView>();
+  private RectF rec;
 
   public static int SELECTED_COLOR = Color.BLUE;
   public static int UNSELECTED_COLOR = Color.BLACK;
   private CropRationClick mCropRationClick = new CropRationClick();
   public TextView selctedTextView;
+  private TextView sView;
 
   public static CropFragment newInstance() {
     CropFragment fragment = new CropFragment();
@@ -138,7 +140,7 @@ public class CropFragment extends BaseEditFragment {
       ratioList.addView(text, params1);
       imageList.addView(image, params);
       text.setTag(i);
-      if (i == 0) {
+      if (i == 0 && selctedTextView == null) {
         selctedTextView = text;
       }
       dataList.get(i).setIndex(i);
@@ -191,7 +193,8 @@ public class CropFragment extends BaseEditFragment {
       RatioItem dataItem = (RatioItem) v.getTag();
       selctedTextView = curTextView;
       selctedTextView.setTextColor(SELECTED_COLOR);
-
+      sView = selctedTextView;
+      sView.setTag(v.getTag());
       mCropPanel.setRatioCropRect(activity.mainImage.getBitmapRect(), dataItem.getRatio());
     }
   }
@@ -219,8 +222,19 @@ public class CropFragment extends BaseEditFragment {
               applyCropImage();
             }
           });
+      if (savedInstanceState != null) {
+        rec = savedInstanceState.getParcelable("Rect");
+        sView.setText(savedInstanceState.getString("text"));
+      }
       onShow();
     }
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    outState.putParcelable("Rect", activity.mainImage.getBitmapRect());
+    outState.putString("text", sView.getText().toString());
   }
 
   @Override
@@ -239,7 +253,20 @@ public class CropFragment extends BaseEditFragment {
     activity.mainImage.setDisplayType(ImageViewTouchBase.DisplayType.FIT_TO_SCREEN);
     activity.mainImage.setScaleEnabled(false);
     RectF r = activity.mainImage.getBitmapRect();
-    activity.mCropPanel.setCropRect(r);
+    if (rec != null) {
+      activity.mCropPanel.setCropRect(rec);
+    } else {
+      activity.mCropPanel.setCropRect(r);
+    }
+
+    if (sView != null) {
+      selctedTextView.setTextColor(UNSELECTED_COLOR);
+      RatioItem dataItem = (RatioItem) sView.getTag();
+      selctedTextView = sView;
+      sView.setTextColor(SELECTED_COLOR);
+      selctedTextView.setTextColor(SELECTED_COLOR);
+      if (rec != null) mCropPanel.setRatioCropRect(rec, dataItem.getRatio());
+    }
   }
 
   private final class BackToMenuClick implements OnClickListener {

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/PaintFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/PaintFragment.java
@@ -54,6 +54,9 @@ public class PaintFragment extends BaseEditFragment
 
   private SaveCustomPaintTask mSavePaintImageTask;
 
+  private static int mStokeColor = Integer.MIN_VALUE;
+  private static float mStokeWidth = Integer.MIN_VALUE;
+
   public int[] mPaintColors = {
     Color.BLACK,
     Color.DKGRAY,
@@ -115,9 +118,30 @@ public class PaintFragment extends BaseEditFragment
 
     initStokeWidthPopWindow();
 
+    if (savedInstanceState != null) {
+      mPaintView.mDrawBit = savedInstanceState.getParcelable("Draw Bit");
+      CustomPaintView.mPaintCanvas = new Canvas(mPaintView.mDrawBit);
+      mStokeColor = savedInstanceState.getInt("Stoke Color");
+      mStokeWidth = savedInstanceState.getFloat("Stoke Width");
+    }
+    if (mStokeColor != Integer.MIN_VALUE && mStokeWidth != Integer.MIN_VALUE) {
+      mPaintModeView.setPaintStrokeColor(mStokeColor);
+      mPaintModeView.setPaintStrokeWidth(mStokeWidth);
+      setPaintColor(mStokeColor);
+      mPaintModeView.setPaintStrokeWidth(mStokeWidth);
+    }
+
     mEraserView.setOnClickListener(this);
     updateEraserView();
     onShow();
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    outState.putFloat("Stoke Width", mPaintModeView.getStokenWidth());
+    outState.putInt("Stoke Color", mPaintModeView.getStokenColor());
+    outState.putParcelable("Draw Bit", mPaintView.mDrawBit);
   }
 
   private void initColorListView() {

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/RecyclerMenuFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/RecyclerMenuFragment.java
@@ -28,7 +28,7 @@ import org.fossasia.phimpme.editor.view.StickerView;
 
 public class RecyclerMenuFragment extends BaseEditFragment {
 
-  RecyclerView recyclerView;
+  private RecyclerView recyclerView;
   int MODE;
   private static ArrayList<Bitmap> filterThumbs;
   View fragmentView;
@@ -58,6 +58,7 @@ public class RecyclerMenuFragment extends BaseEditFragment {
 
   public void clearCurrentSelection() {
     if (currentSelection != -1) {
+      recyclerView = fragmentView.findViewById(R.id.editor_recyclerview);
       mRecyclerAdapter.mViewHolder holder =
           (mRecyclerAdapter.mViewHolder)
               recyclerView.findViewHolderForAdapterPosition(currentSelection);
@@ -95,8 +96,16 @@ public class RecyclerMenuFragment extends BaseEditFragment {
   @Override
   public View onCreateView(
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    fragmentView = null;
+    container.removeAllViews();
     fragmentView = inflater.inflate(R.layout.fragment_editor_recycler, container, false);
     return fragmentView;
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    outState.putInt("sample element", 5);
   }
 
   @Override
@@ -117,7 +126,7 @@ public class RecyclerMenuFragment extends BaseEditFragment {
   @Override
   public void onDestroy() {
     super.onDestroy();
-    //    if (filterThumbs != null)filterThumbs=null;
+    if (filterThumbs != null) filterThumbs = null;
     MyApplication.getRefWatcher(getActivity()).watch(this);
   }
 
@@ -156,11 +165,12 @@ public class RecyclerMenuFragment extends BaseEditFragment {
         bmHeight = currentBitmap.getHeight();
         int leng = (titlelist != null) ? titlelist.length() : 0;
         for (int i = 0; i < leng; i++) {
-          filterThumbs.add(
-              PhotoProcessing.processImage(
-                  getResizedBitmap(currentBitmap, 5),
-                  (i + 100 * EditImageActivity.MODE_FILTERS),
-                  100));
+          if (filterThumbs != null)
+            filterThumbs.add(
+                PhotoProcessing.processImage(
+                    getResizedBitmap(currentBitmap, 5),
+                    (i + 100 * EditImageActivity.MODE_FILTERS),
+                    100));
         }
       }
       return null;

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/RotateFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/RotateFragment.java
@@ -30,6 +30,7 @@ public class RotateFragment extends BaseEditFragment {
 
   private HorizontalWheelView horizontalWheelView;
   private TextView tvAngle;
+  private static double angle = Integer.MIN_VALUE;
 
   public static RotateFragment newInstance() {
     RotateFragment fragment = new RotateFragment();
@@ -54,12 +55,22 @@ public class RotateFragment extends BaseEditFragment {
     return mainView;
   }
 
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+  }
+
   private void initViews() {
     cancel = mainView.findViewById(R.id.rotate_cancel);
     apply = mainView.findViewById(R.id.rotate_apply);
     horizontalWheelView = mainView.findViewById(R.id.horizontalWheelView);
+    if (angle != Integer.MIN_VALUE) {
+      horizontalWheelView.setDegreesAngle(angle);
+    }
     tvAngle = mainView.findViewById(R.id.tvAngle);
     this.mRotatePanel = ensureEditActivity().mRotatePanel;
+    if (angle != Integer.MIN_VALUE)
+      mRotatePanel.rotateImage((int) angle, activity.mainImage.getBitmapRect());
   }
 
   private void setupListeners() {
@@ -93,11 +104,12 @@ public class RotateFragment extends BaseEditFragment {
   private void updateText() {
     String text = String.format(Locale.US, "%.0f°", horizontalWheelView.getDegreesAngle());
     tvAngle.setText(text);
+    angle = horizontalWheelView.getDegreesAngle();
   }
 
   private void updateImage() {
     int angle = (int) horizontalWheelView.getDegreesAngle();
-    mRotatePanel.rotateImage(angle);
+    mRotatePanel.rotateImage(angle, activity.mainImage.getBitmapRect());
   }
 
   @Override
@@ -109,12 +121,10 @@ public class RotateFragment extends BaseEditFragment {
   @Override
   public void onDetach() {
     super.onDetach();
-    resetRotateView();
   }
 
   private void resetRotateView() {
     if (null != activity && null != mRotatePanel) {
-      activity.mRotatePanel.rotateImage(0);
       activity.mRotatePanel.reset();
       activity.mRotatePanel.setVisibility(View.GONE);
       activity.mainImage.setVisibility(View.VISIBLE);

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/SliderFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/SliderFragment.java
@@ -1,10 +1,13 @@
 package org.fossasia.phimpme.editor.fragment;
 
+import static com.mikepenz.iconics.Iconics.TAG;
+
 import android.app.Dialog;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -22,6 +25,7 @@ public class SliderFragment extends BaseEditFragment
   SeekBar seekBar;
   ImageButton cancel, apply;
   public Bitmap filterBit;
+  private int SeekBarProgress;
   Bitmap currentBitmap;
   View fragmentView;
 
@@ -52,17 +56,32 @@ public class SliderFragment extends BaseEditFragment
     apply.setOnClickListener(this);
 
     seekBar.setMax(100);
+    if (savedInstanceState != null) {
+      SeekBarProgress = savedInstanceState.getInt("Seekbar Progress");
+    }
     setDefaultSeekBarProgress();
     seekBar.setOnSeekBarChangeListener(this);
 
     onShow();
   }
 
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    outState.putInt("Seekbar Progress", seekBar.getProgress());
+    outState.putParcelable("FilterBit", filterBit);
+  }
+
   private void setDefaultSeekBarProgress() {
     if (null != seekBar) {
       switch (EditImageActivity.effectType / 100) {
         case EditImageActivity.MODE_FILTERS:
-          seekBar.setProgress(100);
+          if (SeekBarProgress > 0) {
+            seekBar.setProgress(SeekBarProgress);
+          } else {
+            Log.d(TAG, "setDefaultSeekBarProgress:Setting to 100");
+            seekBar.setProgress(100);
+          }
           break;
         case EditImageActivity.MODE_ENHANCE:
           switch (EditImageActivity.effectType % 300) {
@@ -70,14 +89,22 @@ public class SliderFragment extends BaseEditFragment
             case 6:
             case 7:
             case 8:
-              seekBar.setProgress(0);
+              if (SeekBarProgress > 0) {
+                seekBar.setProgress(SeekBarProgress);
+              } else {
+                seekBar.setProgress(0);
+              }
               break;
             case 0:
             case 1:
             case 3:
             case 4:
             case 5:
-              seekBar.setProgress(50);
+              if (SeekBarProgress > 0) {
+                seekBar.setProgress(SeekBarProgress);
+              } else {
+                seekBar.setProgress(50);
+              }
               break;
           }
           break;
@@ -160,7 +187,17 @@ public class SliderFragment extends BaseEditFragment
           filterBit = null;
         }
         if (EditImageActivity.effectType / 100 == EditImageActivity.MODE_FILTERS) {
-          activity.filterFragment.onShow();
+          activity.filterFragment.getFilterThumbs();
+        }
+        switch (activity.mode) {
+          case EditImageActivity.MODE_FILTERS:
+            activity.filterFragment.clearCurrentSelection();
+            break;
+          case EditImageActivity.MODE_ENHANCE:
+            activity.enhanceFragment.clearCurrentSelection();
+            break;
+          default:
+            break;
         }
         backToMain();
         break;

--- a/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/fragment/StickersFragment.java
@@ -1,5 +1,7 @@
 package org.fossasia.phimpme.editor.fragment;
 
+import static com.mikepenz.iconics.Iconics.TAG;
+
 import android.content.DialogInterface;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
@@ -11,6 +13,7 @@ import android.os.Bundle;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -41,6 +44,7 @@ public class StickersFragment extends BaseEditFragment implements View.OnClickLi
   List<String> pathList = new ArrayList<>();
   mRecyclerAdapter adapter;
   ImageButton cancel, apply;
+  String mData;
 
   public StickersFragment() {}
 
@@ -81,6 +85,13 @@ public class StickersFragment extends BaseEditFragment implements View.OnClickLi
     adapter = new mRecyclerAdapter();
     recyclerView.setAdapter(adapter);
 
+    if (savedInstanceState != null) {
+      mData = savedInstanceState.getString("Sticker position");
+      if (mData != null) {
+        selectedStickerItem(mData);
+      }
+    }
+
     this.mStickerView = activity.mStickerView;
     onShow();
   }
@@ -94,6 +105,12 @@ public class StickersFragment extends BaseEditFragment implements View.OnClickLi
   @Override
   public View onCreateView(
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    container.removeAllViews();
+    if (fragmentView != null) {
+      fragmentView.findViewById(R.id.sticker_cancel).setVisibility(View.GONE);
+      fragmentView.findViewById(R.id.sticker_apply).setVisibility(View.GONE);
+      fragmentView = null;
+    }
     fragmentView = inflater.inflate(R.layout.fragment_editor_stickers, container, false);
     return fragmentView;
   }
@@ -109,9 +126,19 @@ public class StickersFragment extends BaseEditFragment implements View.OnClickLi
       return;
     }
     activity.changeMode(EditImageActivity.MODE_STICKERS);
-    activity.stickersFragment.getmStickerView().mainImage = activity.mainImage;
-    activity.stickersFragment.getmStickerView().mainBitmap = activity.mainBitmap;
-    activity.stickersFragment.getmStickerView().setVisibility(View.VISIBLE);
+    if (this.mStickerView == null) Log.d(TAG, "onShow:this.mstickerview is null ");
+
+    getmStickerView().mainImage = activity.mainImage;
+    getmStickerView().mainBitmap = activity.mainBitmap;
+    getmStickerView().setVisibility(View.VISIBLE);
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    if (mData != null) {
+      outState.putString("Sticker position", mData);
+    }
   }
 
   private Bitmap getImageFromAssetsFile(String fileName) {
@@ -193,9 +220,11 @@ public class StickersFragment extends BaseEditFragment implements View.OnClickLi
         return;
       }
       for (Integer id : addItems.keySet()) {
-        StickerItem item = addItems.get(id);
-        item.matrix.postConcat(m);
-        canvas.drawBitmap(item.bitmap, item.matrix, null);
+        if (id != 1) {
+          StickerItem item = addItems.get(id);
+          item.matrix.postConcat(m);
+          canvas.drawBitmap(item.bitmap, item.matrix, null);
+        }
       }
     }
 
@@ -271,6 +300,7 @@ public class StickersFragment extends BaseEditFragment implements View.OnClickLi
             @Override
             public void onClick(View v) {
               String data = (String) v.getTag();
+              mData = data;
               selectedStickerItem(data);
             }
           });

--- a/app/src/main/java/org/fossasia/phimpme/editor/view/CustomPaintView.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/view/CustomPaintView.java
@@ -18,10 +18,10 @@ import org.fossasia.phimpme.editor.view.imagezoom.ImageViewTouch;
 /** Created by panyi on 17/2/11. */
 public class CustomPaintView extends View {
   private Paint mPaint;
-  private Bitmap mDrawBit;
+  public Bitmap mDrawBit;
   private Paint mEraserPaint;
 
-  private Canvas mPaintCanvas = null;
+  public static Canvas mPaintCanvas = null;
 
   private float last_x;
   private float last_y;

--- a/app/src/main/java/org/fossasia/phimpme/editor/view/RotateImageView.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/view/RotateImageView.java
@@ -25,6 +25,7 @@ public class RotateImageView extends View {
   private RectF wrapRect = new RectF(); // Picture surrounded by rectangles
   private Paint bottomPaint;
   private RectF originImageRect;
+  private RectF img;
 
   public RotateImageView(Context context) {
     super(context);
@@ -53,13 +54,16 @@ public class RotateImageView extends View {
     bitmap = bit;
     srcRect.set(0, 0, bitmap.getWidth(), bitmap.getHeight());
     dstRect = imageRect;
+    img = imageRect;
 
     originImageRect.set(0, 0, bit.getWidth(), bit.getHeight());
     this.invalidate();
   }
 
-  public void rotateImage(int angle) {
+  public void rotateImage(int angle, RectF imgRect) {
     rotateAngle = angle;
+    dstRect = imgRect;
+    img = imgRect;
     this.invalidate();
   }
 
@@ -90,6 +94,10 @@ public class RotateImageView extends View {
   }
 
   private void calculateWrapBox() {
+
+    if (dstRect == null) {
+      dstRect = img;
+    }
     wrapRect.set(dstRect);
     matrix.reset(); // Reset matrix is ​​a unit matrix
     int centerX = getWidth() >> 1;

--- a/app/src/main/java/org/fossasia/phimpme/editor/view/StickerItem.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/view/StickerItem.java
@@ -80,7 +80,7 @@ public class StickerItem {
     int top = (random.nextInt(parentView.getHeight() - (int) (parentView.getHeight() * 0.4f)));
     this.dstRect = new RectF(left, top, left + bitWidth, top + bitHeight);
     this.matrix = new Matrix();
-    this.matrix.postTranslate(left, top);
+    this.matrix.postTranslate(this.dstRect.left, this.dstRect.top);
     this.matrix.postScale(
         (float) bitWidth / addBit.getWidth(),
         (float) bitHeight / addBit.getHeight(),

--- a/app/src/main/java/org/fossasia/phimpme/editor/view/StickerView.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/view/StickerView.java
@@ -35,8 +35,7 @@ public class StickerView extends View {
   public ImageViewTouch mainImage;
   private float leftX, rightX, topY, bottomY;
 
-  private LinkedHashMap<Integer, StickerItem> bank =
-      new LinkedHashMap<Integer, StickerItem>(); // Storing each data map
+  public LinkedHashMap<Integer, StickerItem> bank;
 
   public StickerView(Context context) {
     super(context);
@@ -66,6 +65,10 @@ public class StickerView extends View {
 
   private void init(Context context) {
     this.mContext = context;
+    if (bank == null || bank.size() == 0) {
+      bank = new LinkedHashMap<Integer, StickerItem>();
+      bank.put(++imageCount, new StickerItem(context));
+    }
     currentStatus = STATUS_IDLE;
 
     rectPaint.setColor(Color.RED);
@@ -86,11 +89,16 @@ public class StickerView extends View {
   @Override
   protected void onDraw(Canvas canvas) {
     super.onDraw(canvas);
+    if (bank == null) {
+      bank = new LinkedHashMap<>();
+    }
     // System.out.println("on draw!!~");
     for (Integer id : bank.keySet()) {
-      StickerItem item = bank.get(id);
-      canvas.clipRect(leftX, topY, rightX, bottomY);
-      item.draw(canvas);
+      if (id != 1) {
+        StickerItem item = bank.get(id);
+        canvas.clipRect(leftX, topY, rightX, bottomY);
+        item.draw(canvas);
+      }
     } // end for each
   }
 
@@ -110,32 +118,34 @@ public class StickerView extends View {
       case MotionEvent.ACTION_DOWN:
         int deleteId = -1;
         for (Integer id : bank.keySet()) {
-          StickerItem item = bank.get(id);
-          if (item.detectDeleteRect.contains(x, y)) { // Delete mode
-            // ret = true;
-            deleteId = id;
-            currentStatus = STATUS_DELETE;
-          } else if (item.detectRotateRect.contains(x, y)) { // Click the Rotate button
-            ret = true;
-            if (currentItem != null) {
-              currentItem.isDrawHelpTool = false;
+          if (id != 1) {
+            StickerItem item = bank.get(id);
+            if (item.detectDeleteRect.contains(x, y)) { // Delete mode
+              // ret = true;
+              deleteId = id;
+              currentStatus = STATUS_DELETE;
+            } else if (item.detectRotateRect.contains(x, y)) { // Click the Rotate button
+              ret = true;
+              if (currentItem != null) {
+                currentItem.isDrawHelpTool = false;
+              }
+              currentItem = item;
+              currentItem.isDrawHelpTool = true;
+              currentStatus = STATUS_ROTATE;
+              oldx = x;
+              oldy = y;
+            } else if (item.dstRect.contains(x, y)) { // Mobile mode
+              // Selected one map
+              ret = true;
+              if (currentItem != null) {
+                currentItem.isDrawHelpTool = false;
+              }
+              currentItem = item;
+              currentItem.isDrawHelpTool = true;
+              currentStatus = STATUS_MOVE;
+              oldx = x;
+              oldy = y;
             }
-            currentItem = item;
-            currentItem.isDrawHelpTool = true;
-            currentStatus = STATUS_ROTATE;
-            oldx = x;
-            oldy = y;
-          } else if (item.dstRect.contains(x, y)) { // Mobile mode
-            // Selected one map
-            ret = true;
-            if (currentItem != null) {
-              currentItem.isDrawHelpTool = false;
-            }
-            currentItem = item;
-            currentItem.isDrawHelpTool = true;
-            currentStatus = STATUS_MOVE;
-            oldx = x;
-            oldy = y;
           }
         }
 

--- a/app/src/main/java/org/fossasia/phimpme/editor/view/imagezoom/ImageViewTouchBase.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/view/imagezoom/ImageViewTouchBase.java
@@ -10,7 +10,6 @@ import android.graphics.drawable.Drawable;
 import android.os.Handler;
 import android.util.AttributeSet;
 import android.util.Log;
-import android.widget.ImageView;
 import org.fossasia.phimpme.editor.view.imagezoom.easing.Cubic;
 import org.fossasia.phimpme.editor.view.imagezoom.easing.Easing;
 import org.fossasia.phimpme.editor.view.imagezoom.graphic.FastBitmapDrawable;
@@ -21,7 +20,8 @@ import org.fossasia.phimpme.editor.view.imagezoom.utils.IDisposable;
  *
  * @author alessandro
  */
-public abstract class ImageViewTouchBase extends ImageView implements IDisposable {
+public abstract class ImageViewTouchBase extends android.support.v7.widget.AppCompatImageView
+    implements IDisposable {
 
   public interface OnDrawableChangeListener {
 

--- a/app/src/main/res/layout-land/fragment_editor_recycler.xml
+++ b/app/src/main/res/layout-land/fragment_editor_recycler.xml
@@ -8,5 +8,6 @@
         android:layout_gravity="center_vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/editor_recyclerview"/>
+        android:id="@+id/editor_recyclerview"
+        android:baselineAligned="false" />
 </LinearLayout>


### PR DESCRIPTION
Fixed #2702 
Fixed #2789 

Changes: All edits in an image are stored when orientation change happens.

GIF:

![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/41234408/60036432-dd314800-96cc-11e9-8655-3109af79524d.gif)
