### PR TITLE
changed return type of onDown in RecyclerItemClickListner to false as returning true was blocking the recyclerview scroll event - to fix #3051

### DIFF
--- a/app/src/main/java/org/fossasia/phimpme/base/RecyclerItemClickListner.java
+++ b/app/src/main/java/org/fossasia/phimpme/base/RecyclerItemClickListner.java
@@ -80,9 +80,8 @@ public class RecyclerItemClickListner implements RecyclerView.OnItemTouchListene
 
     @Override
     public boolean onDown(MotionEvent event) {
-      // Best practice to always return true here.
-      // http://developer.android.com/training/gestures/detector.html#detect
-      return true;
+      // returning true here will stop scroll event in recyclerview, return false instead
+      return false;
     }
   }
 }


### PR DESCRIPTION
Fixed #3051 

Changes: No Major changes, just changed return type of onDown in RecyclerItemClickListner to false as returning true was blocking the recyclerview scroll event.

Screenshots of the change: 

<img src="https://user-images.githubusercontent.com/19506171/104421550-7ec70580-55a1-11eb-94c7-0ea2cb1cc1e9.gif" height=350 />

