### PR TITLE
chore: Update build gradle version being used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
         classpath "io.realm:realm-gradle-plugin:$realm_version"
         classpath "gradle.plugin.com.github.b3er.local.properties:local-properties-plugin:1.1"


### PR DESCRIPTION
Fixed #2846 

Changes: Updated build gradle version to 3.4.2 which is the latest.
