### PR TITLE
chore: updated buildtools, targetsdk, compilesdk version to 29

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,13 +25,13 @@ def LOCAL_KEY_PRESENT = project.hasProperty('SIGNING_KEY_FILE') && rootProject.f
 keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 29
+    buildToolsVersion "29.0.2"
 
     defaultConfig {
         applicationId "org.fossasia.phimpme"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 12
         versionName '1.9.0'
         multiDexEnabled true


### PR DESCRIPTION
Fixed #2867 

Changes:  updated buildtools, targetsdk, compilesdk version to 29
Screenshots of the change: 