### PR TITLE
feature- standard gallery UI

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
+++ b/app/src/main/java/org/fossasia/phimpme/gallery/adapters/AlbumsAdapter.java
@@ -136,7 +136,13 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
 
     String hexPrimaryColor = String.format("#%06X", (0xFFFFFF & theme.getPrimaryColor()));
 
-    String textColor = theme.getBaseTheme() != ThemeHelper.LIGHT_THEME ? "#FAFAFA" : "#2b2b2b";
+    String nameTextColor;
+    String countTextColor;
+    if (theme.getBaseTheme() == ThemeHelper.LIGHT_THEME) nameTextColor = "#2b2b2b";
+    else {
+      nameTextColor = "#FAFAFA";
+    }
+    countTextColor = "#B4BAC0";
 
     if (a.isSelected()) {
       holder.ivSelectedIcon.setColor(Color.WHITE);
@@ -147,24 +153,22 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
       holder.ivAlbumPreview.setColorFilter(0x77000000, PorterDuff.Mode.SRC_ATOP);
       holder.ivSelectedIcon.setVisibility(View.VISIBLE);
       if (theme.getBaseTheme() == ThemeHelper.LIGHT_THEME) {
-        textColor = "#FAFAFA";
+        nameTextColor = "#2b2b2b"; countTextColor = "#B4BAC0";
       }
     } else {
       holder.ivAlbumPreview.clearColorFilter();
       holder.ivSelectedIcon.setVisibility(View.GONE);
-      holder.tvAlbumName.setBackgroundColor(
-          ColorPalette.getTransparentColor(theme.getBackgroundColor(), 200));
-      holder.tvPhotosCount.setBackgroundColor(
-          ColorPalette.getTransparentColor(theme.getBackgroundColor(), 200));
+      holder.tvAlbumName.setBackgroundColor(theme.getBackgroundColor());
+      holder.tvPhotosCount.setBackgroundColor(theme.getBackgroundColor());
       holder.ivPin.setBackgroundColor(
           ColorPalette.getTransparentColor(theme.getBackgroundColor(), 200));
     }
-    holder.tvAlbumName.setTextColor(Color.parseColor(textColor));
-    holder.tvPhotosCount.setTextColor(Color.parseColor(textColor));
+    holder.tvAlbumName.setTextColor(Color.parseColor(nameTextColor));
+    holder.tvPhotosCount.setTextColor(Color.parseColor(countTextColor));
 
     holder.tvAlbumName.setText(a.getName());
     holder.tvPhotosCount.setText(
-        a.getCount() + " " + holder.tvPhotosCount.getContext().getString(R.string.media));
+        a.getCount() + " " ;
   }
 
   public void setOnClickListener(View.OnClickListener lis) {

--- a/app/src/main/res/layout/card_album.xml
+++ b/app/src/main/res/layout/card_album.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/album_card"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="@dimen/alternate_half_margin"
-    app:cardCornerRadius="8dp"
-    app:cardElevation="@dimen/card_elevation">
+    app:cardElevation="0dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -27,31 +26,36 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             />
-
-
-        <ImageView
-            android:id="@+id/iv_album_preview"
-            android:layout_width="0dp"
-            android:layout_height="140dp"
-            tools:src="@mipmap/ic_launcher"
-            android:scaleType="centerCrop"
+        <androidx.cardview.widget.CardView
+            android:id="@+id/iv_album_previe"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            />
+            app:cardCornerRadius="@dimen/size_8">
 
+            <ImageView
+                android:id="@+id/iv_album_preview"
+                android:layout_width="match_parent"
+                android:layout_height="140dp"
+                tools:src="@mipmap/ic_launcher"
+                android:scaleType="centerCrop"
+
+                />
+        </androidx.cardview.widget.CardView>
         <TextView
             android:id="@+id/tv_album_name"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:maxLines="1"
             tools:text="Album Name"
+            android:fontFamily="sans-serif-medium"
             android:paddingStart="@dimen/size_8"
             android:paddingEnd="@dimen/size_8"
             android:paddingTop="@dimen/size_4"
-            android:paddingBottom="@dimen/size_4"
             android:textColor="@color/white"
-            app:layout_constraintTop_toBottomOf="@id/iv_album_preview"
+            app:layout_constraintTop_toBottomOf="@id/iv_album_previe"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@id/iv_pin"
             />
@@ -77,7 +81,6 @@
             android:textSize="@dimen/moderate_text"
             android:paddingStart="@dimen/size_8"
             android:paddingEnd="@dimen/size_8"
-            android:paddingTop="@dimen/size_4"
             android:paddingBottom="@dimen/size_4"
             app:layout_constraintEnd_toStartOf="@id/iv_storage_icon"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -98,4 +101,4 @@
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.cardview.widget.CardView>
+</LinearLayout>


### PR DESCRIPTION
Fixed #2921 

Changes: 
        1. Removed media word after the counting of photos, because no normal gallery App writes media after the counting
         2. Differentiated the font and color of both album name and count.
        3. changed the font and color of both album name and count.
        4. Made the background of the textview and the theme same to make it look clean.
        5.Made the edges of the imageview rounded to give it a complete feel.


pictures of Android galleries:
![1](https://user-images.githubusercontent.com/67560900/95263385-55cd0100-084b-11eb-9285-b83e8fe94a19.jpg)
![2](https://user-images.githubusercontent.com/67560900/95263420-5ebdd280-084b-11eb-97d7-ee22a077a403.jpg)


Before the change: 
![Project Name](https://user-images.githubusercontent.com/67560900/95265821-9f1f4f80-084f-11eb-87ff-69ff6fa68a04.gif)


After the change:

![Project Name (4)](https://user-images.githubusercontent.com/67560900/95269404-f117a380-0856-11eb-84ce-e1c180f63a7a.gif)

