### PR TITLE
Add material UI theme to documentation site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,96 +1,104 @@
-language: android
-jdk: oraclejdk8
-sudo: true
-dist: trusty
+jobs:
+  include:
+    - language: android
+      jdk: oraclejdk8
+      sudo: true
+      dist: trusty
 
-env:
-  global:
-    - ANDROID_API_LEVEL=22
-    - ANDROID_BUILD_TOOLS_VERSION=28.0.3
-    - ANDROID_ABI=armeabi-v7a arm64-v8a x86 x86_64
-    - ANDROID_TAG=google_apis
-    - ANDROID_TARGET=android-25
-    - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
+      env:
+        - ANDROID_API_LEVEL=22
+        - ANDROID_BUILD_TOOLS_VERSION=28.0.3
+        - ANDROID_ABI=armeabi-v7a arm64-v8a x86 x86_64
+        - ANDROID_TAG=google_apis
+        - ANDROID_TARGET=android-25
+        - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
 
-android:
-  components:
-    - tools
-    - platform-tools
-    - android-$ANDROID_API_LEVEL
-    - build-tools-$ANDROID_BUILD_TOOLS_VERSION
-    - android-$ANDROID_API_LEVEL
-    # For Google APIs
-    - addon-google_apis-google-$ANDROID_API_LEVEL
-    # Google Play Services
-    - extra-google-google_play_services
-    # Support library
-    - extra-android-support
-    # Latest artifacts in local repository
-    - extra-google-m2repository
-    - extra-android-m2repository
-    - android-sdk-license-.+
-    - '.+'
-    # Specify at least one system image
-    - sys-img-armeabi-v7a-android-$ANDROID_API_LEVEL
+      android:
+        components:
+          - tools
+          - platform-tools
+          - android-$ANDROID_API_LEVEL
+          - build-tools-$ANDROID_BUILD_TOOLS_VERSION
+          - android-$ANDROID_API_LEVEL
+          # For Google APIs
+          - addon-google_apis-google-$ANDROID_API_LEVEL
+          # Google Play Services
+          - extra-google-google_play_services
+          # Support library
+          - extra-android-support
+          # Latest artifacts in local repository
+          - extra-google-m2repository
+          - extra-android-m2repository
+          - android-sdk-license-.+
+          - '.+'
+          # Specify at least one system image
+          - sys-img-armeabi-v7a-android-$ANDROID_API_LEVEL
 
-# prevents reuploading of Cache
-before_cache:
-  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+      # prevents reuploading of Cache
+      before_cache:
+        - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 
-cache:
-  directories:
-    - "${TRAVIS_BUILD_DIR}/android/gradle/caches/"
-    - "${TRAVIS_BUILD_DIR}/android/gradle/wrapper/dists/"
-    - "$HOME/android/.gradle/caches/"
-    - "$HOME/android/.gradle/wrapper/"
-    - "$HOME/.android/build-cache"
-    - "${TRAVIS_BUILD_DIR}/cache"
+      cache:
+        directories:
+          - "${TRAVIS_BUILD_DIR}/android/gradle/caches/"
+          - "${TRAVIS_BUILD_DIR}/android/gradle/wrapper/dists/"
+          - "$HOME/android/.gradle/caches/"
+          - "$HOME/android/.gradle/wrapper/"
+          - "$HOME/.android/build-cache"
+          - "${TRAVIS_BUILD_DIR}/cache"
 
-before_install:
-  - mkdir "$ANDROID_HOME/licenses" || true
-  - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
-  - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
-  - curl https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip -o android-ndk-r18b.zip
-  - unzip -q android-ndk-r18b.zip && rm android-ndk-r18b.zip
-  - mv android-ndk-r18b $HOME
-  - export ANDROID_NDK=$HOME/android-ndk-r18b
+      before_install:
+        - mkdir "$ANDROID_HOME/licenses" || true
+        - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
+        - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
+        - curl https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip -o android-ndk-r18b.zip
+        - unzip -q android-ndk-r18b.zip && rm android-ndk-r18b.zip
+        - mv android-ndk-r18b $HOME
+        - export ANDROID_NDK=$HOME/android-ndk-r18b
 
 
-install:
-  - sdkmanager --list || true
-  - echo yes | ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-26"
-  - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2"
-  - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2"
+      install:
+        - sdkmanager --list || true
+        - echo yes | ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-26"
+        - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2"
+        - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2"
 
-licenses:
-  - 'android-sdk-preview-license-.+'
-  - 'android-sdk-license-.+'
-  - 'google-gdk-license-.+'
+      licenses:
+        - 'android-sdk-preview-license-.+'
+        - 'android-sdk-license-.+'
+        - 'google-gdk-license-.+'
 
