### PR TITLE
Setting Switch state not visible properly in Dark AMOLED basic theme

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/util/ThemeHelper.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/util/ThemeHelper.java
@@ -125,6 +125,22 @@ public class ThemeHelper {
     return color;
   }
 
+  public int getUpdatedSwitchColor() {
+    int color;
+    switch (baseTheme) {
+      case DARK_THEME:
+        color = getColor(R.color.md_dark_background);
+        break;
+      case AMOLED_THEME:
+        color = getColor(R.color.md_brown_300);
+        break;
+      case LIGHT_THEME:
+      default:
+        color = getColor(R.color.md_light_background);
+    }
+    return color;
+  }
+
   public int getInvertedBackgroundColor() {
     int color;
     switch (baseTheme) {
@@ -347,7 +363,7 @@ public class ThemeHelper {
         .setColorFilter(sw.isChecked() ? color : getSubTextColor(), PorterDuff.Mode.MULTIPLY);
     sw.getTrackDrawable()
         .setColorFilter(
-            sw.isChecked() ? ColorPalette.getTransparentColor(color, 100) : getBackgroundColor(),
+                sw.isChecked() ? ColorPalette.getTransparentColor(color, 100) : getUpdatedSwitchColor(),
             PorterDuff.Mode.MULTIPLY);
   }
 

--- a/app/src/main/java/org/fossasia/phimpme/gallery/util/ThemeHelper.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/util/ThemeHelper.java
@@ -363,7 +363,7 @@ public class ThemeHelper {
         .setColorFilter(sw.isChecked() ? color : getSubTextColor(), PorterDuff.Mode.MULTIPLY);
     sw.getTrackDrawable()
         .setColorFilter(
-                sw.isChecked() ? ColorPalette.getTransparentColor(color, 100) : getUpdatedSwitchColor(),
+            sw.isChecked() ? ColorPalette.getTransparentColor(color, 100) : getUpdatedSwitchColor(),
             PorterDuff.Mode.MULTIPLY);
   }
 

--- a/app/src/main/java/org/fossasia/phimpme/gallery/util/ThemeHelper.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/util/ThemeHelper.java
@@ -132,7 +132,7 @@ public class ThemeHelper {
         color = getColor(R.color.md_dark_background);
         break;
       case AMOLED_THEME:
-        color = getColor(R.color.md_brown_300);
+        color = getColor(R.color.md_blue_grey_900);
         break;
       case LIGHT_THEME:
       default:

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -46,12 +46,14 @@
     </style>
 
     <!--AMOLED DARK MENU THEME-->
-    <style name="AmoledDarkActionBarMenu" parent="Base.ThemeOverlay.AppCompat.ActionBar">
+    <style name="AmoledDarkActionBarMenu" parent="Base.ThemeOverlay.AppCompat.Dark.ActionBar">
         <item name="android:popupMenuStyle">@style/MyApp.PopupMenu.Dark</item>
     </style>
 
-    <style name="MyApp.PopupMenu.DarkAmoled" parent="Base.ThemeOverlay.AppCompat.ActionBar">
-        <item name="android:popupBackground">@drawable/ic_empty_amoled</item>
+    <style name="MyApp.PopupMenu.DarkAmoled" parent="Base.ThemeOverlay.AppCompat.Dark.ActionBar">
+        <item name="android:backgroundTint" tools:targetApi="lollipop">
+            @color/cardview_dark_background
+        </item>
     </style>
 
     <style name="MyToolbar" parent="Widget.AppCompat.Toolbar">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -46,14 +46,12 @@
     </style>
 
     <!--AMOLED DARK MENU THEME-->
-    <style name="AmoledDarkActionBarMenu" parent="Base.ThemeOverlay.AppCompat.Dark.ActionBar">
+    <style name="AmoledDarkActionBarMenu" parent="Base.ThemeOverlay.AppCompat.ActionBar">
         <item name="android:popupMenuStyle">@style/MyApp.PopupMenu.Dark</item>
     </style>
 
-    <style name="MyApp.PopupMenu.DarkAmoled" parent="Base.ThemeOverlay.AppCompat.Dark.ActionBar">
-        <item name="android:backgroundTint" tools:targetApi="lollipop">
-            @color/cardview_dark_background
-        </item>
+    <style name="MyApp.PopupMenu.DarkAmoled" parent="Base.ThemeOverlay.AppCompat.ActionBar">
+        <item name="android:popupBackground">@drawable/ic_empty_amoled</item>
     </style>
 
     <style name="MyToolbar" parent="Widget.AppCompat.Toolbar">


### PR DESCRIPTION
Fixed #3017 

Changes: 
Added a function in ThemeHelper Class.
Created a function which handle switch colour update on change in Basic theme(in setting section).

Screenshots of the change: 
![Screenshot 2020-02-17 at 10 00 43 PM](https://user-images.githubusercontent.com/29337604/74671388-13c65080-51d1-11ea-9409-14869f8da63f.png)

