### PR TITLE
chore(deps): Bump gradle from 3.5.0 to 3.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
         classpath "io.realm:realm-gradle-plugin:$realm_version"
         classpath "gradle.plugin.com.github.b3er.local.properties:local-properties-plugin:1.1"


### PR DESCRIPTION
Fixed #2906

Changes: Updated build.gradle file , Bumped the Gradle version from 3.5.0 to 3.5.2

Screenshots of the change: 
