### PR TITLE
Menu item not visible properly in Trash Bin Dark AMOLED theme fixed

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -46,12 +46,14 @@
     </style>
 
     <!--AMOLED DARK MENU THEME-->
-    <style name="AmoledDarkActionBarMenu" parent="Base.ThemeOverlay.AppCompat.ActionBar">
+    <style name="AmoledDarkActionBarMenu" parent="Base.ThemeOverlay.AppCompat.Dark.ActionBar">
         <item name="android:popupMenuStyle">@style/MyApp.PopupMenu.Dark</item>
     </style>
 
-    <style name="MyApp.PopupMenu.DarkAmoled" parent="Base.ThemeOverlay.AppCompat.ActionBar">
-        <item name="android:popupBackground">@drawable/ic_empty_amoled</item>
+    <style name="MyApp.PopupMenu.DarkAmoled" parent="Base.ThemeOverlay.AppCompat.Dark.ActionBar">
+        <item name="android:backgroundTint" tools:targetApi="lollipop">
+            @color/cardview_dark_background
+        </item>
     </style>
 
     <style name="MyToolbar" parent="Widget.AppCompat.Toolbar">


### PR DESCRIPTION
Fixed #3031

Changes: Changed AMOLED DARK MENU THEME style  to dark in styles.xml

Screenshots of the change: 
<img width="302" alt="two" src="https://user-images.githubusercontent.com/29337604/74963582-f941e080-5437-11ea-9bc7-cdb84bf1bb49.png">


<img width="302" alt="one" src="https://user-images.githubusercontent.com/29337604/74963625-0d85dd80-5438-11ea-9ba0-7bbd1e8c7c0d.png">
