### PR TITLE
Fix random deletion issue

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/activities/LFMainActivity.java
@@ -1,11 +1,5 @@
 package org.fossasia.phimpme.gallery.activities;
 
-import static org.fossasia.phimpme.gallery.data.base.SortingMode.DATE;
-import static org.fossasia.phimpme.gallery.data.base.SortingMode.NAME;
-import static org.fossasia.phimpme.gallery.data.base.SortingMode.NUMERIC;
-import static org.fossasia.phimpme.gallery.data.base.SortingMode.SIZE;
-import static org.fossasia.phimpme.utilities.ActivitySwitchHelper.context;
-
 import android.Manifest;
 import android.animation.Animator;
 import android.annotation.TargetApi;
@@ -142,6 +136,12 @@ import org.fossasia.phimpme.utilities.ActivitySwitchHelper;
 import org.fossasia.phimpme.utilities.Constants;
 import org.fossasia.phimpme.utilities.NotificationHandler;
 import org.fossasia.phimpme.utilities.SnackBarHandler;
+
+import static org.fossasia.phimpme.gallery.data.base.SortingMode.DATE;
+import static org.fossasia.phimpme.gallery.data.base.SortingMode.NAME;
+import static org.fossasia.phimpme.gallery.data.base.SortingMode.NUMERIC;
+import static org.fossasia.phimpme.gallery.data.base.SortingMode.SIZE;
+import static org.fossasia.phimpme.utilities.ActivitySwitchHelper.context;
 
 public class LFMainActivity extends SharedMediaActivity {
 
@@ -1819,7 +1819,7 @@ public class LFMainActivity extends SharedMediaActivity {
                 && !hidden
                 && getAlbums().getSelectedCount() == 1);
     menu.findItem(R.id.delete_action)
-        .setVisible((!albumsMode || editMode) && (!all_photos || editMode));
+        .setVisible(editMode);
     if (fav_photos) {
       menu.findItem(R.id.delete_action).setVisible(editMode);
     }


### PR DESCRIPTION
Fixed #2979 

Changes:
The delete icon is visible now only in edit mode and not always.

## Before
Since it was visible even when the images were not selected, random no of images was getting deleted and the app was crashing.

![WhatsApp Image 2020-01-20 at 1 02 14 AM](https://user-images.githubusercontent.com/34706326/72687067-956a8600-3b20-11ea-832c-65aee0bd20e7.jpeg)

## After
Now, only when either albums or images are selected, the delete icon is visible on the Action bar.

![WhatsApp Image 2020-01-20 at 12 58 45 AM](https://user-images.githubusercontent.com/34706326/72687066-91d6ff00-3b20-11ea-86a5-f7ba6448cd71.jpeg)

