### PR TITLE
chore: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Before you begin, you should have already downloaded the Android Studio SDK and 
      - Copy all the files from *"OpenCV-android-sdk/sdk/native/3rdparty"* to *"phimpme-android/app/src/main/3rdparty"* (create directory if it doesn't exist)
      - Copy all the files from *"OpenCV-android-sdk/sdk/native/libs"* to *"phimpme-android/app/src/main/jniLibs"* (create directory if it doesn't exist)
      - Copy all the files from *"OpenCV-android-sdk/sdk/native/jni/include"* to *"phimpme-android/app/src/main/jni/include"* (create directory if it doesn't exist)
+      - Copy all the files from *"OpenCV-android-sdk/sdk/native/jni/staticlibs"* to *"phimpme-android/app/src/main/staticlibs"* (create directory if it doesn't exist)
      - Now build your project. If your build fails then try deleting these build directories *"phimpme-android/app/.externalNativeBuild"* and *"phimpme-android/app/build"*, if they exist and run the build again.
 
 7. If build error still persist, try replacing ndk with ndk version 18b from [ndk-archives](https://developer.android.com/ndk/downloads/older_releases) .  Once all build errors have been resolved, you should be all set to build the app and test it.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Before you begin, you should have already downloaded the Android Studio SDK and 
      - Copy all the files from *"OpenCV-android-sdk/sdk/native/3rdparty"* to *"phimpme-android/app/src/main/3rdparty"* (create directory if it doesn't exist)
      - Copy all the files from *"OpenCV-android-sdk/sdk/native/libs"* to *"phimpme-android/app/src/main/jniLibs"* (create directory if it doesn't exist)
      - Copy all the files from *"OpenCV-android-sdk/sdk/native/jni/include"* to *"phimpme-android/app/src/main/jni/include"* (create directory if it doesn't exist)
-      - Copy all the files from *"OpenCV-android-sdk/sdk/native/jni/staticlibs"* to *"phimpme-android/app/src/main/staticlibs"* (create directory if it doesn't exist)
+     - Copy all the files from *"OpenCV-android-sdk/sdk/native/jni/staticlibs"* to *"phimpme-android/app/src/main/staticlibs"* (create directory if it doesn't exist)
      - Now build your project. If your build fails then try deleting these build directories *"phimpme-android/app/.externalNativeBuild"* and *"phimpme-android/app/build"*, if they exist and run the build again.
 
 7. If build error still persist, try replacing ndk with ndk version 18b from [ndk-archives](https://developer.android.com/ndk/downloads/older_releases) .  Once all build errors have been resolved, you should be all set to build the app and test it.


### PR DESCRIPTION
Fixed #2802 

Changes: The present Readme.md file does not mention about copying the `staticlibs` folder due to which the project was not getting set up in the local machine.  Updated the Readme.md file mentioning the need to copy `staticlibs` folder in the project.