-before_script:
-  - ./scripts/setup_opencv.sh
-  - echo "Starting AVD"
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
-  - emulator -avd test -no-audio -no-window &
-  - android-wait-for-emulator
-  - adb shell input keyevent 82 &
-  - bash scripts/prep-key.sh
+      before_script:
+        - ./scripts/setup_opencv.sh
+        - echo "Starting AVD"
+        - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+        - emulator -avd test -no-audio -no-window &
+        - android-wait-for-emulator
+        - adb shell input keyevent 82 &
+        - bash scripts/prep-key.sh
 
-script:
-  - ./gradlew spotlessCheck
-  - ./gradlew build
-  - ./gradlew build connectedAndroidTest jacocoTestReport --stacktrace
+      script:
+        - ./gradlew spotlessCheck
+        - ./gradlew build
+        - ./gradlew build connectedAndroidTest jacocoTestReport --stacktrace
 
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
-  - bash scripts/update-apk.sh
+      after_success:
+        - bash <(curl -s https://codecov.io/bash)
+        - bash scripts/update-apk.sh
 
-deploy:
-  - provider: script
-    skip_cleanup: true
-    script: bash scripts/upload-gh-pages.sh
-    on:
-      all_branches: true
+    - language: python
+      python: 3.7
+      install:
+        - pip install Sphinx
+        - pip install git+https://github.com/bashtage/sphinx-material
+        - pip install m2r
+      script: skip
+      deploy:
+        - provider: script
+          skip_cleanup: true
+          script: bash scripts/upload-gh-pages.sh
+          on:
+            all_branches: true
 
 notifications:
   slack: fossasia:JgzycrBUs0nKnmJhsAxCB4bL

--- a/docs/sources/conf.py
+++ b/docs/sources/conf.py
@@ -13,7 +13,7 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-
+import sphinx_material
 
 # -- Project information -----------------------------------------------------
 
@@ -28,7 +28,7 @@ master_doc = 'index'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['m2r']
+extensions = ['m2r', 'sphinx_material']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -44,9 +44,20 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_material'
+
+# Get the them path
+html_theme_path = sphinx_material.html_theme_path()
+# Register the required helpers for the html context
+html_context = sphinx_material.get_html_context()
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+html_theme_options = {
+    # Set the color and the accent color
+    'color_primary': 'blue',
+    'color_accent': 'light-blue',
+}

--- a/docs/sources/index.rst
+++ b/docs/sources/index.rst
@@ -2,19 +2,9 @@
    sphinx-quickstart on Mon Aug  11 13:46:17 2019.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
-Welcome to Phimp.me's documentation!
-=======================================
+
 .. mdinclude:: ../../README.md
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
-
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`

--- a/scripts/upload-gh-pages.sh
+++ b/scripts/upload-gh-pages.sh
@@ -15,7 +15,7 @@ mkdir _build/html/docs
 cp -r ../images _build/html/docs
 cp -r ../../fastlane _build/html
 
-git clone --quiet --branch=gh-pages https://kumuditha-udayanga:$GITHUB_API_KEY@github.com/kumuditha-udayanga/phimpme-android gh-pages > /dev/null
+git clone --quiet --branch=gh-pages https://fossasia:$GITHUB_API_KEY@github.com/fossasia/phimpme-android gh-pages > /dev/null
 
 cd gh-pages
 

--- a/scripts/upload-gh-pages.sh
+++ b/scripts/upload-gh-pages.sh
@@ -3,19 +3,20 @@
 git config --global user.name "Travis CI"
 git config --global user.email "noreply+travis@fossasia.org"
 
-sudo pip install Sphinx
-sudo pip install m2r
-
 cd docs/sources
 
 make html
+mkdir _build/html/docs
+cp -r ../images _build/html/docs
+cp -r ../../fastlane _build/html
 
 # Copy image files.
 mkdir _build/html/docs
 cp -r ../images _build/html/docs
 cp -r ../../fastlane _build/html
 
-git clone --quiet --branch=gh-pages https://fossasia:$GITHUB_API_KEY@github.com/fossasia/phimpme-android gh-pages > /dev/null
+git clone --quiet --branch=gh-pages https://kumuditha-udayanga:$GITHUB_API_KEY@github.com/kumuditha-udayanga/phimpme-android gh-pages > /dev/null
+
 cd gh-pages
 
 rm -rf *


### PR DESCRIPTION
Fixed #2967 

Changes:
- Add sphinx material theme to the documentation site.
- Add a new job to travis.yml to deploy documentation to gh-pages (to configure python 3)
- Modify `upload-gh-pages.sh` script.

Preview link: https://kumuditha-udayanga.github.io/phimpme-android

Screenshots of the change: 

<img width="1680" alt="Screenshot 2020-01-04 at 15 01 51" src="https://user-images.githubusercontent.com/27630091/71763547-26c3e080-2f03-11ea-964d-59ea0312c536.png">


