### PR TITLE
Added Changelog in website

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,7 @@ jobs:
         - pip install Sphinx
         - pip install git+https://github.com/bashtage/sphinx-material
         - pip install m2r
+        - pip install sphinx-git
       script: skip
       deploy:
         - provider: script

--- a/README.md
+++ b/README.md
@@ -86,9 +86,7 @@ We have the following branches
    This branch contains automatically generated apk file for testing.
 
  * **gh-pages**
-   Hosting the landing page [phimp.me](http://phimp.me)  
-
-> For reference https://fossasia.github.io/phimpme-android/ is the Gihub-Pages link for this Repo
+   For reference gh-pages branch is hosting the Gihub-Pages link for this Repo at https://fossasia.github.io/phimpme-android/
 
 ## Development Setup
 
@@ -131,17 +129,6 @@ Before you begin, you should have already downloaded the Android Studio SDK and 
     * Imgur: https://apidocs.imgur.com/
     * Box: https://developer.box.com
     * Dropbox: https://www.dropbox.com/developers
-  
-## Social 
-
-Phimp.me is a joint collaboration from the members of Fossasia. To follow up upon the updates of the org, Follow us on our official social media pages 🌐.
-- Facebook : https://www.facebook.com/fossasia
-- Twitter : https://twitter.com/fossasia
-- Github : https://github.com/fossasia
-- Youtube : https://www.youtube.com/fossasiaorg
-- LinkedIn : https://www.linkedin.com/company/fossasia
-
-> Official website : https://fossasia.org/
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ We have the following branches
  * **gh-pages**
    Hosting the landing page [phimp.me](http://phimp.me)  
 
+> For reference https://fossasia.github.io/phimpme-android/ is the Gihub-Pages link for this Repo
+
 ## Development Setup
 
 Before you begin, you should have already downloaded the Android Studio SDK and set it up correctly. You can find a guide on how to do this here: [Setting up Android Studio](http://developer.android.com/sdk/installing/index.html?pkg=studio)
@@ -129,6 +131,17 @@ Before you begin, you should have already downloaded the Android Studio SDK and 
     * Imgur: https://apidocs.imgur.com/
     * Box: https://developer.box.com
     * Dropbox: https://www.dropbox.com/developers
+  
+## Social 
+
+Phimp.me is a joint collaboration from the members of Fossasia. To follow up upon the updates of the org, Follow us on our official social media pages 🌐.
+- Facebook : https://www.facebook.com/fossasia
+- Twitter : https://twitter.com/fossasia
+- Github : https://github.com/fossasia
+- Youtube : https://www.youtube.com/fossasiaorg
+- LinkedIn : https://www.linkedin.com/company/fossasia
+
+> Official website : https://fossasia.org/
 
 ## License
 

--- a/docs/sources/conf.py
+++ b/docs/sources/conf.py
@@ -28,7 +28,7 @@ master_doc = 'index'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['m2r', 'sphinx_material']
+extensions = ['m2r', 'sphinx_material',"sphinx_git"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/sources/index.rst
+++ b/docs/sources/index.rst
@@ -5,6 +5,10 @@
 
 .. mdinclude:: ../../README.md
 
+Change Log (Commits)
+=======
+.. git_changelog::
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:


### PR DESCRIPTION
Fixed #2973 #2974 

## Changes: 
- Added https://sphinx-git.readthedocs.io/en/latest/index.html git-sphinx for changeLog
- Added the hosting page link as per #2973 

## Screenshots of the change: 


PREVIEW: https://sid911.github.io/phimpme-android/
![image](https://user-images.githubusercontent.com/27860105/71768741-25b0a480-2f3f-11ea-8fa6-e5d16bcaeea4.png)

Don't worry the changelog heading is above the changelog.... its just like that in the preview because its coming from another branch which is old 😅