### PR TITLE
fix: Text in edit image screen disappears on rotation

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/editor/EditImageActivity.java
@@ -201,6 +201,11 @@ public class EditImageActivity extends EditBaseActivity
       check = true;
       mainBitmap = savedInstanceState.getParcelable("Edited Bitmap");
       mOpTimes = savedInstanceState.getInt("numberOfEdits");
+      Fragment restoredAddTextFragment =
+          getSupportFragmentManager().getFragment(savedInstanceState, "addTextFragment");
+      if (restoredAddTextFragment != null) {
+        addTextFragment = (AddTextFragment) restoredAddTextFragment;
+      }
     }
     if (exitDialog) {
       onSaveTaskDone();
@@ -757,6 +762,9 @@ public class EditImageActivity extends EditBaseActivity
     outState.putInt("checkString", messageCheck);
     outState.putParcelable("Edited Bitmap", mainBitmap);
     outState.putInt("numberOfEdits", mOpTimes);
+    if (addTextFragment.isAdded()) {
+      getSupportFragmentManager().putFragment(outState, "addTextFragment", addTextFragment);
+    }
   }
 
   @Override


### PR DESCRIPTION
Fixed #2806 

Changes: EditImageActivity has been changed to store instance of AddText Fragment when device is rotated and restore the instance of the same fragment when activity is created again after device rotation.