### PR TITLE
Fix-Enable-Small-Screen

### DIFF
--- a/app/src/main/res/layout/content_accounts.xml
+++ b/app/src/main/res/layout/content_accounts.xml
@@ -16,11 +16,18 @@
         android:layout_above="@+id/bottombar"
         android:layout_below="@id/toolbar">
 
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/accounts_recycler_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_below="@id/toolbar" />
+
+        </ScrollView>
+
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 


### PR DESCRIPTION
Fixed #3051 

Changes: This pullrequest enables the Account Activity for small screen devices, In previous version bottom navigation was overlapping the recyclerView.

Screenshots of the change: 
![IMG-20201002-WA0022 1](https://user-images.githubusercontent.com/67560900/95012733-9e709880-0658-11eb-8611-0b200e9b97fa.jpg)
