### PR TITLE
fix: Added a background dialog for delete, copy/move actions

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -8,6 +8,8 @@ import static org.fossasia.phimpme.utilities.ActivitySwitchHelper.context;
 
 import android.animation.Animator;
 import android.annotation.TargetApi;
+import android.app.Dialog;
+import android.app.ProgressDialog;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
@@ -2042,11 +2044,21 @@ public class LFMainActivity extends SharedMediaActivity {
 
           private boolean succ = false;
           private int imagesUnfav = 0;
+          private Dialog dialog;
 
           @Override
           protected void onPreExecute() {
+            dialog = getLoadingDialog(context, "Deleting", false);
+            dialog.show();
             swipeRefreshLayout.setRefreshing(true);
             super.onPreExecute();
+          }
+
+          private Dialog getLoadingDialog(Context context, String title, boolean canCancel) {
+            ProgressDialog dialog = new ProgressDialog(context);
+            dialog.setCancelable(canCancel);
+            dialog.setMessage(title);
+            return dialog;
           }
 
           @Override
@@ -2190,6 +2202,7 @@ public class LFMainActivity extends SharedMediaActivity {
 
           @Override
           protected void onPostExecute(Boolean result) {
+            dialog.dismiss();
             if (result) {
               // in albumsMode, the selected albums have been deleted.
               if (albumsMode) {
@@ -4503,6 +4516,7 @@ public class LFMainActivity extends SharedMediaActivity {
     // private Snackbar snackbar;
     private ArrayList<Media> temp;
     private Boolean moveAction, copyAction, success;
+    private Dialog dialog;
 
     CopyPhotos(String path, Boolean moveAction, Boolean copyAction, LFMainActivity reference) {
       this.path = path;
@@ -4513,9 +4527,18 @@ public class LFMainActivity extends SharedMediaActivity {
 
     @Override
     protected void onPreExecute() {
+      dialog = getLoadingDialog(context, "Copying photos", false);
+      dialog.show();
       LFMainActivity asyncActivityRef = reference.get();
       asyncActivityRef.swipeRefreshLayout.setRefreshing(true);
       super.onPreExecute();
+    }
+
+    private Dialog getLoadingDialog(Context context, String title, boolean canCancel) {
+      ProgressDialog dialog = new ProgressDialog(context);
+      dialog.setCancelable(canCancel);
+      dialog.setMessage(title);
+      return dialog;
     }
 
     @Override
@@ -4535,6 +4558,7 @@ public class LFMainActivity extends SharedMediaActivity {
 
     @Override
     protected void onPostExecute(Boolean result) {
+      dialog.dismiss();
       LFMainActivity asyncActivityRef = reference.get();
       if (result) {
         if (!asyncActivityRef.all_photos) {

--- a/app/src/main/java/org/fossasia/phimpme/trashbin/TrashBinActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/trashbin/TrashBinActivity.java
@@ -2,6 +2,8 @@ package org.fossasia.phimpme.trashbin;
 
 import static org.fossasia.phimpme.utilities.ActivitySwitchHelper.context;
 
+import android.app.Dialog;
+import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -280,11 +282,21 @@ public class TrashBinActivity extends ThemedActivity
 
   class DeleteAll extends AsyncTask<Void, Void, Void> {
     private final Boolean[] deleted = {false};
+    private Dialog dialog;
 
     @Override
     protected void onPreExecute() {
+      dialog = getLoadingDialog(context, "Deleting all photos", false);
+      dialog.show();
       swipeRefreshLayout.setRefreshing(true);
       super.onPreExecute();
+    }
+
+    private Dialog getLoadingDialog(Context context, String title, boolean canCancel) {
+      ProgressDialog dialog = new ProgressDialog(context);
+      dialog.setCancelable(canCancel);
+      dialog.setMessage(title);
+      return dialog;
     }
 
     @Override
@@ -310,6 +322,7 @@ public class TrashBinActivity extends ThemedActivity
     protected void onPostExecute(Void aVoid) {
       swipeRefreshLayout.setRefreshing(false);
       super.onPostExecute(aVoid);
+      dialog.dismiss();
       if (deleted[0] && trashBinRealmModelRealmQuery.count() == 0) {
         swipeRefreshLayout.setEnabled(false);
         emptyView.setVisibility(View.VISIBLE);
@@ -325,10 +338,13 @@ public class TrashBinActivity extends ThemedActivity
 
   class RestoreAll extends AsyncTask<Void, Void, Void> {
     private int count = 0, originalCount = 0;
+    private Dialog dialog;
 
     @Override
     protected void onPreExecute() {
       super.onPreExecute();
+      dialog = getLoadingDialog(context, "Restoring", false);
+      dialog.show();
       swipeRefreshLayout.setRefreshing(true);
     }
 
@@ -350,9 +366,17 @@ public class TrashBinActivity extends ThemedActivity
       return null;
     }
 
+    private Dialog getLoadingDialog(Context context, String title, boolean canCancel) {
+      ProgressDialog dialog = new ProgressDialog(context);
+      dialog.setCancelable(canCancel);
+      dialog.setMessage(title);
+      return dialog;
+    }
+
     @Override
     protected void onPostExecute(Void aVoid) {
       super.onPostExecute(aVoid);
+      dialog.dismiss();
       swipeRefreshLayout.setRefreshing(false);
       trashBinAdapter.setResults(getTrashObjects());
       if (trashBinRealmModelRealmQuery.count() == 0) {


### PR DESCRIPTION
Fixed #2455

Changes: Added a background progress dialog for copy/move and delete actions.

Screenshots of the change: 

![screencap](https://user-images.githubusercontent.com/41234408/60513137-116fbe80-9cf4-11e9-8a6f-13ce920d99f4.png)
