### PR TITLE
fix: Swipe to refresh enabled for all activities

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/trashbin/TrashBinActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/trashbin/TrashBinActivity.java
@@ -197,21 +197,17 @@ public class TrashBinActivity extends ThemedActivity
     swipeRefreshLayout.setColorSchemeColors(getAccentColor());
     swipeRefreshLayout.setProgressBackgroundColorSchemeColor(getBackgroundColor());
     Realm realm = Realm.getDefaultInstance();
-    trashBinRealmModelRealmQuery = realm.where(TrashBinRealmModel.class);
-    if (getTrashObjects().size() == 0) {
-      swipeRefreshLayout.setEnabled(false);
-    } else {
-      swipeRefreshLayout.setOnRefreshListener(
-          new SwipeRefreshLayout.OnRefreshListener() {
-            @Override
-            public void onRefresh() {
-              trashBinAdapter.setResults(getTrashObjects());
-              if (swipeRefreshLayout.isRefreshing()) {
-                swipeRefreshLayout.setRefreshing(false);
-              }
+
+    swipeRefreshLayout.setOnRefreshListener(
+        new SwipeRefreshLayout.OnRefreshListener() {
+          @Override
+          public void onRefresh() {
+            trashBinAdapter.setResults(getTrashObjects());
+            if (swipeRefreshLayout.isRefreshing()) {
+              swipeRefreshLayout.setRefreshing(false);
             }
-          });
-    }
+          }
+        });
   }
 
   private int checkpos(String path) {

--- a/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
+++ b/app/src/main/java/org/fossasia/phimpme/uploadhistory/UploadHistory.java
@@ -106,7 +106,6 @@ public class UploadHistory extends ThemedActivity {
     uploadHistoryRealmModelRealmQuery = realm.where(UploadHistoryRealmModel.class);
     if (uploadHistoryRealmModelRealmQuery.count() == 0) {
       emptyLayout.setVisibility(View.VISIBLE);
-      swipeRefreshLayout.setEnabled(false);
     } else {
       String choiceofdisply =
           preferenceUtil.getString(
@@ -330,7 +329,6 @@ public class UploadHistory extends ThemedActivity {
       if (result[0] && uploadHistoryRealmModelRealmQuery.count() == 0) {
         emptyLayout.setVisibility(View.VISIBLE);
         uploadHistoryRecyclerView.setVisibility(View.GONE);
-        swipeRefreshLayout.setEnabled(false);
       }
       invalidateOptionsMenu();
     }


### PR DESCRIPTION
Fixed #2722

Changes: Swipe to refresh had been earlier disabled in some activities. But as per the discussion on issue #2722, it shouldn't have been. 
